### PR TITLE
steamcompmgr: Allow setting the default mouse cursor

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ dep_xfixes = dependency('xfixes')
 dep_xxf86vm = dependency('xxf86vm')
 dep_xtst = dependency('xtst')
 dep_xres = dependency('xres')
+dep_xmu = dependency('xmu')
 
 drm_dep = dependency('libdrm', version: '>= 2.4.105')
 vulkan_dep = dependency('vulkan')
@@ -106,7 +107,7 @@ executable(
   src,
   dependencies: [
     dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
-    dep_xxf86vm, dep_xres, drm_dep, wayland_server, wayland_protos,
+    dep_xxf86vm, dep_xres, dep_xmu, drm_dep, wayland_server, wayland_protos,
     xkbcommon, thread_dep, sdl_dep, wlroots_dep,
     vulkan_dep, liftoff_dep, dep_xtst, cap_dep, pipewire_dep, stb_dep,
   ],

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@ const struct option *gamescope_options = (struct option[]){
 
 	// steamcompmgr options
 	{ "cursor", required_argument, nullptr, 0 },
+	{ "cursor-name", required_argument, nullptr, 0 },
 	{ "ready-fd", required_argument, nullptr, 'R' },
 	{ "stats-path", required_argument, nullptr, 'T' },
 	{ "hide-cursor-delay", required_argument, nullptr, 'C' },

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -49,6 +49,7 @@ public:
 			   struct VulkanPipeline_t *pPipeline);
 	void setDirty();
 
+	bool setCursorImageByName(char const* name);
 	// Will take ownership of data.
 	bool setCursorImage(char *data, int w, int h);
 


### PR DESCRIPTION
Unless we explicitly load a file with `--cursor` option, or call
xsetroot to the display created by gamescope, the default cursor is
the default X icon. Some games, like Factorio, do not set the cursor.

This change adds `--cursor-name` which will set the default cursor
without needed to provide an image file. Typically we want to use
`--cursor-name left_ptr`, which is a more sensible default.

Note that if we did not want to depend on xmu, we could change to not use a name but the index value (`XC_*` constants).

Also we could set the default to `XC_left_ptr` if no parameter was given.
