### PR TITLE
Add a CLI option to disable sending key events for the Super key.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "nested-unfocused-refresh", required_argument, nullptr, 'o' },
 	{ "borderless", no_argument, nullptr, 'b' },
 	{ "fullscreen", no_argument, nullptr, 'f' },
+	{ "no-mod-key", no_argument, nullptr, 0 },
 
 	// embedded mode options
 	{ "disable-layers", no_argument, nullptr, 0 },
@@ -91,6 +92,7 @@ const char usage[] =
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"
 	"  -b, --borderless               make the window borderless\n"
 	"  -f, --fullscreen               make the window fullscreen\n"
+	"  --no-mod-key                   do not generate events for the Super key\n"
 	"\n"
 	"Embedded mode options:\n"
 	"  -O, --prefer-output            list of connectors in order of preference\n"
@@ -126,6 +128,8 @@ uint32_t g_nOutputHeight = 0;
 int g_nOutputRefresh = 0;
 
 bool g_bFullscreen = false;
+
+bool g_bNoModKey = false;
 
 bool g_bIsNested = false;
 
@@ -262,6 +266,8 @@ int main(int argc, char **argv)
 					g_nTouchClickMode = g_nDefaultTouchClickMode;
 				} else if (strcmp(opt_name, "generate-drm-mode") == 0) {
 					g_drmModeGeneration = parse_drm_mode_generation( optarg );
+				} else if (strcmp(opt_name, "no-mod-key") == 0) {
+					g_bNoModKey = true;
 				}
 				break;
 			case '?':

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -22,6 +22,8 @@ extern int g_nOutputRefresh; // Hz
 
 extern bool g_bFullscreen;
 
+extern bool g_bNoModKey;
+
 extern bool g_bFilterGameWindow;
 
 extern bool g_bBorderlessOutputWindow;

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -131,6 +131,11 @@ void inputSDLThreadRun( void )
 			case SDL_KEYUP:
 				key = SDLScancodeToLinuxKey( event.key.keysym.scancode );
 
+				if ( g_bNoModKey == true && key == KEY_LEFTMETA )
+				{
+					break;
+				}
+
 				if ( event.type == SDL_KEYUP && ( event.key.keysym.mod & KMOD_LGUI ) )
 				{
 					bool handled = true;
@@ -153,6 +158,11 @@ void inputSDLThreadRun( void )
 					{
 						break;
 					}
+				}
+
+				if ( g_bNoModKey == true && ( event.key.keysym.mod & KMOD_LGUI ) )
+				{
+					break;
 				}
 
 				// On Wayland, clients handle key repetition


### PR DESCRIPTION
This adds a CLI option, --no-mod-key, that disables sending key events
for the Super key itself as well as any shortcut keys that involve the
Super key like Super+F, Super+N, etc.  It can be especially useful when
running emulators like 86box or a VM like VirtualBox under Gamescope
that runs Windows since the events get mixed up. Also avoids the case
where the game handles, e.g., the F key, it 'sees' a Super+F keydown
event (but ignores the Super part so assumes just an F key) and then it
misses the Super+F keyup event (which is 'eaten' by Gamescope) so now it
thinks F is still pressed. Though this might be better solved by also
'eating' the Super+F/N/S/etc keydown events too in addition to the keyup
events.