### PR TITLE
Key remapping

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,7 @@ src = [
   'src/rendervulkan.cpp',
   'src/log.cpp',
   'src/ime.cpp',
+  'src/acmap.cpp',
   spirv_shader,
 ]
 

--- a/src/acmap.cpp
+++ b/src/acmap.cpp
@@ -1,0 +1,121 @@
+#include "acmap.hpp"
+#include "wlserver.hpp"
+#include <stdio.h>
+
+std::vector<actionmapping> g_ActionMap;
+bool g_bReportActionMaps;
+
+static int findmap(uint32_t srcdev, uint32_t srcid)
+{
+	if ( g_ActionMap.empty() == false )
+	{
+		for ( actionmapping& am : g_ActionMap )
+		{
+			if ( am.src.dev == srcdev && am.src.id == srcid )
+			{
+				return &am - &g_ActionMap[0];
+			}
+		}
+	}
+	return -1;
+}
+
+void actionmap_reset()
+{
+	g_ActionMap = std::vector<actionmapping>();
+}
+
+void actionmap_set(uint32_t srcdev, uint32_t srcid, uint32_t dstdev, uint32_t dstid)
+{
+	int index = findmap(srcdev, srcid);
+	if ( index == -1 )
+	{
+		g_ActionMap.push_back({{srcdev, srcid}, {dstdev, dstid}});
+	}
+	else
+	{
+		g_ActionMap[index].dst.dev = dstdev;
+		g_ActionMap[index].dst.id = dstid;
+	}
+}
+
+void actionmap_get(uint32_t srcdev, uint32_t srcid, uint32_t* dstdev, uint32_t* dstid)
+{
+	int index = findmap(srcdev, srcid);
+	if (index == -1 )
+	{
+		*dstdev = srcdev;
+		*dstid = srcid;
+	}
+	else
+	{
+		*dstdev = g_ActionMap[index].dst.dev;
+		*dstid = g_ActionMap[index].dst.id;
+	}
+}
+
+void actionmap_unset(uint32_t dev, uint32_t id)
+{
+	int index = findmap(dev, id);
+	if (index != -1)
+	{
+		g_ActionMap.erase(g_ActionMap.begin() + index);
+	}
+}
+
+static int chtodev(char ch)
+{
+	return ch == ACDEV_KEYBOARD || ch == ACDEV_BUTTON ? ch : ACDEV_NONE;
+}
+
+void actionmap_load(const char* filename)
+{
+	FILE* f = fopen(filename, "r");
+	if (!f)
+	{
+		fprintf(stderr, "gamescope: actionmap file '%s' not found\n", filename);
+		return;
+	}
+	while (!feof(f))
+	{
+		char srcdev = 0, dstdev = 0;
+		int srcid, dstid;
+		fscanf(f, "%c %i %c %i\n", &srcdev, &srcid, &dstdev, &dstid);
+		srcdev = chtodev(srcdev);
+		dstdev = chtodev(dstdev);
+		if (srcdev && dstdev)
+		{
+			actionmap_set(srcdev, srcid, dstdev, dstid);
+		}
+	}
+	fclose(f);
+}
+
+void actionmap_perform(uint32_t dev, uint32_t id, int value, uint32_t time)
+{
+	uint32_t dstdev, dstid;
+	actionmap_get(dev, id, &dstdev, &dstid);
+	if (g_bReportActionMaps)
+	{
+		fprintf(stderr, "actionmap: %c %i -> %c %i\n", dev, id, dstdev, dstid);
+	}
+	switch (dstdev)
+	{
+	case ACDEV_KEYBOARD:
+		wlserver_key(dstid, value != 0, time);
+		break;
+	case ACDEV_BUTTON:
+		wlserver_mousebutton(dstid, value != 0, time);
+		break;
+	}
+}
+
+void actionmap_performkey(uint32_t key, int down, uint32_t time)
+{
+	actionmap_perform(ACDEV_KEYBOARD, key, down ? 1 : 0, time);
+}
+
+void actionmap_performbutton(uint32_t button, int down, uint32_t time)
+{
+	actionmap_perform(ACDEV_BUTTON, button, down ? 1 : 0, time);
+}

--- a/src/acmap.cpp
+++ b/src/acmap.cpp
@@ -65,7 +65,7 @@ void actionmap_unset(uint32_t dev, uint32_t id)
 
 static int chtodev(char ch)
 {
-	return ch == ACDEV_KEYBOARD || ch == ACDEV_BUTTON ? ch : ACDEV_NONE;
+	return ch == ACDEV_KEYBOARD || ch == ACDEV_BUTTON || ch == ACDEV_NULL ? ch : ACDEV_NONE;
 }
 
 void actionmap_load(const char* filename)

--- a/src/acmap.hpp
+++ b/src/acmap.hpp
@@ -8,6 +8,7 @@
 #define ACDEV_NONE	0
 #define ACDEV_KEYBOARD	'k'
 #define ACDEV_BUTTON	'b'
+#define ACDEV_NULL	'n'
 
 struct action {
 	uint32_t dev, id;

--- a/src/acmap.hpp
+++ b/src/acmap.hpp
@@ -1,0 +1,30 @@
+// Action maps
+
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+
+#define ACDEV_NONE	0
+#define ACDEV_KEYBOARD	'k'
+#define ACDEV_BUTTON	'b'
+
+struct action {
+	uint32_t dev, id;
+};
+
+struct actionmapping {
+	action src, dst;
+};
+
+extern std::vector<actionmapping> g_ActionMap;
+extern bool g_bReportActionMaps;
+
+void actionmap_reset();
+void actionmap_set(uint32_t srcdev, uint32_t srcid, uint32_t dstdev, uint32_t dstid);
+void actionmap_get(uint32_t srcdev, uint32_t srcid, uint32_t* dstdev, uint32_t* dstid);
+void actionmap_unset(uint32_t dev, uint32_t id);
+void actionmap_load(const char* filename);
+void actionmap_perform(uint32_t dev, uint32_t id, int value, uint32_t time);
+void actionmap_performkey(uint32_t key, int down, uint32_t time);
+void actionmap_performbutton(uint32_t button, int down, uint32_t time);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "rendervulkan.hpp"
 #include "sdlwindow.hpp"
 #include "wlserver.hpp"
+#include "acmap.hpp"
 #include "gpuvis_trace_utils.h"
 
 #if HAVE_PIPEWIRE
@@ -64,6 +65,8 @@ const struct option *gamescope_options = (struct option[]){
 	{ "composite-debug", no_argument, nullptr, 0 },
 	{ "disable-xres", no_argument, nullptr, 'x' },
 	{ "fade-out-duration", required_argument, nullptr, 0 },
+	{ "actionmap-file", required_argument, nullptr, 0 },
+	{ "report-actionmaps", no_argument, nullptr, 0 },
 
 	{} // keep last
 };
@@ -86,6 +89,8 @@ const char usage[] =
 	"  -T, --stats-path               write statistics to path\n"
 	"  -C, --hide-cursor-delay        hide cursor image after delay\n"
 	"  -e, --steam                    enable Steam integration\n"
+	"  --actionmap-file filename      provide an actionmap file for remapping keys and buttons\n"
+	"  --report-actionmaps            report action maps to stderr\n"
 	"\n"
 	"Nested mode options:\n"
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"
@@ -262,6 +267,10 @@ int main(int argc, char **argv)
 					g_nTouchClickMode = g_nDefaultTouchClickMode;
 				} else if (strcmp(opt_name, "generate-drm-mode") == 0) {
 					g_drmModeGeneration = parse_drm_mode_generation( optarg );
+				} else if (strcmp(opt_name, "actionmap-file") == 0) {
+					actionmap_load(optarg);
+				} else if (strcmp(opt_name, "report-actionmaps") == 0) {
+					g_bReportActionMaps = true;
 				}
 				break;
 			case '?':

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -10,6 +10,7 @@
 #include "sdlwindow.hpp"
 #include "rendervulkan.hpp"
 #include "steamcompmgr.hpp"
+#include "acmap.hpp"
 
 #include "sdlscancodetable.hpp"
 
@@ -117,9 +118,9 @@ void inputSDLThreadRun( void )
 			case SDL_MOUSEBUTTONDOWN:
 			case SDL_MOUSEBUTTONUP:
 				wlserver_lock();
-				wlserver_mousebutton( SDLButtonToLinuxButton( event.button.button ),
-									  event.button.state == SDL_PRESSED,
-									  event.button.timestamp );
+				actionmap_performbutton( SDLButtonToLinuxButton( event.button.button ),
+							 event.button.state == SDL_PRESSED,
+							 event.button.timestamp );
 				wlserver_unlock();
 				break;
 			case SDL_MOUSEWHEEL:
@@ -160,7 +161,7 @@ void inputSDLThreadRun( void )
 					break;
 
 				wlserver_lock();
-				wlserver_key( key, event.type == SDL_KEYDOWN, event.key.timestamp );
+				actionmap_performkey( key, event.type == SDL_KEYDOWN, event.key.timestamp );
 				wlserver_unlock();
 				break;
 			case SDL_WINDOWEVENT:


### PR DESCRIPTION
This adds a simple form of action and button remapping by routing calls to wlserver_key and wlserver_mousebutton via actionmap_performkey and actionmap_performbutton which in turn call actionmap_perform that can be used to remap the calls between keyboard and mouse keys and buttons. The actionmap is specified using a simple text file of the form:

srcdev srcid dstdev dstid

where each line specified a mapping from srcdev/srcid to dstdev/dstid. The dev is k, b or n (for keyboard, mouse button and null - used to ignore keys) and id depends on dev. For example:

b 277 k 15
b 274 k 48
b 278 k 33
k 15 n 0

This maps the X1 button to Tab key, the middle button to B key, the X2 button to F key and the Tab key itself to nothing (the 0 is ignored and can be any number).

This functionality can be used with games that have partial or no support for key (re)mapping.

The --actionmap-file CLI parameter can be used to specify an actionmap file and the --report-actionmaps parameter can be used to dump the action mappings to stderr while they happen (which can also be used to find the key and button ids).