### PR TITLE
Enabled fsr for downscaling

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1757,7 +1757,7 @@ paint_all(bool async)
 				paint_window(w, w, &frameInfo, global_focus.cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders, 1.0f, override);
 
 				bool needsScaling = frameInfo.layers[0].scale.x < 1.0f && frameInfo.layers[0].scale.y < 1.0f;
-				frameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR && needsScaling;
+				frameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR;
 				frameInfo.useNISLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::NIS && needsScaling;
 			}
 			update_touch_scaling( &frameInfo );


### PR DESCRIPTION
Hi,

This PR is related to issue #692, besides upscaling, FSR can yield good results for downscaling.

This is the current result of gamescope (from 5120x2160 to 2560x1080):
![downscaling-default](https://user-images.githubusercontent.com/18180693/206035885-bb632ebf-bb18-4a66-91ce-a3f90871e0c6.png)

This is with fsr for downscaling  (from 5120x2160 to 2560x1080):
![downscaling-fsr](https://user-images.githubusercontent.com/18180693/206035978-7d8728c1-01b2-4599-a41b-0bc7b728ff99.png)


The power lines, stage mounts, and everything else is better defined, with less jagged edges.