### PR TITLE
Fix freeze on poll in wlserver and use after free in sdlwindow.

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -334,7 +334,10 @@ void inputSDLThreadRun( void )
 					if ( g_bUpdateSDLWindowIcon )
 					{
 						if ( icon_surface )
+						{
 							SDL_FreeSurface( icon_surface );
+							icon_surface = nullptr;
+						}
 
 						if ( g_SDLWindowIcon && g_SDLWindowIcon->size() >= 3 )
 						{

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1217,7 +1217,7 @@ void wlserver_run(void)
 		.events = POLLIN,
 	};
 	while ( g_bRun ) {
-		int ret = poll( &pollfd, 1, -1 );
+		int ret = poll( &pollfd, 1, 3 );
 		if ( ret < 0 ) {
 			if ( errno == EINTR )
 				continue;


### PR DESCRIPTION
Hi, 2 small fixes. First work around [this problem](https://github.com/Plagman/gamescope/issues/777). Second is a simple use after free case in sdlwindow.