### PR TITLE
sdlwindow: set icon_surface to nullptr after free

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -341,7 +341,10 @@ void inputSDLThreadRun( void )
 					if ( g_bUpdateSDLWindowIcon )
 					{
 						if ( icon_surface )
+						{
 							SDL_FreeSurface( icon_surface );
+							icon_surface = nullptr;
+						}
 
 						if ( g_SDLWindowIcon && g_SDLWindowIcon->size() >= 3 )
 						{


### PR DESCRIPTION
Prevents a double free that might occur if icon_surface is not allocated in the conditional following the free.

Duplicates part of #829, but seems like it would be good to separate that PR into two anyways.