### PR TITLE
Fix an undefined variable causing strange behavior with cursor hiding on the Steam Deck

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4026,6 +4026,7 @@ add_win(xwayland_ctx_t *ctx, Window id, Window prev, unsigned long sequence)
 	new_win->ignoreOverrideRedirect = false;
 
 	new_win->mouseMoved = 0;
+        new_win->ignoreNextClickForVisibility = 0;
 
 	wlserver_x11_surface_info_init( &new_win->xwayland().surface, ctx->xwayland_server, id );
 


### PR DESCRIPTION
Because the ignoreNextClickForVisibility variable was not defined before being used within mouseCursor::checkSuspension(), the code that was specifically added for only Disgaea for PC (AppID 405900) was running for other windows, resulting in the mouse cursor being hidden when it was not supposed to. Setting it to 0 along with the rest of the variables when a new window is created fixes this behavior and makes it behave as before.

Specifically I was seeing this on the Main channel with the gamescope release gamescope-3.11.52.beta6-4, but the actual code was added previously. I was able to get it to hide the cursor reliably by running a game in full screen in pcsx2, though it also can be seen at least sometimes by holding down the steam button and moving the cursor using the trackpad, with the mouse being hidden and some elements highlighting. After the cursor gets erroneously hidden, it tends to stay that way until gamescope is restarted. This particular code has fixed that issue. 