### PR TITLE
Fix colour mgmt crash

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -2824,8 +2824,10 @@ bool drm_supports_color_mgmt(struct drm_t *drm)
 	if (!drm->crtc)
 		return false;
 
-	// TODO: hook up
-	return true;
+	return (drm->crtc->has_valve1_regamma_tf &&
+			drm->crtc->has_degamma_lut &&
+			drm->crtc->has_gamma_lut &&
+			drm->crtc->has_ctm);
 }
 
 void drm_get_native_colorimetry( struct drm_t *drm,

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -2082,7 +2082,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 						liftoff_layer_set_property( drm->lo_layers[ i ], "VALVE1_PLANE_BLEND_TF", 0 );
 				}
 			}
-			else
+			else if ( drm_supports_color_mgmt( drm ) )
 			{
 				liftoff_layer_set_property( drm->lo_layers[ i ], "VALVE1_PLANE_DEGAMMA_TF", DRM_VALVE1_TRANSFER_FUNCTION_DEFAULT );
 				liftoff_layer_set_property( drm->lo_layers[ i ], "VALVE1_PLANE_SHAPER_LUT", 0 );

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -296,6 +296,8 @@ extern enum g_panel_orientation g_drmModeOrientation;
 
 extern std::atomic<uint64_t> g_drmEffectiveOrientation; // DRM_MODE_ROTATE_*
 
+extern bool g_bForceDisableColorMgmt;
+
 bool init_drm(struct drm_t *drm, int width, int height, int refresh, bool wants_adaptive_sync);
 void finish_drm(struct drm_t *drm);
 int drm_commit(struct drm_t *drm, const struct FrameInfo_t *frameInfo );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "force-orientation", required_argument, nullptr, 0 },
 	{ "force-windows-fullscreen", no_argument, nullptr, 0 },
 
+	{ "disable-color-management", no_argument, nullptr, 0 },
 	{ "hdr-enabled", no_argument, nullptr, 0 },
 	{ "hdr-sdr-content-nits", required_argument, nullptr, 0 },
 	{ "hdr-wide-gammut-for-sdr", no_argument, nullptr, 0 },
@@ -204,6 +205,7 @@ const char usage[] =
 	"  --force-composition            disable direct scan-out\n"
 	"  --composite-debug              draw frame markers on alternating corners of the screen when compositing\n"
 	"  --disable-xres                 disable XRes for PID lookup\n"
+	"  --disable-color-management     disable color remapping\n"
 	"  --hdr-debug-force-support      forces support for HDR, etc even if the display doesn't support it. HDR clients will be outputted as SDR still in that case.\n"
 	"  --hdr-debug-force-output       forces support and output to HDR10 PQ even if the output does not support it (will look very wrong if it doesn't)\n"
 	"  --hdr-debug-heatmap            displays a heatmap-style debug view of HDR luminence across the scene in nits."
@@ -482,6 +484,8 @@ int main(int argc, char **argv)
 					g_bUseLayers = false;
 				} else if (strcmp(opt_name, "debug-layers") == 0) {
 					g_bDebugLayers = true;
+				} else if (strcmp(opt_name, "disable-color-management") == 0) {
+					g_bForceDisableColorMgmt = true;
 				} else if (strcmp(opt_name, "xwayland-count") == 0) {
 					g_nXWaylandCount = atoi( optarg );
 				} else if (strcmp(opt_name, "composite-debug") == 0) {


### PR DESCRIPTION
Resolves  a crash at start up in embedded mode since 2548f3375c4f857db500d64945dd0fb7cc6882ee (which was not fixed by 5d9ecd462e6d5939fc2697509f53bcb6aba7eb92).

Running on nvidia gtx 2070 connected to TV via HDMI, proprietary driver 530.41.03, Arch kernel 6.2.12-zen1-1-zen.