### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1,7 +1,6 @@
 // DRM output stuff
 
 #include <limits.h>
-#include <linux/limits.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Regressed by #849. a90e359fc477 added `<linux/limits.h>` in addition to `<limits.h>`. Let's see if CI passes without it or add `#ifdef __linux__` otherwise.