### PR TITLE
Avoid out of bounds accesses in drm.cpp

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -524,6 +524,11 @@ const char *drm_get_patched_edid_path()
 
 static void create_patched_edid( const uint8_t *orig_data, size_t orig_size, drm_t *drm, struct connector *conn )
 {
+	// A zero length indicates that the edid parsing failed.
+	if (orig_size == 0) {
+		return;
+	}
+
 	std::vector<uint8_t> edid(orig_data, orig_data + orig_size);
 
 	if ( g_bRotated )


### PR DESCRIPTION
On certain configurations the EDID retrieval and parsing seems to fail, leading to create_patched_edid accessing out of bounds indexes on a zero length vector.

Fixes #860.
