### PR TITLE
vulkan: Check if selected queue can be used

### DIFF
--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -318,9 +318,10 @@ namespace CompositeDebugFlag
 	static constexpr uint32_t Tonemap_Reinhard = 1u << 7;
 };
 
-bool vulkan_init(void);
+VkInstance vulkan_create_instance(void);
+bool vulkan_init(VkInstance instance, VkSurfaceKHR surface);
 bool vulkan_init_formats(void);
-bool vulkan_make_output(void);
+bool vulkan_make_output(VkSurfaceKHR surface);
 
 std::shared_ptr<CVulkanTexture> vulkan_create_texture_from_dmabuf( struct wlr_dmabuf_attributes *pDMA );
 std::shared_ptr<CVulkanTexture> vulkan_create_texture_from_bits( uint32_t width, uint32_t height, uint32_t contentWidth, uint32_t contentHeight, uint32_t drmFormat, CVulkanTexture::createFlags texCreateFlags, void *bits );


### PR DESCRIPTION
This is essentially a fix for [src/rendervulkan.cpp:3075](https://github.com/ValveSoftware/gamescope/tree/378cfa5b7bb6fd005c32241330938b7f1bd9c881/src/rendervulkan.cpp#L3075) (before this commit).

Instead of first selecting a queue and later failing, if the selected queue can't be used for presenting, this patch considers the fact, *when* selecting a queue.
As a result quite a bit of code had to be re-ordered to make sure the surface already exists, when selecting the queue.

This is not just an academic exercise, but necessary e.g. for running nested on the nvidia-driver, which doesn't support presenting with the normally selected compute queue.
While that can be worked around by setting `ENABLE_VKBASALT=1`, this seems like a more appropriate fix, given that nothing in the spec seems to guarantee, that a compute queue is supposed to work.

I couldn't find formatting rule beside the bare-bones editor-config, so I tried to mimic the style of the rest of the code base. If I missed anything, please let me know.