### PR TITLE
Don't send frame callback before we have actually committed.

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6533,6 +6533,8 @@ void steamcompmgr_check_xdg(bool vblank)
 		{
 			steamcompmgr_flush_frame_done(xdg_win.get());
 		}
+
+		handle_presented_xdg();
 	}
 
 	check_new_xdg_res();
@@ -6976,8 +6978,6 @@ steamcompmgr_main(int argc, char **argv)
 			gamescope_xwayland_server_t *server = NULL;
 			for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
 				handle_presented_xwayland( server->ctx.get() );
-
-			handle_presented_xdg();
 		}
 
 		//

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5642,7 +5642,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 			already_exists = true;
 	}
 
-	if ( already_exists )
+	if ( already_exists && !reslistentry.feedback && reslistentry.presentation_feedbacks.empty() )
 	{
 		wlserver_lock();
 		wlr_buffer_unlock( buf );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4525,24 +4525,21 @@ init_runtime_info()
 }
 
 static void
-steamcompmgr_send_done( steamcompmgr_win_t *w, uint64_t vblank_idx, struct timespec& now )
+steamcompmgr_flush_frame_done( steamcompmgr_win_t *w )
 {
-	wlr_surface *main_surface = w->main_surface();
 	wlr_surface *current_surface = w->current_surface();
-	bool bSendCallback = current_surface != nullptr;
-
-	int nRefresh = g_nNestedRefresh ? g_nNestedRefresh : g_nOutputRefresh;
-	int nTargetFPS = g_nSteamCompMgrTargetFPS;
-	if ( g_nSteamCompMgrTargetFPS && steamcompmgr_window_should_limit_fps( w ) && nRefresh > nTargetFPS )
+	if ( current_surface && w->unlockedForFrameCallback && w->receivedDoneCommit )
 	{
-		int nVblankDivisor = nRefresh / nTargetFPS;
+		// TODO: Look into making this _RAW
+		// wlroots, seems to just use normal MONOTONIC
+		// all over so this may be problematic to just change.
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
 
-		if ( vblank_idx % nVblankDivisor != 0 )
-			bSendCallback = false;
-	}
+		wlr_surface *main_surface = w->main_surface();
+		w->unlockedForFrameCallback = false;
+		w->receivedDoneCommit = false;
 
-	if ( bSendCallback )
-	{
 		// Acknowledge commit once.
 		wlserver_lock();
 
@@ -4557,6 +4554,27 @@ steamcompmgr_send_done( steamcompmgr_win_t *w, uint64_t vblank_idx, struct times
 		}
 
 		wlserver_unlock();
+	}
+}
+
+static void
+steamcompmgr_latch_frame_done( steamcompmgr_win_t *w, uint64_t vblank_idx )
+{
+	bool bSendCallback = true;
+
+	int nRefresh = g_nNestedRefresh ? g_nNestedRefresh : g_nOutputRefresh;
+	int nTargetFPS = g_nSteamCompMgrTargetFPS;
+	if ( g_nSteamCompMgrTargetFPS && steamcompmgr_window_should_limit_fps( w ) && nRefresh > nTargetFPS )
+	{
+		int nVblankDivisor = nRefresh / nTargetFPS;
+
+		if ( vblank_idx % nVblankDivisor != 0 )
+			bSendCallback = false;
+	}
+
+	if ( bSendCallback )
+	{
+		w->unlockedForFrameCallback = true;
 	}
 }
 
@@ -5510,6 +5528,7 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 			// we can release all commits prior to done ones
 			w->commit_queue.erase( w->commit_queue.begin(), w->commit_queue.begin() + j );
 		}
+		w->receivedDoneCommit = true;
 		return true;
 	}
 
@@ -6497,7 +6516,7 @@ static bool g_bWasFSRActive = false;
 
 extern std::atomic<uint64_t> g_nCompletedPageFlipCount;
 
-void steamcompmgr_check_xdg()
+void steamcompmgr_check_xdg(bool vblank)
 {
 	if (wlserver_xdg_dirty())
 	{
@@ -6506,6 +6525,16 @@ void steamcompmgr_check_xdg()
 	}
 
 	handle_done_commits_xdg();
+
+	// When we have observed both a complete commit and a VBlank, we should request a new frame.
+	if (vblank)
+	{
+		for ( const auto& xdg_win : g_steamcompmgr_xdg_wins )
+		{
+			steamcompmgr_flush_frame_done(xdg_win.get());
+		}
+	}
+
 	check_new_xdg_res();
 }
 
@@ -6879,13 +6908,11 @@ steamcompmgr_main(int argc, char **argv)
 #endif
 		}
 
-		// TODO: Look into making this _RAW
-		// wlroots, seems to just use normal MONOTONIC
-		// all over so this may be problematic to just change.
-		struct timespec now;
-		clock_gettime(CLOCK_MONOTONIC, &now);
-
 		// Ask for a new surface every vblank
+		// When we observe a new commit being complete for a surface, we ask for a new frame.
+		// This ensures that FIFO works properly, since otherwise we might ask for a new frame
+		// application can commit a new frame that completes before we ever displayed
+		// the current pending commit.
 		if ( vblank == true )
 		{
 			static int vblank_idx = 0;
@@ -6895,13 +6922,13 @@ steamcompmgr_main(int argc, char **argv)
 				{
 					for (steamcompmgr_win_t *w = server->ctx->list; w; w = w->xwayland().next)
 					{
-						steamcompmgr_send_done( w, vblank_idx, now );
+						steamcompmgr_latch_frame_done( w, vblank_idx );
 					}
 				}
 
 				for ( const auto& xdg_win : g_steamcompmgr_xdg_wins )
 				{
-					steamcompmgr_send_done( xdg_win.get(), vblank_idx, now );
+					steamcompmgr_latch_frame_done( xdg_win.get(), vblank_idx );
 				}
 			}
 			vblank_idx++;
@@ -6910,7 +6937,18 @@ steamcompmgr_main(int argc, char **argv)
 		{
 			gamescope_xwayland_server_t *server = NULL;
 			for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
+			{
 				handle_done_commits_xwayland(server->ctx.get());
+
+				// When we have observed both a complete commit and a VBlank, we should request a new frame.
+				if (vblank)
+				{
+					for (steamcompmgr_win_t *w = server->ctx->list; w; w = w->xwayland().next)
+					{
+						steamcompmgr_flush_frame_done(w);
+					}
+				}
+			}
 		}
 
 		// Handle presentation-time stuff
@@ -6999,7 +7037,7 @@ steamcompmgr_main(int argc, char **argv)
 			}
 		}
 
-		steamcompmgr_check_xdg();
+		steamcompmgr_check_xdg(vblank);
 
 		// Handles if we got a commit for the window we want to focus
 		// to switch to it for painting (outdatedInteractiveFocus)

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5648,6 +5648,11 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		wlr_buffer_unlock( buf );
 		wlserver_unlock();
 		xwm_log.errorf( "got the same buffer commited twice, ignoring." );
+
+		// If we have a duplicated commit + frame callback, ensure that is signalled.
+		// This matches Mutter and Weston behavior, so it's plausible that some application relies on forward progress.
+		// We're essentially discarding the commit here, so consider it complete right away.
+		w->receivedDoneCommit = true;
 		return;
 	}
 

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -122,6 +122,9 @@ struct steamcompmgr_win_t {
 	bool nudged;
 	bool ignoreOverrideRedirect;
 
+	bool unlockedForFrameCallback;
+	bool receivedDoneCommit;
+
 	unsigned int mouseMoved;
 
 	std::vector< std::shared_ptr<commit_t> > commit_queue;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -144,12 +144,11 @@ void wlserver_xdg_commit(struct wlr_surface *surf, struct wlr_buffer *buf)
 }
 
 void xwayland_surface_commit(struct wlr_surface *wlr_surface) {
-	uint32_t committed = wlr_surface->current.committed;
 	wlr_surface->current.committed = 0;
 
-	if (!(committed & WLR_SURFACE_STATE_BUFFER)) {
-		return;
-	}
+	// Committing without buffer state is valid and commits the same buffer again.
+	// Mutter and Weston have forward progress on the frame callback in this situation,
+	// so let the commit go through. It will be duplication-eliminated later.
 
 	VulkanWlrTexture_t *tex = (VulkanWlrTexture_t *) wlr_surface_get_texture( wlr_surface );
 	if ( tex == NULL )


### PR DESCRIPTION
This avoids a problem where frame callback is reported before we have actually committed to display a surface. This could lead to skipping where application commits a new surface before the current surface will be queued up for display. This breaks FIFO rules in e.g. Vulkan. A scenario where this matters is when GPU is rendering slower than refresh rate.

Also avoids a problem where the commit queue can grow large since frame callbacks will be pumped faster than the GPU is able to process the frames.

At least Mutter behavior is similar here, so I think this is the correct interpretation.

Also fixes KHR_present_wait in Xwayland. Xwayland uses frame callback to signal PRESENT_COMPLETE and this fixes that.