### PR TITLE
Fallback to regular-priority queue when vkCreateDevice fails

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -876,6 +876,13 @@ bool CVulkanDevice::createDevice()
 	};
 
 	VkResult res = vk.CreateDevice(physDev(), &deviceCreateInfo, nullptr, &m_device);
+	if ( res == VK_ERROR_NOT_PERMITTED_KHR && g_bNiceCap )
+	{
+		fprintf(stderr, "vkCreateDevice failed with a high-priority queue. Falling back to regular priority.\n");
+		queueCreateInfo.pNext = nullptr;
+		res = vk.CreateDevice(physDev(), &deviceCreateInfo, nullptr, &m_device);
+	}
+
 	if ( res != VK_SUCCESS )
 	{
 		vk_errorf( res, "vkCreateDevice failed" );


### PR DESCRIPTION
Currently gamescope tries to use a high priority queue whenever we have CAP_SYS_NICE.

I think that Nvidia only supports this feature on Pascal and newer (https://forums.developer.nvidia.com/t/linux-solaris-and-freebsd-driver-470-42-01-beta/181536), so gamescope can fail to start on older cards with CAP_SYS_NICE 
(e.g. https://github.com/HoloISO/holoiso/issues/262#issue-1260909682).

If this happens, just fall back to a regular-priority queue.

Many thanks.