### PR TITLE
Added option to set scaler and filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On any X11 or Wayland desktop, you can set the Steam launch arguments of your ga
 
 ```sh
 # Upscale a 720p game to 1440p with integer scaling
-gamescope -h 720 -H 1440 -s integer -- %command%
+gamescope -h 720 -H 1440 -S integer -- %command%
 
 # Limit a vsynced game to 30 FPS
 gamescope -r 30 -- %command%
@@ -63,9 +63,9 @@ See `gamescope --help` for a full list of options.
 * `-w`, `-h`: set the resolution used by the game. If `-h` is specified but `-w` isn't, a 16:9 aspect ratio is assumed. Defaults to the values specified in `-W` and `-H`.
 * `-r`: set a frame-rate limit for the game. Specified in frames per second. Defaults to unlimited.
 * `-o`: set a frame-rate limit for the game when unfocused. Specified in frames per second. Defaults to unlimited.
-* `-U`: use AMD FidelityFX™ Super Resolution 1.0 for upscaling
-* `-Y`: use NVIDIA Image Scaling v1.0.3 for upscaling
-* `-s integer`: use integer scaling.
-* `-s stretch`: use stretch scaling, the game will fill the window. (e.g. 4:3 to 16:9)
+* `-F fsr`: use AMD FidelityFX™ Super Resolution 1.0 for upscaling
+* `-F nis`: use NVIDIA Image Scaling v1.0.3 for upscaling
+* `-S integer`: use integer scaling.
+* `-S stretch`: use stretch scaling, the game will fill the window. (e.g. 4:3 to 16:9)
 * `-b`: create a border-less window.
 * `-f`: create a full-screen window.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On any X11 or Wayland desktop, you can set the Steam launch arguments of your ga
 
 ```sh
 # Upscale a 720p game to 1440p with integer scaling
-gamescope -h 720 -H 1440 -i -- %command%
+gamescope -h 720 -H 1440 -s integer -- %command%
 
 # Limit a vsynced game to 30 FPS
 gamescope -r 30 -- %command%
@@ -65,6 +65,7 @@ See `gamescope --help` for a full list of options.
 * `-o`: set a frame-rate limit for the game when unfocused. Specified in frames per second. Defaults to unlimited.
 * `-U`: use AMD FidelityFX™ Super Resolution 1.0 for upscaling
 * `-Y`: use NVIDIA Image Scaling v1.0.3 for upscaling
-* `-i`: use integer scaling.
+* `-s integer`: use integer scaling.
+* `-s stretch`: use stretch scaling, the game will fill the window. (e.g. 4:3 to 16:9)
 * `-b`: create a border-less window.
 * `-f`: create a full-screen window.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "nested-height", required_argument, nullptr, 'h' },
 	{ "nested-refresh", required_argument, nullptr, 'r' },
 	{ "max-scale", required_argument, nullptr, 'm' },
-	{ "integer-scale", no_argument, nullptr, 'i' },
+	{ "scaler", required_argument, nullptr, 's' },
 	{ "output-width", required_argument, nullptr, 'W' },
 	{ "output-height", required_argument, nullptr, 'H' },
 	{ "nearest-neighbor-filter", no_argument, nullptr, 'n' },
@@ -137,7 +137,7 @@ const char usage[] =
 	"  -h, --nested-height            game height\n"
 	"  -r, --nested-refresh           game refresh rate (frames per second)\n"
 	"  -m, --max-scale                maximum scale factor\n"
-	"  -i, --integer-scale            force scale factor to integer\n"
+	"  -s, --scaler                   force scaler type (auto, integer, fit, fill, stretch)\n"
 	"  -W, --output-width             output width\n"
 	"  -H, --output-height            output height\n"
 	"  -n, --nearest-neighbor-filter  use nearest neighbor filtering\n"
@@ -337,6 +337,24 @@ static enum g_panel_orientation force_orientation(const char *str)
 	}
 }
 
+static enum GamescopeUpscaleScaler parse_upscaler_scaler(const char *str)
+{
+	if (strcmp(str, "auto") == 0) {
+		return GamescopeUpscaleScaler::AUTO;
+	} else if (strcmp(str, "integer") == 0) {
+		return GamescopeUpscaleScaler::INTEGER;
+	} else if (strcmp(str, "fit") == 0) {
+		return GamescopeUpscaleScaler::FIT;
+	} else if (strcmp(str, "fill") == 0) {
+		return GamescopeUpscaleScaler::FILL;
+	} else if (strcmp(str, "stretch") == 0) {
+		return GamescopeUpscaleScaler::STRETCH;
+	} else {
+		fprintf( stderr, "gamescope: invalid value for --scaler\n" );
+		exit(1);
+	}
+}
+
 static void handle_signal( int sig )
 {
 	switch ( sig ) {
@@ -455,8 +473,8 @@ int main(int argc, char **argv)
 			case 'm':
 				g_flMaxWindowScale = atof( optarg );
 				break;
-			case 'i':
-				g_wantedUpscaleScaler = GamescopeUpscaleScaler::INTEGER;
+			case 's':
+				g_wantedUpscaleScaler = parse_upscaler_scaler(optarg);
 				break;
 			case 'n':
 				g_wantedUpscaleFilter = GamescopeUpscaleFilter::NEAREST;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,12 +45,10 @@ const struct option *gamescope_options = (struct option[]){
 	{ "nested-height", required_argument, nullptr, 'h' },
 	{ "nested-refresh", required_argument, nullptr, 'r' },
 	{ "max-scale", required_argument, nullptr, 'm' },
-	{ "scaler", required_argument, nullptr, 's' },
+	{ "scaler", required_argument, nullptr, 'S' },
+	{ "filter", required_argument, nullptr, 'F' },
 	{ "output-width", required_argument, nullptr, 'W' },
 	{ "output-height", required_argument, nullptr, 'H' },
-	{ "nearest-neighbor-filter", no_argument, nullptr, 'n' },
-	{ "fsr-upscaling", no_argument, nullptr, 'U' },
-	{ "nis-upscaling", no_argument, nullptr, 'Y' },
 	{ "sharpness", required_argument, nullptr, 0 },
 	{ "fsr-sharpness", required_argument, nullptr, 0 },
 	{ "rt", no_argument, nullptr, 0 },
@@ -133,16 +131,16 @@ const char usage[] =
 	"\n"
 	"Options:\n"
 	"  --help                         show help message\n"
+	"  -W, --output-width             output width\n"
+	"  -H, --output-height            output height\n"
 	"  -w, --nested-width             game width\n"
 	"  -h, --nested-height            game height\n"
 	"  -r, --nested-refresh           game refresh rate (frames per second)\n"
 	"  -m, --max-scale                maximum scale factor\n"
-	"  -s, --scaler                   force scaler type (auto, integer, fit, fill, stretch)\n"
-	"  -W, --output-width             output width\n"
-	"  -H, --output-height            output height\n"
-	"  -n, --nearest-neighbor-filter  use nearest neighbor filtering\n"
-	"  -U, --fsr-upscaling            use AMD FidelityFX™ Super Resolution 1.0 for upscaling\n"
-	"  -Y, --nis-upscaling            use NVIDIA Image Scaling v1.0.3 for upscaling\n"
+	"  -S, --scaler                   upscaler type (auto, integer, fit, fill, stretch)\n"
+	"  -F, --filter                   upscaler filter (linear, nearest, fsr, nis)\n"
+	"                                     fsr => AMD FidelityFX™ Super Resolution 1.0\n"
+	"                                     nis => NVIDIA Image Scaling v1.0.3\n"
 	"  --sharpness, --fsr-sharpness   upscaler sharpness from 0 (max) to 20 (min)\n"
 	"  --expose-wayland               support wayland clients using xdg-shell\n"
 	"  --cursor                       path to default cursor image\n"
@@ -355,6 +353,22 @@ static enum GamescopeUpscaleScaler parse_upscaler_scaler(const char *str)
 	}
 }
 
+static enum GamescopeUpscaleFilter parse_upscaler_filter(const char *str)
+{
+	if (strcmp(str, "linear") == 0) {
+		return GamescopeUpscaleFilter::LINEAR;
+	} else if (strcmp(str, "nearest") == 0) {
+		return GamescopeUpscaleFilter::NEAREST;
+	} else if (strcmp(str, "fsr") == 0) {
+		return GamescopeUpscaleFilter::FSR;
+	} else if (strcmp(str, "nis") == 0) {
+		return GamescopeUpscaleFilter::NIS;
+	} else {
+		fprintf( stderr, "gamescope: invalid value for --filter\n" );
+		exit(1);
+	}
+}
+
 static void handle_signal( int sig )
 {
 	switch ( sig ) {
@@ -473,11 +487,11 @@ int main(int argc, char **argv)
 			case 'm':
 				g_flMaxWindowScale = atof( optarg );
 				break;
-			case 's':
+			case 'S':
 				g_wantedUpscaleScaler = parse_upscaler_scaler(optarg);
 				break;
-			case 'n':
-				g_wantedUpscaleFilter = GamescopeUpscaleFilter::NEAREST;
+			case 'F':
+				g_wantedUpscaleFilter = parse_upscaler_filter(optarg);
 				break;
 			case 'b':
 				g_bBorderlessOutputWindow = true;
@@ -487,12 +501,6 @@ int main(int argc, char **argv)
 				break;
 			case 'O':
 				g_sOutputName = optarg;
-				break;
-			case 'U':
-				g_wantedUpscaleFilter = GamescopeUpscaleFilter::FSR;
-				break;
-			case 'Y':
-				g_wantedUpscaleFilter = GamescopeUpscaleFilter::NIS;
 				break;
 			case 'g':
 				g_bGrabbed = true;


### PR DESCRIPTION
One of my friends rage-uninstalled Linux as he wasn't able to set his shooter to a streched resolution.
Therefore I want to prevent other people from suffering **that** much and made the already existing option accessible.

As it was superfluous, I removed the option to explicitly force integer scaler. This might be a breaking change.

Some points to discuss:
- Shouldn't we do the same for the upscaler filter?
At the moment there are multiple options that contradict each other. (-U, -Y, -n)
- On my machine the `README.md` isn't correct about building instructions as the binary is at `build/src/gamescope`.
Is this a mistake?
- I thought about implementing shortcuts to cycle through the scalers / filters.
Would this be useful to anybody or would explicit shortcuts make more sense?

Related: #399