### PR TITLE
Shortcut for cycling scalers and filters / Output in MangoApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ meson install -C build/ --skip-subprojects
 * **Super + O** : Decrease FSR sharpness by 1
 * **Super + S** : Take screenshot (currently goes to `/tmp/gamescope_$DATE.png`)
 
+* **Super + X** : Cycle upscalers (Auto, Integer, Fit, Fill, Stretch)
+* **Super + Z** : Cycle upscaling filters (Linear, Nearest, FSR, NIS)
+
 ## Examples
 
 On any X11 or Wayland desktop, you can set the Steam launch arguments of your game as follows:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,7 +249,7 @@ GamescopeUpscaleScaler g_upscaleScaler = GamescopeUpscaleScaler::AUTO;
 
 GamescopeUpscaleFilter g_wantedUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 GamescopeUpscaleScaler g_wantedUpscaleScaler = GamescopeUpscaleScaler::AUTO;
-int g_upscaleFilterSharpness = 2;
+uint8_t g_upscaleFilterSharpness = 2;
 
 bool g_bBorderlessOutputWindow = false;
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -23,7 +23,7 @@ extern bool g_bFullscreen;
 
 extern bool g_bGrabbed;
 
-enum class GamescopeUpscaleFilter : uint32_t
+enum class GamescopeUpscaleFilter : uint8_t
 {
     LINEAR = 0,
     NEAREST,
@@ -34,7 +34,7 @@ enum class GamescopeUpscaleFilter : uint32_t
     _LAST = NIS
 };
 
-enum class GamescopeUpscaleScaler : uint32_t
+enum class GamescopeUpscaleScaler : uint8_t
 {
     AUTO,
     INTEGER,
@@ -50,7 +50,7 @@ extern GamescopeUpscaleFilter g_upscaleFilter;
 extern GamescopeUpscaleScaler g_upscaleScaler;
 extern GamescopeUpscaleFilter g_wantedUpscaleFilter;
 extern GamescopeUpscaleScaler g_wantedUpscaleScaler;
-extern int g_upscaleFilterSharpness;
+extern uint8_t g_upscaleFilterSharpness;
 
 extern bool g_bBorderlessOutputWindow;
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -28,7 +28,10 @@ enum class GamescopeUpscaleFilter : uint32_t
     LINEAR = 0,
     NEAREST,
     FSR,
-    NIS
+    NIS,
+
+    _FIRST = LINEAR,
+    _LAST = NIS
 };
 
 enum class GamescopeUpscaleScaler : uint32_t
@@ -38,6 +41,9 @@ enum class GamescopeUpscaleScaler : uint32_t
     FIT,
     FILL,
     STRETCH,
+
+    _FIRST = AUTO,
+    _LAST = STRETCH
 };
 
 extern GamescopeUpscaleFilter g_upscaleFilter;

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -25,6 +25,7 @@ struct mangoapp_msg_v1 {
     uint64_t latency_ns;
     uint32_t outputWidth;
     uint32_t outputHeight;
+    uint8_t scaler;
     // WARNING: Always ADD fields, never remove or repurpose fields
 } __attribute__((packed)) mangoapp_msg_v1;
 
@@ -50,5 +51,6 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
     mangoapp_msg_v1.pid = focusWindow_pid;
     mangoapp_msg_v1.outputWidth = g_nOutputWidth;
     mangoapp_msg_v1.outputHeight = g_nOutputHeight;
+    mangoapp_msg_v1.scaler = (uint8_t)g_upscaleScaler;
     msgsnd(msgid, &mangoapp_msg_v1, sizeof(mangoapp_msg_v1) - sizeof(mangoapp_msg_v1.hdr.msg_type), IPC_NOWAIT);
 }

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -19,7 +19,7 @@ struct mangoapp_msg_v1 {
 
     uint32_t pid;
     uint64_t visible_frametime_ns;
-    uint8_t fsrUpscale;
+    uint8_t scaler_filter;
     uint8_t fsrSharpness;
     uint64_t app_frametime_ns;
     uint64_t latency_ns;
@@ -33,7 +33,7 @@ void init_mangoapp(){
     msgid = msgget(key, 0666 | IPC_CREAT);
     mangoapp_msg_v1.hdr.msg_type = 1;
     mangoapp_msg_v1.hdr.version = 1;
-    mangoapp_msg_v1.fsrUpscale = 0;
+    mangoapp_msg_v1.scaler_filter = 0;
     mangoapp_msg_v1.fsrSharpness = 0;
     inited = true;
 }
@@ -43,7 +43,7 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
         init_mangoapp();
 
     mangoapp_msg_v1.visible_frametime_ns = visible_frametime;
-    mangoapp_msg_v1.fsrUpscale = g_bFSRActive;
+    mangoapp_msg_v1.scaler_filter = (uint8_t)g_upscaleFilter;
     mangoapp_msg_v1.fsrSharpness = g_upscaleFilterSharpness;
     mangoapp_msg_v1.app_frametime_ns = app_frametime_ns;
     mangoapp_msg_v1.latency_ns = latency_ns;

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -233,6 +233,14 @@ void inputSDLThreadRun( void )
 						case KEY_B:
 							g_wantedUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 							break;
+						case KEY_X:
+							g_wantedUpscaleScaler = (g_wantedUpscaleScaler == GamescopeUpscaleScaler::_LAST) ?
+								GamescopeUpscaleScaler::_FIRST : (GamescopeUpscaleScaler)((int)g_wantedUpscaleScaler + 1);
+							break;
+						case KEY_Z:
+							g_wantedUpscaleFilter = (g_wantedUpscaleFilter == GamescopeUpscaleFilter::_LAST) ?
+								GamescopeUpscaleFilter::_FIRST : (GamescopeUpscaleFilter)((int)g_wantedUpscaleFilter + 1);
+							break;
 						case KEY_U:
 							g_wantedUpscaleFilter = (g_wantedUpscaleFilter == GamescopeUpscaleFilter::FSR) ?
 								GamescopeUpscaleFilter::LINEAR : GamescopeUpscaleFilter::FSR;


### PR DESCRIPTION
As discussed in #893, I have implemented key bindings to cycle through the upscalers and filters.
I have not removed the existing shortcuts yet, as you can not determine which scaler is active for now.

I added the current scaler settings to the mango message protocol, as it supports FSR only atm.
The PR to show it in MangoHud: https://github.com/flightlessmango/MangoHud/pull/1042

The new shortcuts are `Super + X` (scalers) and `Super + Z` (filters).

This keys are one of the last ones that do not trigger something in my DE (KDE Plasma) and they are neighbors.
They are placeholders though. If there is a better idea, we should change them before they are merged.