### PR TITLE
steamcompmgr: Fix enabling VRR from commandline

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6595,7 +6595,8 @@ void update_vrr_atoms(xwayland_ctx_t *root_ctx, bool force, bool* needs_flush = 
 	// Keep this as a preference, starting with off.
 	if ( force )
 	{
-		uint32_t enabled_value = 0;
+        bool wants_vrr = g_DRM.wants_vrr_enabled;
+		uint32_t enabled_value = wants_vrr ? 1 : 0;
 		XChangeProperty(root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeVRREnabled, XA_CARDINAL, 32, PropModeReplace,
 			(unsigned char *)&enabled_value, 1 );
 		if (needs_flush)


### PR DESCRIPTION
The --adaptive-sync flag is not used during vrr atom update so it's value get's overwritten with 0 thus disabling the VRR in the process.