### PR TITLE
Add clipboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ meson install -C build/ --skip-subprojects
 * **Super + O** : Decrease FSR sharpness by 1
 * **Super + S** : Take screenshot (currently goes to `/tmp/gamescope_$DATE.png`)
 * **Super + G** : Toggle keyboard grab
-* **Super + S** : Update clipboard
+* **Super + C** : Update clipboard
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ meson install -C build/ --skip-subprojects
 * **Super + I** : Increase FSR sharpness by 1
 * **Super + O** : Decrease FSR sharpness by 1
 * **Super + S** : Take screenshot (currently goes to `/tmp/gamescope_$DATE.png`)
+* **Super + G** : Toggle keyboard grab
+* **Super + S** : Update clipboard
 
 ## Examples
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -847,13 +847,7 @@ static bool initOutput( int preferredWidth, int preferredHeight, int preferredRe
 		{
 			return sdlwindow_init();
 		}
-		else
-		{
-			return true;
-		}
+		return true;
 	}
-	else
-	{
-		return init_drm( &g_DRM, preferredWidth, preferredHeight, preferredRefresh, s_bInitialWantsVRREnabled );
-	}
+	return init_drm( &g_DRM, preferredWidth, preferredHeight, preferredRefresh, s_bInitialWantsVRREnabled );
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,6 +224,7 @@ const char usage[] =
 	"  Super + O                      decrease FSR sharpness by 1\n"
 	"  Super + S                      take a screenshot\n"
 	"  Super + G                      toggle keyboard grab\n"
+	"  Super + C                      update clipboard\n"
 	"";
 
 std::atomic< bool > g_bRun{true};

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -35,9 +35,6 @@ extern bool g_bFirstFrame;
 
 SDL_Window *g_SDLWindow;
 
-std::string clipboard;
-std::string primarySelection;
-
 enum UserEvents
 {
 	USER_EVENT_TITLE,
@@ -484,35 +481,25 @@ void sdlwindow_set_selection(std::string contents, int selection)
 {
 	if (selection == CLIPBOARD)
 	{
-		clipboard = contents;
 		SDL_SetClipboardText(contents.c_str());
 	}
 	else if (selection == PRIMARYSELECTION)
 	{
-		primarySelection = contents;
 		SDL_SetPrimarySelectionText(contents.c_str());
 	}
 }
 
 static void set_gamescope_selections()
 {
-	char *text;
+	char *_clipboard = SDL_GetClipboardText();
 
-	text = SDL_GetClipboardText();
-	clipboard = text;
-	SDL_free(text);
+	char *_primarySelection = SDL_GetPrimarySelectionText();
 
-	text = SDL_GetPrimarySelectionText();
-	primarySelection = text;
-	SDL_free(text);
+	gamescope_set_selection(_clipboard, CLIPBOARD);
+	gamescope_set_selection(_primarySelection, PRIMARYSELECTION);
 
-	for (int i = 0; i < g_nXWaylandCount; i++)
-	{
-		gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(0);
-		xwayland_ctx_t *ctx = server->ctx.get();
-		x11_set_selection(ctx, clipboard, CLIPBOARD);
-		x11_set_selection(ctx, primarySelection, PRIMARYSELECTION);
-	}
+	SDL_free(_clipboard);
+	SDL_free(_primarySelection);
 }
 
 void sdlwindow_visible( bool bVisible )

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -270,9 +270,6 @@ void inputSDLThreadRun( void )
 							event.type = g_unSDLUserEventID + USER_EVENT_TITLE;
 							SDL_PushEvent( &event );
 							break;
-						case KEY_C:
-							 set_gamescope_selections();
-							 break;
 						default:
 							handled = false;
 					}

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -1,10 +1,13 @@
 // For the nested case, reads input from the SDL window and send to wayland
 
+#include <X11/Xlib.h>
 #include <thread>
 #include <mutex>
 
 #include <linux/input-event-codes.h>
 
+#include "SDL_clipboard.h"
+#include "SDL_events.h"
 #include "main.hpp"
 #include "wlserver.hpp"
 #include "sdlwindow.hpp"
@@ -32,6 +35,9 @@ extern bool g_bFirstFrame;
 
 SDL_Window *g_SDLWindow;
 
+std::string clipboard;
+std::string primarySelection;
+
 enum UserEvents
 {
 	USER_EVENT_TITLE,
@@ -58,6 +64,8 @@ struct SDLPendingCursor
 static std::mutex g_SDLCursorLock;
 static SDLPendingCursor g_SDLPendingCursorData;
 static bool g_bUpdateSDLCursor = false;
+
+static void set_gamescope_selections();
 
 //-----------------------------------------------------------------------------
 // Purpose: Convert from the remote scancode to a Linux event keycode
@@ -165,6 +173,9 @@ void inputSDLThreadRun( void )
 
 		switch( event.type )
 		{
+			case SDL_CLIPBOARDUPDATE:
+				set_gamescope_selections();
+				break;
 			case SDL_MOUSEMOTION:
 				if ( bRelativeMouse )
 				{
@@ -259,6 +270,9 @@ void inputSDLThreadRun( void )
 							event.type = g_unSDLUserEventID + USER_EVENT_TITLE;
 							SDL_PushEvent( &event );
 							break;
+						case KEY_C:
+							 set_gamescope_selections();
+							 break;
 						default:
 							handled = false;
 					}
@@ -466,6 +480,41 @@ void sdlwindow_title( std::shared_ptr<std::string> title, std::shared_ptr<std::v
 			event.type = g_unSDLUserEventID + USER_EVENT_TITLE;
 			SDL_PushEvent( &event );
 		}
+	}
+}
+
+void sdlwindow_set_selection(std::string contents, int selection)
+{
+	if (selection == CLIPBOARD)
+	{
+		clipboard = contents;
+		SDL_SetClipboardText(contents.c_str());
+	}
+	else if (selection == PRIMARYSELECTION)
+	{
+		primarySelection = contents;
+		SDL_SetPrimarySelectionText(contents.c_str());
+	}
+}
+
+static void set_gamescope_selections()
+{
+	char *text;
+
+	text = SDL_GetClipboardText();
+	clipboard = text;
+	SDL_free(text);
+
+	text = SDL_GetPrimarySelectionText();
+	primarySelection = text;
+	SDL_free(text);
+
+	for (int i = 0; i < g_nXWaylandCount; i++)
+	{
+		gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(0);
+		xwayland_ctx_t *ctx = server->ctx.get();
+		x11_set_selection(ctx, clipboard, CLIPBOARD);
+		x11_set_selection(ctx, primarySelection, PRIMARYSELECTION);
 	}
 }
 

--- a/src/sdlwindow.hpp
+++ b/src/sdlwindow.hpp
@@ -20,5 +20,3 @@ void sdlwindow_grab( bool bGrab );
 void sdlwindow_cursor(std::shared_ptr<std::vector<uint32_t>> pixels, uint32_t width, uint32_t height, uint32_t xhot, uint32_t yhot);
 
 extern SDL_Window *g_SDLWindow;
-extern std::string clipboard;
-extern std::string primarySelection;

--- a/src/sdlwindow.hpp
+++ b/src/sdlwindow.hpp
@@ -5,10 +5,14 @@
 #include <SDL.h>
 #include <SDL_vulkan.h>
 
+#define CLIPBOARD 0
+#define PRIMARYSELECTION 1
+
 bool sdlwindow_init( void );
 
 void sdlwindow_update( void );
 void sdlwindow_title( std::shared_ptr<std::string> title, std::shared_ptr<std::vector<uint32_t>> icon );
+void sdlwindow_set_selection(std::string, int selection);
 
 // called from other threads with interesting things have happened with clients that might warrant updating the nested window
 void sdlwindow_visible( bool bVisible );
@@ -16,3 +20,5 @@ void sdlwindow_grab( bool bGrab );
 void sdlwindow_cursor(std::shared_ptr<std::vector<uint32_t>> pixels, uint32_t width, uint32_t height, uint32_t xhot, uint32_t yhot);
 
 extern SDL_Window *g_SDLWindow;
+extern std::string clipboard;
+extern std::string primarySelection;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -129,6 +129,9 @@ extern float g_flHDRItmTargetNits;
 
 extern std::atomic<uint64_t> g_lastVblank;
 
+std::string clipboard;
+std::string primarySelection;
+
 uint64_t timespec_to_nanos(struct timespec& spec)
 {
 	return spec.tv_sec * 1'000'000'000ul + spec.tv_nsec;
@@ -4584,13 +4587,8 @@ handle_client_message(xwayland_ctx_t *ctx, XClientMessageEvent *ev)
 	}
 }
 
-void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int selectionTarget)
+static void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int selectionTarget)
 {
-	if (!BIsNested())
-	{
-		return;
-	}
-
 	Atom target;
 	if (selectionTarget == CLIPBOARD)
 	{
@@ -4611,14 +4609,28 @@ void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int selectionT
 	XFlush(ctx->dpy);
 }
 
+void gamescope_set_selection(std::string contents, int selection)
+{
+	if (selection == CLIPBOARD)
+	{
+		clipboard = contents;
+	}
+	else if (selection == PRIMARYSELECTION)
+	{
+		primarySelection = contents;
+	}
+
+	for (int i = 0; i < g_nXWaylandCount; i++)
+	{
+		gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(i);
+		xwayland_ctx_t *ctx = server->ctx.get();
+		x11_set_selection(ctx, contents, selection);
+	}
+}
+
 static void
 handle_selection_request(xwayland_ctx_t *ctx, XSelectionRequestEvent *ev)
 {
-	if (!BIsNested())
-	{
-		return;
-	}
-
 	std::string *selection = ev->selection == ctx->atoms.primarySelection ? &primarySelection : &clipboard;
 
 	const char *targetString = XGetAtomName(ctx->dpy, ev->target);
@@ -4654,6 +4666,7 @@ handle_selection_request(xwayland_ctx_t *ctx, XSelectionRequestEvent *ev)
 		!strcmp(targetString, "UTF8_STRING") ||
 		!strcmp(targetString, "STRING"))
 	{
+
 		XChangeProperty(ctx->dpy, ev->requestor, ev->property, ev->target, 8, PropModeReplace,
 				(unsigned char *)selection->c_str(), selection->length());
 		response.xselection.property = ev->property;
@@ -4671,10 +4684,7 @@ handle_selection_request(xwayland_ctx_t *ctx, XSelectionRequestEvent *ev)
 static void
 handle_selection_notify(xwayland_ctx_t *ctx, XSelectionEvent *ev)
 {
-	if (!BIsNested())
-	{
-		return;
-	}
+	int selection;
 
 	Atom actual_type;
 	int actual_format;
@@ -4693,14 +4703,36 @@ handle_selection_notify(xwayland_ctx_t *ctx, XSelectionEvent *ev)
 				&actual_type, &actual_format, &nitems, &bytes_after, &data);
 		if (data) {
 			const char *contents = (const char *) data;
+
 			if (ev->selection == ctx->atoms.clipboard)
 			{
-				sdlwindow_set_selection(contents, CLIPBOARD);
+				selection = CLIPBOARD;
 			}
 			else if (ev->selection == ctx->atoms.primarySelection)
 			{
-				sdlwindow_set_selection(contents, PRIMARYSELECTION);
+				selection = PRIMARYSELECTION;
 			}
+			else
+			{
+				xwm_log.errorf( "Selection '%s' not supported.  Ignoring", XGetAtomName(ctx->dpy, ev->selection) );
+				goto done;
+			}
+
+			if (BIsNested())
+			{
+				/*
+				 * gamescope_set_selection() doesn't need to be called here.
+				 * sdlwindow_set_selection triggers a clipboard update, which
+				 * then indirectly ccalls gamescope_set_selection()
+				*/
+				sdlwindow_set_selection(contents, selection);
+			}
+			else
+			{
+				gamescope_set_selection(contents, selection);
+			}
+
+done:
 			XFree(data);
 		}
 	}
@@ -6101,6 +6133,11 @@ spawn_client( char **argv )
 static void
 handle_xfixes_selection_notify( xwayland_ctx_t *ctx, XFixesSelectionNotifyEvent *event )
 {
+	if (event->owner == ctx->ourWindow)
+	{
+		return;
+	}
+
 	XConvertSelection(ctx->dpy, event->selection, ctx->atoms.utf8StringAtom, event->selection, ctx->ourWindow, CurrentTime);
 	XFlush(ctx->dpy);
 }

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4587,7 +4587,7 @@ handle_client_message(xwayland_ctx_t *ctx, XClientMessageEvent *ev)
 	}
 }
 
-static void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int selectionTarget)
+static void x11_set_selection_owner(xwayland_ctx_t *ctx, std::string contents, int selectionTarget)
 {
 	Atom target;
 	if (selectionTarget == CLIPBOARD)
@@ -4604,9 +4604,6 @@ static void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int sel
 	}
 
 	XSetSelectionOwner(ctx->dpy, target, ctx->ourWindow, CurrentTime);
-	XChangeProperty(ctx->dpy, ctx->ourWindow, target, ctx->atoms.utf8StringAtom, 8, PropModeReplace,
-			(unsigned char *)contents.c_str(), contents.length());
-	XFlush(ctx->dpy);
 }
 
 void gamescope_set_selection(std::string contents, int selection)
@@ -4620,11 +4617,10 @@ void gamescope_set_selection(std::string contents, int selection)
 		primarySelection = contents;
 	}
 
-	for (int i = 0; i < g_nXWaylandCount; i++)
+	gamescope_xwayland_server_t *server = NULL;
+	for (int i = 0; (server = wlserver_get_xwayland_server(i)); i++)
 	{
-		gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(i);
-		xwayland_ctx_t *ctx = server->ctx.get();
-		x11_set_selection(ctx, contents, selection);
+		x11_set_selection_owner(server->ctx.get(), contents, selection);
 	}
 }
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -29,7 +29,10 @@
  *   says above. Not that I can really do anything about it
  */
 
+#include "xwayland_ctx.hpp"
+#include <X11/X.h>
 #include <X11/Xlib.h>
+#include <X11/extensions/xfixeswire.h>
 #include <cstdint>
 #include <drm_mode.h>
 #include <memory>
@@ -4581,6 +4584,127 @@ handle_client_message(xwayland_ctx_t *ctx, XClientMessageEvent *ev)
 	}
 }
 
+void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int selectionTarget)
+{
+	if (!BIsNested())
+	{
+		return;
+	}
+
+	Atom target;
+	if (selectionTarget == CLIPBOARD)
+	{
+		target = ctx->atoms.clipboard;
+	}
+	else if (selectionTarget == PRIMARYSELECTION)
+	{
+		target = ctx->atoms.primarySelection;
+	}
+	else
+	{
+		return;
+	}
+
+	XSetSelectionOwner(ctx->dpy, target, ctx->ourWindow, CurrentTime);
+	XChangeProperty(ctx->dpy, ctx->ourWindow, target, ctx->atoms.utf8StringAtom, 8, PropModeReplace,
+			(unsigned char *)contents.c_str(), contents.length());
+	XFlush(ctx->dpy);
+}
+
+static void
+handle_selection_request(xwayland_ctx_t *ctx, XSelectionRequestEvent *ev)
+{
+	if (!BIsNested())
+	{
+		return;
+	}
+
+	std::string *selection = ev->selection == ctx->atoms.primarySelection ? &primarySelection : &clipboard;
+
+	const char *targetString = XGetAtomName(ctx->dpy, ev->target);
+
+	XEvent response;
+	response.xselection.type = SelectionNotify;
+	response.xselection.selection = ev->selection;
+	response.xselection.requestor = ev->requestor;
+	response.xselection.time = ev->time;
+	response.xselection.property = None;
+	response.xselection.target = None;
+
+	if (ev->requestor == ctx->ourWindow)
+	{
+		return;
+	}
+
+	if (ev->target == ctx->atoms.targets)
+	{
+		Atom targetList[] = {
+			ctx->atoms.targets,
+			XA_STRING,
+		};
+
+		XChangeProperty(ctx->dpy, ev->requestor, ev->property, XA_ATOM, 32, PropModeReplace,
+				(unsigned char *)&targetList, 2);
+		response.xselection.property = ev->property;
+		response.xselection.target = ev->target;
+	}
+	else if (!strcmp(targetString, "text/plain;charset=utf-8") ||
+		!strcmp(targetString, "text/plain") ||
+		!strcmp(targetString, "TEXT") ||
+		!strcmp(targetString, "UTF8_STRING") ||
+		!strcmp(targetString, "STRING"))
+	{
+		XChangeProperty(ctx->dpy, ev->requestor, ev->property, ev->target, 8, PropModeReplace,
+				(unsigned char *)selection->c_str(), selection->length());
+		response.xselection.property = ev->property;
+		response.xselection.target = ev->target;
+	}
+	else
+	{
+		xwm_log.debugf("Unsupported clipboard type: %s.  Ignoring", targetString);
+	}
+
+	XSendEvent(ctx->dpy, ev->requestor, False, NoEventMask, &response);
+	XFlush(ctx->dpy);
+}
+
+static void
+handle_selection_notify(xwayland_ctx_t *ctx, XSelectionEvent *ev)
+{
+	if (!BIsNested())
+	{
+		return;
+	}
+
+	Atom actual_type;
+	int actual_format;
+	unsigned long nitems;
+	unsigned long bytes_after;
+	unsigned char *data = NULL;
+
+	XGetWindowProperty(ctx->dpy, ev->requestor, ev->property, 0, 0, False, AnyPropertyType,
+			&actual_type, &actual_format, &nitems, &bytes_after, &data);
+	if (data) {
+		XFree(data);
+	}
+
+	if (actual_type == ctx->atoms.utf8StringAtom && actual_format == 8) {
+		XGetWindowProperty(ctx->dpy, ev->requestor, ev->property, 0, bytes_after, False, AnyPropertyType,
+				&actual_type, &actual_format, &nitems, &bytes_after, &data);
+		if (data) {
+			const char *contents = (const char *) data;
+			if (ev->selection == ctx->atoms.clipboard)
+			{
+				sdlwindow_set_selection(contents, CLIPBOARD);
+			}
+			else if (ev->selection == ctx->atoms.primarySelection)
+			{
+				sdlwindow_set_selection(contents, PRIMARYSELECTION);
+			}
+			XFree(data);
+		}
+	}
+}
 
 template<typename T, typename J>
 T bit_cast(const J& src) {
@@ -5975,6 +6099,13 @@ spawn_client( char **argv )
 }
 
 static void
+handle_xfixes_selection_notify( xwayland_ctx_t *ctx, XFixesSelectionNotifyEvent *event )
+{
+	XConvertSelection(ctx->dpy, event->selection, ctx->atoms.utf8StringAtom, event->selection, ctx->ourWindow, CurrentTime);
+	XFlush(ctx->dpy);
+}
+
+static void
 dispatch_x11( xwayland_ctx_t *ctx )
 {
 	MouseCursor *cursor = ctx->cursor.get();
@@ -6113,6 +6244,12 @@ dispatch_x11( xwayland_ctx_t *ctx )
 					bShouldResetCursor = true;
 				}
 				break;
+			case SelectionNotify:
+				handle_selection_notify(ctx, &ev.xselection);
+				break;
+			case SelectionRequest:
+				handle_selection_request(ctx, &ev.xselectionrequest);
+				break;
 			default:
 				if (ev.type == ctx->damage_event + XDamageNotify)
 				{
@@ -6121,6 +6258,10 @@ dispatch_x11( xwayland_ctx_t *ctx )
 				else if (ev.type == ctx->xfixes_event + XFixesCursorNotify)
 				{
 					cursor->setDirty();
+				}
+				else if (ev.type == ctx->xfixes_event + XFixesSelectionNotify)
+				{
+					handle_xfixes_selection_notify(ctx, (XFixesSelectionNotifyEvent *) &ev);
 				}
 				break;
 		}
@@ -6491,6 +6632,10 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 	ctx->atoms.wineHwndStyle = XInternAtom( ctx->dpy, "_WINE_HWND_STYLE", false );
 	ctx->atoms.wineHwndStyleEx = XInternAtom( ctx->dpy, "_WINE_HWND_EXSTYLE", false );
 
+	ctx->atoms.clipboard = XInternAtom(ctx->dpy, "CLIPBOARD", false);
+	ctx->atoms.primarySelection = XInternAtom(ctx->dpy, "PRIMARY", false);
+	ctx->atoms.targets = XInternAtom(ctx->dpy, "TARGETS", false);
+
 	ctx->root_width = DisplayWidth(ctx->dpy, ctx->scr);
 	ctx->root_height = DisplayHeight(ctx->dpy, ctx->scr);
 
@@ -6519,6 +6664,8 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 				  PropertyChangeMask);
 	XShapeSelectInput(ctx->dpy, ctx->root, ShapeNotifyMask);
 	XFixesSelectCursorInput(ctx->dpy, ctx->root, XFixesDisplayCursorNotifyMask);
+	XFixesSelectSelectionInput(ctx->dpy, ctx->root, ctx->atoms.clipboard, XFixesSetSelectionOwnerNotifyMask);
+	XFixesSelectSelectionInput(ctx->dpy, ctx->root, ctx->atoms.primarySelection, XFixesSetSelectionOwnerNotifyMask);
 	XQueryTree(ctx->dpy, ctx->root, &root_return, &parent_return, &children, &nchildren);
 	for (uint32_t i = 0; i < nchildren; i++)
 		add_win(ctx, children[i], i ? children[i-1] : None, 0);

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -141,6 +141,6 @@ extern uint64_t g_SteamCompMgrVBlankTime;
 extern pid_t focusWindow_pid;
 
 void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_server);
-void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int selectionTarget);
+void gamescope_set_selection(std::string contents, int selection);
 
 extern int g_nAsyncFlipsEnabled;

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -141,5 +141,6 @@ extern uint64_t g_SteamCompMgrVBlankTime;
 extern pid_t focusWindow_pid;
 
 void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_server);
+void x11_set_selection(xwayland_ctx_t *ctx, std::string contents, int selectionTarget);
 
 extern int g_nAsyncFlipsEnabled;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -48,6 +48,7 @@ extern "C" {
 #include "log.hpp"
 #include "ime.hpp"
 #include "xwayland_ctx.hpp"
+#include "sdlwindow.hpp"
 
 #if HAVE_PIPEWIRE
 #include "pipewire.hpp"

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -207,5 +207,9 @@ struct xwayland_ctx_t
 
 		Atom wineHwndStyle;
 		Atom wineHwndStyleEx;
+
+		Atom clipboard;
+		Atom primarySelection;
+		Atom targets;
 	} atoms;
 };


### PR DESCRIPTION
Tested with `gamescope gvim`.  This PR adds support for copying/pasting utf-8 text for both the clipboard and the primary selection.  In the event that SDL_CLIPBOARDUPDATE doesn't get triggered (for example, when running gamescope as XWayland under sway), I've implemented the keybinding `Super + C` to sync both the clipboard and primary selection with gamescope.  As of now, this PR only supports Xwayland application windows under gamescope.  I don't have much experience with Xlib, so any feedback is appreciated.

Closes #303