### PR TITLE
Fix compilation with GCC13

### DIFF
--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -93,6 +93,7 @@ extern "C" {
 #include <unordered_map>
 #include <mutex>
 #include <vector>
+#include <string>
 
 struct saved_mode {
 	int width;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <vector>
 #include <cstring>
+#include <string>
 #if defined(__linux__)
 #include <sys/capability.h>
 #endif

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -2,6 +2,7 @@
 
 #include <thread>
 #include <mutex>
+#include <string>
 
 #include <linux/input-event-codes.h>
 


### PR DESCRIPTION
Tested for 3.11.51 only, but should also apply to master.
Fixes:
```
[34/45] c++ -Igamescope.p -I. -I.. -Iprotocol -I/usr/include/libdrm -I/usr/include/SDL2 -I/usr/include/pixman-1 -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/stb -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++14 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-unused-const-variable -DHAVE_PIPEWIRE=1 '-DHWDATA_PNP_IDS="//usr/share/hwdata/pnp.ids"' -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -D_REENTRANT -pthread -MD -MQ gamescope.p/src_drm.cpp.o -MF gamescope.p/src_drm.cpp.o.d -o gamescope.p/src_drm.cpp.o -c ../src/drm.cpp
FAILED: gamescope.p/src_drm.cpp.o 
c++ -Igamescope.p -I. -I.. -Iprotocol -I/usr/include/libdrm -I/usr/include/SDL2 -I/usr/include/pixman-1 -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/stb -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++14 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-unused-const-variable -DHAVE_PIPEWIRE=1 '-DHWDATA_PNP_IDS="//usr/share/hwdata/pnp.ids"' -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -D_REENTRANT -pthread -MD -MQ gamescope.p/src_drm.cpp.o -MF gamescope.p/src_drm.cpp.o.d -o gamescope.p/src_drm.cpp.o -c ../src/drm.cpp
../src/drm.cpp:35:23: error: use of deleted function ‘std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map() [with _Key = std::__cxx11::basic_string<char>; _Tp = int; _Hash = std::hash<std::__cxx11::basic_string<char> >; _Pred = std::equal_to<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, int> >]’
   35 | struct drm_t g_DRM = {};
      |                       ^
In file included from /usr/include/c++/13/unordered_map:41,
                 from ../src/rendervulkan.hpp:50,
                 from ../src/drm.hpp:41,
                 from ../src/drm.cpp:21:
[very lengthy C++ error message for not including <string>]

[36/45] c++ -Igamescope.p -I. -I.. -Iprotocol -I/usr/include/libdrm -I/usr/include/SDL2 -I/usr/include/pixman-1 -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/stb -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++14 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-unused-const-variable -DHAVE_PIPEWIRE=1 '-DHWDATA_PNP_IDS="//usr/share/hwdata/pnp.ids"' -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -D_REENTRANT -pthread -MD -MQ gamescope.p/src_sdlwindow.cpp.o -MF gamescope.p/src_sdlwindow.cpp.o.d -o gamescope.p/src_sdlwindow.cpp.o -c ../src/sdlwindow.cpp
FAILED: gamescope.p/src_sdlwindow.cpp.o 
c++ -Igamescope.p -I. -I.. -Iprotocol -I/usr/include/libdrm -I/usr/include/SDL2 -I/usr/include/pixman-1 -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/stb -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++14 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-unused-const-variable -DHAVE_PIPEWIRE=1 '-DHWDATA_PNP_IDS="//usr/share/hwdata/pnp.ids"' -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -D_REENTRANT -pthread -MD -MQ gamescope.p/src_sdlwindow.cpp.o -MF gamescope.p/src_sdlwindow.cpp.o.d -o gamescope.p/src_sdlwindow.cpp.o -c ../src/sdlwindow.cpp
../src/sdlwindow.cpp:31:20: error: aggregate ‘std::string g_SDLWindowTitle’ has incomplete type and cannot be defined
   31 | static std::string g_SDLWindowTitle;
      |                    ^~~~~~~~~~~~~~~~

[38/45] c++ -Igamescope.p -I. -I.. -Iprotocol -I/usr/include/libdrm -I/usr/include/SDL2 -I/usr/include/pixman-1 -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/stb -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++14 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-unused-const-variable -DHAVE_PIPEWIRE=1 '-DHWDATA_PNP_IDS="//usr/share/hwdata/pnp.ids"' -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -D_REENTRANT -pthread -MD -MQ gamescope.p/src_main.cpp.o -MF gamescope.p/src_main.cpp.o.d -o gamescope.p/src_main.cpp.o -c ../src/main.cpp
FAILED: gamescope.p/src_main.cpp.o 
c++ -Igamescope.p -I. -I.. -Iprotocol -I/usr/include/libdrm -I/usr/include/SDL2 -I/usr/include/pixman-1 -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/stb -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++14 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-unused-const-variable -DHAVE_PIPEWIRE=1 '-DHWDATA_PNP_IDS="//usr/share/hwdata/pnp.ids"' -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -D_REENTRANT -pthread -MD -MQ gamescope.p/src_main.cpp.o -MF gamescope.p/src_main.cpp.o.d -o gamescope.p/src_main.cpp.o -c ../src/main.cpp
../src/main.cpp:197:64: error: return type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’} is incomplete
  197 | static std::string build_optstring(const struct option *options)
      |                                                                ^
../src/main.cpp: In function ‘void build_optstring(const option*)’:
../src/main.cpp:199:21: error: aggregate ‘std::string optstring’ has incomplete type and cannot be defined
  199 |         std::string optstring;
      |                     ^~~~~~~~~
[less lengthy C++ error message for not including <string>]

```
See also https://bugs.debian.org/1037668