### PR TITLE
Add configurable mouse sensitivity

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "rt", no_argument, nullptr, 0 },
 	{ "prefer-vk-device", required_argument, 0 },
 	{ "expose-wayland", no_argument, 0 },
+	{ "mouse-sensitivity", required_argument, nullptr, 's' },
 
 	{ "headless", no_argument, 0 },
 
@@ -154,6 +155,7 @@ const char usage[] =
 	"                                     nis => NVIDIA Image Scaling v1.0.3\n"
 	"  --sharpness, --fsr-sharpness   upscaler sharpness from 0 (max) to 20 (min)\n"
 	"  --expose-wayland               support wayland clients using xdg-shell\n"
+	"  -s, --mouse-sensitivity        multiply mouse movement by given decimal number\n"
 	"  --headless                     use headless backend (no window, no DRM output)\n"
 	"  --cursor                       path to default cursor image\n"
 	"  -R, --ready-fd                 notify FD when ready\n"
@@ -258,6 +260,8 @@ bool g_bIsNested = false;
 bool g_bHeadless = false;
 
 bool g_bGrabbed = false;
+
+float g_mouseSensitivity = 1.0;
 
 GamescopeUpscaleFilter g_upscaleFilter = GamescopeUpscaleFilter::LINEAR;
 GamescopeUpscaleScaler g_upscaleScaler = GamescopeUpscaleScaler::AUTO;
@@ -581,6 +585,9 @@ int main(int argc, char **argv)
 				break;
 			case 'g':
 				g_bGrabbed = true;
+				break;
+			case 's':
+				g_mouseSensitivity = atof( optarg );
 				break;
 			case 0: // long options without a short option
 				opt_name = gamescope_options[opt_index].name;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -23,6 +23,8 @@ extern bool g_bFullscreen;
 
 extern bool g_bGrabbed;
 
+extern float g_mouseSensitivity;
+
 enum class GamescopeUpscaleFilter : uint32_t
 {
     LINEAR = 0,

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -261,6 +261,9 @@ static void wlserver_perform_rel_pointer_motion(double unaccel_dx, double unacce
 	auto server = steamcompmgr_get_focused_server();
 	if ( server != NULL )
 	{
+		unaccel_dx *= g_mouseSensitivity;
+		unaccel_dy *= g_mouseSensitivity;
+
 		server->ctx->accum_x += unaccel_dx;
 		server->ctx->accum_y += unaccel_dy;
 
@@ -1674,15 +1677,7 @@ void wlserver_mousefocus( struct wlr_surface *wlrsurface, int x /* = 0 */, int y
 
 void wlserver_mousemotion( int x, int y, uint32_t time )
 {
-	assert( wlserver_is_lock_held() );
-
-	// TODO: Pick the xwayland_server with active focus
-	auto server = steamcompmgr_get_focused_server();
-	if ( server != NULL )
-	{
-		XTestFakeRelativeMotionEvent( server->get_xdisplay(), x, y, CurrentTime );
-		XFlush( server->get_xdisplay() );
-	}
+	wlserver_perform_rel_pointer_motion( x, y );
 }
 
 void wlserver_mousewarp( int x, int y, uint32_t time )


### PR DESCRIPTION
The `--mouse-sensitivity`/`-s` command line option allows the user to set the value `g_mouseSensitivity` which is used to scale the mouse movement in `wlserver_mousemotion`.

This works well for reducing sensitivity: sub-pixel increments taken into account to avoid jerky cursor movement as a result of rounding.

However, increasing sensitivity results in a loss of precision proportional to the multiplier since it seems mouse movements are only ever given in terms of pixels (i.e. a multiplier of `2.0` causes 2 pixels to be the shortest distance the cursor can be moved. If there is a way to get around this, please let me know).

This change is a possible workaround for #196 and #244, but the main motivation is to allow forcing mouse sensitivity scaling on games that don't respect the host mouse settings or otherwise misbehave with respect to cursor speed.