### PR TITLE
Consume KeyDown event when the user is activating a shortcut

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -216,6 +216,18 @@ void inputSDLThreadRun( void )
 				wlserver_unlock();
 				break;
 			case SDL_KEYDOWN:
+				// If this keydown event is super + one of the shortcut keys, consume the keydown event, since the corresponding keyup
+				// event will be consumed by the next case statement when the user releases the key
+				if ( event.key.keysym.mod & KMOD_LGUI )
+				{
+					key = SDLScancodeToLinuxKey( event.key.keysym.scancode );
+					const uint32_t shortcutKeys[] = {KEY_F, KEY_N, KEY_B, KEY_U, KEY_Y, KEY_I, KEY_O, KEY_S, KEY_G};
+					const bool isShortcutKey = std::find(std::begin(shortcutKeys), std::end(shortcutKeys), key) != std::end(shortcutKeys);
+					if ( isShortcutKey )
+					{
+						break;
+					}
+				}
 			case SDL_KEYUP:
 				key = SDLScancodeToLinuxKey( event.key.keysym.scancode );
 


### PR DESCRIPTION
Normally when the user activates a shortcut like Super+S, gamescope will pass through the keydown event for Super+S to the game. However, when the key is released, gamescope consumes the keyup event, making it so the game doesn't realize that the key was released and just keeps it held down.

This issue is pretty old (#577 was created in 8/2022 and this issue was mentioned in #335 in 12/2021). This issue would've been fixed (mostly as a side effect) in the aforementioned pull request #335 but a collaborator mentioned that they'd rather just handle this issue the right way and make shortcuts fully configurable rather than include the option to disable them (like in #335) or fix the "key getting stuck" issue (my fix). While I agree that that would be a better solution, I would really appreciate it if the current maintainers would consider merging this as this issue was been pretty frustrating to me and likely many other users for years now. 

I'm also an amateur C++ programmer, so I'm open to any suggestions or changes if the way I wrote the fix isn't optimal.