### PR TITLE
Remove reference to non-existent key bind

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,6 @@ const char usage[] =
 	"  Super + O                      decrease FSR sharpness by 1\n"
 	"  Super + S                      take a screenshot\n"
 	"  Super + G                      toggle keyboard grab\n"
-	"  Super + C                      update clipboard\n"
 	"";
 
 std::atomic< bool > g_bRun{true};


### PR DESCRIPTION
Looks like this was missed by e631460bc5a1ce53af994cf7f0c9f9e96325a298