### PR TITLE
rendervulkan: ensure queue is idle before swapchain recreation

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -488,6 +488,7 @@ private:
 	VK_FUNC(MapMemory) \
 	VK_FUNC(QueuePresentKHR) \
 	VK_FUNC(QueueSubmit) \
+	VK_FUNC(QueueWaitIdle) \
 	VK_FUNC(ResetCommandBuffer) \
 	VK_FUNC(ResetFences) \
 	VK_FUNC(UnmapMemory) \
@@ -2988,7 +2989,7 @@ bool vulkan_make_swapchain( VulkanOutput_t *pOutput )
 bool vulkan_remake_swapchain( void )
 {
 	VulkanOutput_t *pOutput = &g_output;
-	g_device.waitIdle();
+	g_device.vk.QueueWaitIdle( g_device.queue() );
 
 	pOutput->outputImages.clear();
 


### PR DESCRIPTION
The CVulkanDevice::waitIdle call at the beginning of vulkan_remake_swapchain only waits for the most recently submitted command buffer to complete. This is inadequate because it does not wait for any additional commands which may have been submitted by the driver during vkQueuePresentKHR.  Such commands could reference resources associated with the old swapchain, so it is not safe to destroy it until they are also complete.

To fix the issue, instead of calling CVulkanDevice::waitIdle, vulkan_remake_swapchain will call vkQueueWaitIdle.

Fixes: #945