### PR TITLE
rendervulkan: Add PIXEL filter (band-limited pixel filter)

### DIFF
--- a/protocol/gamescope-control.xml
+++ b/protocol/gamescope-control.xml
@@ -39,6 +39,7 @@
       <entry name="done" value="0" summary="sent at the end of the feature list"/>
       <entry name="reshade_shaders" value="1"/>
       <entry name="display_info" value="2"/>
+      <entry name="pixel_filter" value="3"/>
     </enum>
 
     <event name="feature_support">

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,7 +149,7 @@ const char usage[] =
 	"  -r, --nested-refresh           game refresh rate (frames per second)\n"
 	"  -m, --max-scale                maximum scale factor\n"
 	"  -S, --scaler                   upscaler type (auto, integer, fit, fill, stretch)\n"
-	"  -F, --filter                   upscaler filter (linear, nearest, fsr, nis)\n"
+	"  -F, --filter                   upscaler filter (linear, nearest, fsr, nis, pixel)\n"
 	"                                     fsr => AMD FidelityFX™ Super Resolution 1.0\n"
 	"                                     nis => NVIDIA Image Scaling v1.0.3\n"
 	"  --sharpness, --fsr-sharpness   upscaler sharpness from 0 (max) to 20 (min)\n"
@@ -391,6 +391,8 @@ static enum GamescopeUpscaleFilter parse_upscaler_filter(const char *str)
 		return GamescopeUpscaleFilter::FSR;
 	} else if (strcmp(str, "nis") == 0) {
 		return GamescopeUpscaleFilter::NIS;
+	} else if (strcmp(str, "pixel") == 0) {
+		return GamescopeUpscaleFilter::PIXEL;
 	} else {
 		fprintf( stderr, "gamescope: invalid value for --filter\n" );
 		exit(1);

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -29,6 +29,7 @@ enum class GamescopeUpscaleFilter : uint32_t
     NEAREST,
     FSR,
     NIS,
+    PIXEL,
 
     FROM_VIEW = 255, // internal
 };

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -28,7 +28,9 @@ enum class GamescopeUpscaleFilter : uint32_t
     LINEAR = 0,
     NEAREST,
     FSR,
-    NIS
+    NIS,
+
+    FROM_VIEW = 255, // internal
 };
 
 enum class GamescopeUpscaleScaler : uint32_t

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3319,7 +3319,10 @@ void bind_all_layers(CVulkanCmdBuffer* cmdBuffer, const struct FrameInfo_t *fram
 	{
 		const FrameInfo_t::Layer_t *layer = &frameInfo->layers[i];
 
-		bool nearest = layer->isScreenSize() || layer->filter == GamescopeUpscaleFilter::NEAREST || (layer->filter == GamescopeUpscaleFilter::LINEAR && !layer->viewConvertsToLinearAutomatically());
+		bool nearest = layer->isScreenSize()
+                    || layer->filter == GamescopeUpscaleFilter::NEAREST
+                    || (layer->filter == GamescopeUpscaleFilter::LINEAR && !layer->viewConvertsToLinearAutomatically());
+
 		cmdBuffer->bindTexture(i, layer->tex);
 		cmdBuffer->setTextureSrgb(i, false);
 		cmdBuffer->setSamplerNearest(i, nearest);

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -246,7 +246,12 @@ struct vec2_t
 
 static inline bool float_is_integer(float x)
 {
-	return fabsf(ceilf(x) - x) <= 0.0001f;
+	return fabsf(ceilf(x) - x) <= 0.001f;
+}
+
+inline bool close_enough(float a, float b, float epsilon = 0.001f)
+{
+	return fabsf(a - b) <= epsilon;
 }
 
 struct FrameInfo_t
@@ -290,8 +295,8 @@ struct FrameInfo_t
 		}
 
 		bool isScreenSize() const {
-			return scale.x >= 0.99f && scale.x <= 1.01f &&
-				scale.y >= 0.99f && scale.y <= 1.01f &&
+			return close_enough(scale.x, 1.0f) &&
+			       close_enough(scale.y, 1.0f) &&
 				float_is_integer(offset.x) &&
 				float_is_integer(offset.y);
 		}

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -266,7 +266,7 @@ void inputSDLThreadRun( void )
 							SDL_SetWindowFullscreen( g_SDLWindow, g_bFullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0 );
 							break;
 						case KEY_N:
-							g_wantedUpscaleFilter = GamescopeUpscaleFilter::NEAREST;
+							g_wantedUpscaleFilter = GamescopeUpscaleFilter::PIXEL;
 							break;
 						case KEY_B:
 							g_wantedUpscaleFilter = GamescopeUpscaleFilter::LINEAR;

--- a/src/shaders/blit_push_data.h
+++ b/src/shaders/blit_push_data.h
@@ -7,6 +7,9 @@ uniform layers_t {
     uint u_frameId;
     uint u_blur_radius;
 
+    uint8_t u_shaderFilter[VKR_MAX_LAYERS];
+    uint8_t u_padding[2];
+
     // hdr
     float u_linearToNits; // sdr -> hdr
     float u_nitsToLinear; // hdr -> sdr

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -1,5 +1,45 @@
 #include "colorimetry.h"
 
+vec4 sampleRegular(sampler2D tex, vec2 coord, uint colorspace) {
+    vec4 color = textureLod(tex, coord, 0);
+    color.rgb = colorspace_plane_degamma_tf(color.rgb, colorspace);
+    return color;
+}
+
+// To be considered pseudo-bandlimited, upscaling factor must be at least 2x.
+
+const float bandlimited_PI = 3.14159265359;
+const float bandlimited_PI_half = 0.5 * bandlimited_PI;
+// size: resolution of sampled texture
+// inv_size: inverse resolution of sampled texture
+// extent: Screen-space gradient of UV in texels. Typically computed as (texture resolution) / (viewport resolution).
+//   If screen is rotated by 90 or 270 degrees, the derivatives need to be computed appropriately.
+//   For uniform scaling, none of this matters.
+//   extent can be multiplied to achieve LOD bias.
+//   extent must be at least 1.0 / 256.0.
+vec4 sampleBandLimited(sampler2D samp, vec2 uv, vec2 size, vec2 inv_size, vec2 extent, uint colorspace, bool unnormalized)
+{
+    // Josh:
+    // Clamp to behaviour like 4x scale (0.25).
+    //
+    // Was defaulted to 2x before (0.5), which is 1px, but gives blurry result
+    // on Cave Story (480p) -> 800p on Deck.
+    // TODO: Maybe make this configurable?
+    const float max_extent = 0.25f;
+
+	// Get base pixel and phase, range [0, 1).
+	vec2 pixel = uv * (unnormalized ? vec2(1.0f) : size) - 0.5;
+	vec2 base_pixel = floor(pixel);
+	vec2 phase = pixel - base_pixel;
+
+	// We can resolve the filter by just sampling a single 2x2 block.
+	// Lerp between normal sampling at LOD 0, and bandlimited pixel filter at LOD -1.
+	vec2 shift = 0.5 + 0.5 * sin(bandlimited_PI_half * clamp((phase - 0.5) / min(extent, vec2(max_extent)), -1.0, 1.0));
+	uv = (base_pixel + 0.5 + shift) * (unnormalized ? vec2(1.0f) : inv_size);
+
+	return sampleRegular(samp, uv, colorspace);
+}
+
 uint pseudo_random(uint seed) {
     seed ^= (seed << 13);
     seed ^= (seed >> 17);
@@ -101,12 +141,6 @@ vec4 sampleBilinear(sampler2D tex, vec2 coord, uint colorspace, bool unnormalize
     return mix(temp1, temp0, filterWeight.y);
 }
 
-vec4 sampleRegular(sampler2D tex, vec2 coord, uint colorspace, bool unnormalized) {
-    vec4 color = textureLod(tex, coord, 0);
-    color.rgb = colorspace_plane_degamma_tf(color.rgb, colorspace);
-    return color;
-}
-
 vec4 sampleLayerEx(sampler2D layerSampler, uint offsetLayerIdx, uint colorspaceLayerIdx, vec2 uv, bool unnormalized) {
     vec2 coord = ((uv + u_offset[offsetLayerIdx]) * u_scale[offsetLayerIdx]);
     vec2 texSize = textureSize(layerSampler, 0);
@@ -126,10 +160,17 @@ vec4 sampleLayerEx(sampler2D layerSampler, uint offsetLayerIdx, uint colorspaceL
 
     uint colorspace = get_layer_colorspace(colorspaceLayerIdx);
     vec4 color;
-    if (u_shaderFilter[offsetLayerIdx] == filter_linear_emulated)
+    if (u_shaderFilter[offsetLayerIdx] == filter_pixel) {
+        vec2 output_res = texSize / u_scale[offsetLayerIdx];
+        vec2 extent = max((texSize / output_res), vec2(1.0 / 256.0));
+        color = sampleBandLimited(layerSampler, coord, unnormalized ? vec2(1.0f) : texSize, unnormalized ? vec2(1.0f) : vec2(1.0f) / texSize, extent, colorspace, unnormalized);
+    }
+    else if (u_shaderFilter[offsetLayerIdx] == filter_linear_emulated) {
         color = sampleBilinear(layerSampler, coord, colorspace, unnormalized);
-    else
-        color = sampleRegular(layerSampler, coord, colorspace, unnormalized);
+    }
+    else {
+        color = sampleRegular(layerSampler, coord, colorspace);
+    }
     color.rgb = apply_layer_color_mgmt(color.rgb, colorspace);
 
     return color;

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -71,6 +71,41 @@ vec3 apply_layer_color_mgmt(vec3 color, uint colorspace) {
     return color;
 }
 
+vec4 sampleBilinear(sampler2D tex, vec2 coord, uint colorspace, bool unnormalized) {
+    vec2 scale = unnormalized ? vec2(1.0) : vec2(textureSize(tex, 0));
+
+    vec2 pixCoord = coord * scale - 0.5f;
+    vec2 originPixCoord = floor(pixCoord);
+
+    vec2 gatherUV = (originPixCoord * scale + 1.0f) / scale;
+
+    vec4 red   = textureGather(tex, gatherUV, 0);
+    vec4 green = textureGather(tex, gatherUV, 1);
+    vec4 blue  = textureGather(tex, gatherUV, 2);
+    vec4 alpha = textureGather(tex, gatherUV, 3);
+
+    vec4 c00 = vec4(red.w, green.w, blue.w, alpha.w);
+    vec4 c01 = vec4(red.x, green.x, blue.x, alpha.x);
+    vec4 c11 = vec4(red.y, green.y, blue.y, alpha.y);
+    vec4 c10 = vec4(red.z, green.z, blue.z, alpha.z);
+
+    c00.rgb = colorspace_plane_degamma_tf(c00.rgb, colorspace);
+    c01.rgb = colorspace_plane_degamma_tf(c01.rgb, colorspace);
+    c11.rgb = colorspace_plane_degamma_tf(c11.rgb, colorspace);
+    c10.rgb = colorspace_plane_degamma_tf(c10.rgb, colorspace);
+
+    vec2 filterWeight = pixCoord - originPixCoord;
+
+    vec4 temp0 = mix(c01, c11, filterWeight.x);
+    vec4 temp1 = mix(c00, c10, filterWeight.x);
+    return mix(temp1, temp0, filterWeight.y);
+}
+
+vec4 sampleRegular(sampler2D tex, vec2 coord, uint colorspace, bool unnormalized) {
+    vec4 color = textureLod(tex, coord, 0);
+    color.rgb = colorspace_plane_degamma_tf(color.rgb, colorspace);
+    return color;
+}
 
 vec4 sampleLayerEx(sampler2D layerSampler, uint offsetLayerIdx, uint colorspaceLayerIdx, vec2 uv, bool unnormalized) {
     vec2 coord = ((uv + u_offset[offsetLayerIdx]) * u_scale[offsetLayerIdx]);
@@ -89,13 +124,12 @@ vec4 sampleLayerEx(sampler2D layerSampler, uint offsetLayerIdx, uint colorspaceL
     if (!unnormalized)
         coord /= texSize;
 
-    vec4 color = textureLod(layerSampler, coord, 0.0f);
-
-    // TODO(Josh): If colorspace != linear, emulate bilinear ourselves to blend
-    // in linear space!
-    // Split this into two parts!
     uint colorspace = get_layer_colorspace(colorspaceLayerIdx);
-    color.rgb = colorspace_plane_degamma_tf(color.rgb, colorspace);
+    vec4 color;
+    if (u_shaderFilter[offsetLayerIdx] == filter_linear_emulated)
+        color = sampleBilinear(layerSampler, coord, colorspace, unnormalized);
+    else
+        color = sampleRegular(layerSampler, coord, colorspace, unnormalized);
     color.rgb = apply_layer_color_mgmt(color.rgb, colorspace);
 
     return color;

--- a/src/shaders/cs_composite_blit.comp
+++ b/src/shaders/cs_composite_blit.comp
@@ -1,6 +1,7 @@
 #version 450
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 

--- a/src/shaders/cs_composite_blur.comp
+++ b/src/shaders/cs_composite_blur.comp
@@ -1,6 +1,7 @@
 #version 450
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 

--- a/src/shaders/cs_composite_blur_cond.comp
+++ b/src/shaders/cs_composite_blur_cond.comp
@@ -1,6 +1,7 @@
 #version 450
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 

--- a/src/shaders/cs_composite_rcas.comp
+++ b/src/shaders/cs_composite_rcas.comp
@@ -1,6 +1,7 @@
 #version 460
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 
@@ -18,6 +19,9 @@ uniform layers_t {
     uint u_borderMask;
     uint u_frameId;
     uint u_c1;
+
+	uint8_t u_shaderFilter[VKR_MAX_LAYERS];
+    uint8_t u_padding[2];
 
     // hdr
     float u_linearToNits;

--- a/src/shaders/cs_easu.comp
+++ b/src/shaders/cs_easu.comp
@@ -1,6 +1,7 @@
 #version 460
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 

--- a/src/shaders/cs_easu_fp16.comp
+++ b/src/shaders/cs_easu_fp16.comp
@@ -2,6 +2,7 @@
 
 #extension GL_GOOGLE_include_directive : require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 

--- a/src/shaders/cs_gaussian_blur_horizontal.comp
+++ b/src/shaders/cs_gaussian_blur_horizontal.comp
@@ -1,6 +1,7 @@
 #version 460
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 
@@ -17,6 +18,9 @@ uniform layers_t {
     uint u_borderMask;
     uint u_frameId;
     uint u_blur_radius;
+
+	uint8_t u_shaderFilter[VKR_MAX_LAYERS];
+    uint8_t u_padding[2];
 
     // hdr
     float u_linearToNits;

--- a/src/shaders/cs_nis.comp
+++ b/src/shaders/cs_nis.comp
@@ -1,6 +1,7 @@
 #version 450
 
 #extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #define NIS_GLSL 1
 #define NIS_SCALER 1

--- a/src/shaders/cs_nis_fp16.comp
+++ b/src/shaders/cs_nis_fp16.comp
@@ -2,6 +2,7 @@
 
 #extension GL_GOOGLE_include_directive : enable
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #define NIS_GLSL 1
 #define NIS_USE_HALF_PRECISION 1

--- a/src/shaders/cs_rgb_to_nv12.comp
+++ b/src/shaders/cs_rgb_to_nv12.comp
@@ -1,6 +1,7 @@
 #version 450
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #include "descriptor_set.h"
 
@@ -15,6 +16,7 @@ layout(
 // UVUVUVUVUVUVUVU...
 
 const uint u_frameId = 0;
+const uint8_t u_shaderFilter[VKR_MAX_LAYERS] = { uint8_t(0), uint8_t(0), uint8_t(0), uint8_t(0), uint8_t(0), uint8_t(0) };
 const float u_linearToNits = 400.0f;
 const float u_nitsToLinear = 1.0f / 100.0f;
 const float u_itmSdrNits = 100.f;

--- a/src/shaders/descriptor_set.h
+++ b/src/shaders/descriptor_set.h
@@ -20,6 +20,7 @@ const int filter_linear_emulated = 0;
 const int filter_nearest = 1;
 const int filter_fsr = 2;
 const int filter_nis = 3;
+const int filter_pixel = 4;
 const int filter_from_view = 255;
 
 const int EOTF_Gamma22 = 0;

--- a/src/shaders/descriptor_set.h
+++ b/src/shaders/descriptor_set.h
@@ -16,6 +16,12 @@ const int colorspace_pq = 3;
 const int colorspace_reserved = 3;
 const int colorspace_max_bits = 2;
 
+const int filter_linear_emulated = 0;
+const int filter_nearest = 1;
+const int filter_fsr = 2;
+const int filter_nis = 3;
+const int filter_from_view = 255;
+
 const int EOTF_Gamma22 = 0;
 const int EOTF_PQ = 1;
 const int EOTF_Count = 2;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -894,6 +894,7 @@ static void gamescope_control_bind( struct wl_client *client, void *data, uint32
 	// Send feature support
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_RESHADE_SHADERS, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_DISPLAY_INFO, 1, 0 );
+	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_PIXEL_FILTER, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_DONE, 0, 0 );
 
 	wlserver.gamescope_controls.push_back(resource);


### PR DESCRIPTION
Adds a "Sharp" filter which is a band-limited pixel filter based on
https://github.com/Themaister/Granite/blob/master/assets/shaders/inc/bandlimited_pixel_filter.h
by Hans-Kristian.

Also emulates bilinear sampling for HDR10 PQ content to blend in the right space.

Closes: https://github.com/ValveSoftware/gamescope/issues/712