### PR TITLE
Lock stb to last revision with stb_image_resize.h

### DIFF
--- a/subprojects/stb.wrap
+++ b/subprojects/stb.wrap
@@ -2,7 +2,7 @@
 directory = stb
 
 url = https://github.com/nothings/stb.git
-revision = master
+revision = 5736b15f7ea0ffb08dd38af21067c314d6a3aae9
 depth = 1
 
 patch_directory = stb


### PR DESCRIPTION
Newer revisions of nothings/stb have switched to stb_image_resize2.h and moved the original header to deprecated/stb_image_resize.h since [1]. Pin down the version to prevent future breaking changes.

[1]: https://github.com/nothings/stb/commit/c4bbb6e75f688318b2df2b70c2df2d641c1a8481