### PR TITLE
layer: Prefer C++11 `std::any_of` over '03 `std::find_if` style

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -22,8 +22,8 @@ using namespace std::literals;
 namespace GamescopeWSILayer {
 
   static bool contains(const std::vector<const char *> vec, std::string_view lookupValue) {
-    return std::find_if(vec.begin(), vec.end(),
-      [=](const char* value) { return value == lookupValue; }) != vec.end();
+    return std::any_of(vec.begin(), vec.end(),
+      [=](const char* value) { return value == lookupValue; });
   }
 
   // TODO: Maybe move to Wayland event or something.
@@ -605,11 +605,10 @@ namespace GamescopeWSILayer {
           pDispatch->PhysicalDevice,
           swapchainInfo.surface);
 
-        bool supportedSwapchainFormat = std::find_if(
+        bool supportedSwapchainFormat = std::any_of(
           supportedSurfaceFormats.begin(),
           supportedSurfaceFormats.end(),
-          [=](VkSurfaceFormatKHR value) { return value.format == swapchainInfo.imageFormat; })
-          != supportedSurfaceFormats.end();
+          [=](VkSurfaceFormatKHR value) { return value.format == swapchainInfo.imageFormat; });
 
         if (!supportedSwapchainFormat) {
           fprintf(stderr, "[Gamescope WSI] Refusing to make swapchain (unsupported VkFormat) for xid: 0x%0x - format: %s - colorspace: %s - flip: %s\n",


### PR DESCRIPTION
Hi there,
Minor refactor edit to use the C++11 library API `std::any_of` instead of its previous '03 idiom.
Let me know if these C++ modernisation refactors are ok, happy to send in some more if it helps! (But what C++ standard should one target by default?)
Thanks! :smile: 