### PR TITLE
layer: Prefer C++20 ranges::any_of over '11 style

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <vector>
 #include <algorithm>
+#include <functional>
 #include <unordered_map>
 #include <optional>
 
@@ -38,8 +39,7 @@ namespace GamescopeWSILayer {
   }
 
   static bool contains(const std::vector<const char *> vec, std::string_view lookupValue) {
-    return std::any_of(vec.begin(), vec.end(),
-      [=](const char* value) { return value == lookupValue; });
+    return std::ranges::any_of(vec, std::bind_front(std::equal_to{}, lookupValue));
   }
 
   static int waylandPumpEvents(wl_display *display) {
@@ -762,10 +762,10 @@ namespace GamescopeWSILayer {
           pDispatch->PhysicalDevice,
           swapchainInfo.surface);
 
-        bool supportedSwapchainFormat = std::any_of(
-          supportedSurfaceFormats.begin(),
-          supportedSurfaceFormats.end(),
-          [=](VkSurfaceFormatKHR value) { return value.format == swapchainInfo.imageFormat; });
+        bool supportedSwapchainFormat = std::ranges::any_of(
+          supportedSurfaceFormats,
+          std::bind_front(std::equal_to{}, swapchainInfo.imageFormat),
+          &VkSurfaceFormatKHR::format);
 
         if (!supportedSwapchainFormat) {
           fprintf(stderr, "[Gamescope WSI] Refusing to make swapchain (unsupported VkFormat) for xid: 0x%0x - format: %s - colorspace: %s - flip: %s\n",


### PR DESCRIPTION
Hi there!

After @Joshua-Ashton's [previous comment](https://github.com/ValveSoftware/gamescope/pull/989#issuecomment-1765193024) that the project is `C++20`, I have updated the [previous changeset merged](https://github.com/ValveSoftware/gamescope/pull/989) once more to reflect this, let me know what ya think!

Major pros for this `C++20` version:
* `.{begin,end}` member-functions unneeded! :tada: 
* **Very standardised**; instead of custom lambdas for a simple comparison, where one has to worry about datatype of elements to be scanned, reference capturing & prefect-forwarding concerns and blah blah blah, _**everything**_ can use the awesome C++ standardised approach, `std::bind_front`. :crown:
* **Scoping of comparator variable**; because one does not need use lambda syntax anymore as `std::bind_front`:crown: does all the boring concerns and _(forwarding)_ work for you -- for the simple `any_of()`, the comparator variable becomes very "shallow" _(in depth - in terms of scoping and also when reading the source-code)_!
* **Projections**; due to the slightly custom nature of accessing the `VkSurfaceFormatKHR`'s member-element needed to be compared, one can use `C++20`'s projections - as well as the awesome `std::bind_front`:crown: , to keep the needed callable for `any_of`, standardised and uniform.


`std::bind_front`:crown: is part of `<functional>` and that's why it is included.

Thanks and hope this helps! :smile: 

