### PR TITLE
Add --version and separate dependency installation into script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,7 @@ jobs:
         run: |
           pacman-key --init
           pacman -Syu --noconfirm
-          pacman -S --noconfirm git meson clang glslang libcap wlroots \
-            sdl2 vulkan-headers libx11 libxmu libxcomposite libxrender libxres \
-            libxtst libxkbcommon libdrm libinput wayland-protocols benchmark \
-            xorg-xwayland pipewire cmake
+          ./scripts/install_arch_deps.sh
       - uses: actions/checkout@v2
         with:
           submodules: recursive

--- a/meson.build
+++ b/meson.build
@@ -10,9 +10,6 @@ project(
   ],
 )
 
-version = run_command('git', 'describe', '--dirty', '--broken', check: true).stdout().strip()
-add_global_arguments('-DGAMESCOPE_VERSION="@0@"'.format(version), language : 'cpp')
-
 add_project_arguments([
   '-DWLR_USE_UNSTABLE',
 ], language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -10,13 +10,6 @@ project(
   ],
 )
 
-version_h = custom_target(
-    "gamescope_version.h",
-    output : "gamescope_version.h",
-    input: "scripts/generate_version_header.sh",
-    command : ['@INPUT@', '@OUTPUT@'],
-)
-
 add_project_arguments([
   '-DWLR_USE_UNSTABLE',
 ], language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,9 @@ project(
   ],
 )
 
+version = run_command('git', 'describe', '--dirty', '--broken', check: true).stdout().strip()
+add_global_arguments('-DGAMESCOPE_VERSION="@0@"'.format(version), language : 'cpp')
+
 add_project_arguments([
   '-DWLR_USE_UNSTABLE',
 ], language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,13 @@ project(
   ],
 )
 
+version_h = custom_target(
+    "gamescope_version.h",
+    output : "gamescope_version.h",
+    input: "scripts/generate_version_header.sh",
+    command : ['@INPUT@', '@OUTPUT@'],
+)
+
 add_project_arguments([
   '-DWLR_USE_UNSTABLE',
 ], language: 'cpp')

--- a/scripts/generate_version_header.sh
+++ b/scripts/generate_version_header.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-echo "in gamescope version script $1"
 export VERSION=`git describe --dirty --broken`
 echo "#define GAMESCOPE_VERSION \"$VERSION\"" > $1

--- a/scripts/generate_version_header.sh
+++ b/scripts/generate_version_header.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+echo "in gamescope version script $1"
 export VERSION=`git describe --dirty --broken`
-echo "#DEFINE VERSION "$VERSION > $1
+echo "#define GAMESCOPE_VERSION \"$VERSION\"" > $1

--- a/scripts/generate_version_header.sh
+++ b/scripts/generate_version_header.sh
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
-export VERSION=`git describe --dirty --broken`
+if [[ -z "${GAMESCOPE_VERSION}" ]]; then
+  if git status &>/dev/null; then
+      export VERSION=`git describe --dirty --broken`
+  else
+      export VERSION="Check your package manager for version"
+  fi
+else
+  export VERSION=${GAMESCOPE_VERSION}
+fi
 echo "#define GAMESCOPE_VERSION \"$VERSION\"" > $1

--- a/scripts/generate_version_header.sh
+++ b/scripts/generate_version_header.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export VERSION=`git describe --dirty --broken`
+echo "#DEFINE VERSION "$VERSION > $1

--- a/scripts/generate_version_header.sh
+++ b/scripts/generate_version_header.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 if [[ -z "${GAMESCOPE_VERSION}" ]]; then
   if git status &>/dev/null; then
       export VERSION=`git describe --dirty --broken`
   else
-      export VERSION="Check your package manager for version"
+      export VERSION="Check your package manager for the version"
   fi
 else
   export VERSION=${GAMESCOPE_VERSION}

--- a/scripts/install_arch_deps.sh
+++ b/scripts/install_arch_deps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+pacman -S --noconfirm git meson clang glslang libcap wlroots \
+  sdl2 vulkan-headers libx11 libxmu libxcomposite libxrender libxres \
+  libxtst libxkbcommon libdrm libinput wayland-protocols benchmark \
+  xorg-xwayland pipewire cmake

--- a/scripts/install_arch_deps.sh
+++ b/scripts/install_arch_deps.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 pacman -S --noconfirm git meson clang glslang libcap wlroots \
   sdl2 vulkan-headers libx11 libxmu libxcomposite libxrender libxres \
   libxtst libxkbcommon libdrm libinput wayland-protocols benchmark \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "sdlwindow.hpp"
 #include "wlserver.hpp"
 #include "gpuvis_trace_utils.h"
+#include "gamescope_version.h"
 
 #if HAVE_OPENVR
 #include "vr_session.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ const char *g_pOriginalWaylandDisplay = nullptr;
 
 const struct option *gamescope_options = (struct option[]){
 	{ "help", no_argument, nullptr, 0 },
+	{ "version", no_argument, nullptr, 0 },
 	{ "nested-width", required_argument, nullptr, 'w' },
 	{ "nested-height", required_argument, nullptr, 'h' },
 	{ "nested-refresh", required_argument, nullptr, 'r' },
@@ -142,6 +143,7 @@ const char usage[] =
 	"\n"
 	"Options:\n"
 	"  --help                         show help message\n"
+        "  --version                      prints the version\n"
 	"  -W, --output-width             output width\n"
 	"  -H, --output-height            output height\n"
 	"  -w, --nested-width             game width\n"
@@ -587,6 +589,9 @@ int main(int argc, char **argv)
 				opt_name = gamescope_options[opt_index].name;
 				if (strcmp(opt_name, "help") == 0) {
 					fprintf(stderr, "%s", usage);
+					return 0;
+				} else if (strcmp(opt_name, "version") == 0) {
+					fprintf(stdout, "%s\n", GAMESCOPE_VERSION);
 					return 0;
 				} else if (strcmp(opt_name, "disable-layers") == 0) {
 					g_bUseLayers = false;

--- a/src/meson.build
+++ b/src/meson.build
@@ -129,6 +129,7 @@ version_h = custom_target(
     output : 'gamescope_version.h',
     input: '../scripts/generate_version_header.sh',
     command : ['bash', '@INPUT@', '@OUTPUT@'],
+    build_always_stale: true,
     build_by_default: true,
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -124,6 +124,7 @@ if openvr_dep.found()
   src += 'vr_session.cpp'
 endif
 
+  version = run_command('git', 'describe', '--dirty', '--broken', check: true).stdout().strip()
   executable(
     'gamescope',
     src, reshade_src,
@@ -135,6 +136,7 @@ endif
       vulkan_dep, liftoff_dep, dep_xtst, dep_xmu, cap_dep, pipewire_dep, librt_dep,
       stb_dep, displayinfo_dep, openvr_dep,
     ],
+    cpp_args: '-DGAMESCOPE_VERSION="@0@"'.format(version),
     install: true,
   )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -124,21 +124,29 @@ if openvr_dep.found()
   src += 'vr_session.cpp'
 endif
 
-  version = run_command('git', 'describe', '--dirty', '--broken', check: true).stdout().strip()
-  executable(
-    'gamescope',
-    src, reshade_src,
-    include_directories : [reshade_include],
-    dependencies: [
-      dep_wayland, dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
-      dep_xxf86vm, dep_xres, glm_dep, drm_dep, wayland_server,
-      xkbcommon, thread_dep, sdl_dep, wlroots_dep,
-      vulkan_dep, liftoff_dep, dep_xtst, dep_xmu, cap_dep, pipewire_dep, librt_dep,
-      stb_dep, displayinfo_dep, openvr_dep,
-    ],
-    cpp_args: '-DGAMESCOPE_VERSION="@0@"'.format(version),
-    install: true,
-  )
+version_h = custom_target(
+    'gamescope_version.h',
+    output : 'gamescope_version.h',
+    input: '../scripts/generate_version_header.sh',
+    command : ['bash', '@INPUT@', '@OUTPUT@'],
+    build_by_default: true,
+)
+
+src += version_h
+
+executable(
+  'gamescope',
+  src, reshade_src,
+  include_directories : [reshade_include],
+  dependencies: [
+    dep_wayland, dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
+    dep_xxf86vm, dep_xres, glm_dep, drm_dep, wayland_server,
+    xkbcommon, thread_dep, sdl_dep, wlroots_dep,
+    vulkan_dep, liftoff_dep, dep_xtst, dep_xmu, cap_dep, pipewire_dep, librt_dep,
+    stb_dep, displayinfo_dep, openvr_dep,
+  ],
+  install: true,
+)
 
 
 benchmark_dep = dependency('benchmark', required: get_option('benchmark'), disabler: true)


### PR DESCRIPTION
This PR adds a way to encode the current "version" into the gamescope binary. The version comes from a `git describe` command and looks like: `3.12.1-133-gb4af6e3-dirty` where the first part is the nearest tag, the short git hash is added after the `-g` and if any files in the git repo have been changed but not committed the `-dirty` flag is added. There's also a way to inject a version by setting the `GAMESCOPE_VERSION` environment variable prior to the build, and if the folder isn't a git repo and this variable is not set then calling `--version` prints out a message telling the user to check the version using their distro's package manager.

This is done by creating a "gamescope_version.h" file every time ninja is called. This has the small downside that even with no changes _some_ compilation will happen. I'm looking for ways to eliminate this when the .h file has not changed.

Also the dependency installation step has been put into its own script.

Some of this stuff I can't fully test because I don't know how the actual builds are done.