### PR TITLE
set global default optimization level to O1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
   'cpp',
   meson_version: '>=0.58.0',
   default_options: [
+    'optimization=1',
     'cpp_std=c++20',
     'warning_level=2',
     'force_fallback_for=wlroots,libliftoff,vkroots',

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,7 +24,7 @@ wlroots_dep = dependency(
   'wlroots',
   version: ['>= 0.17.0', '< 0.18.0'],
   fallback: ['wlroots', 'wlroots'],
-  default_options: ['default_library=static', 'examples=false', 'xwayland=enabled', 'backends=libinput', 'renderers=[]', 'allocators=[]', 'session=enabled'],
+  default_options: ['optimization=2','default_library=static', 'examples=false', 'xwayland=enabled', 'backends=libinput', 'renderers=[]', 'allocators=[]', 'session=enabled'],
 )
 
 displayinfo_dep = dependency(


### PR DESCRIPTION
Meson will otherwise compile some files (such as steamcompmgr.cpp) w/ -O0 if the person compiling gamescope didn't pass a command line argument like --buildtype or --optimization. 
Oftentimes, people will just put -O<num> in their C[XX]FLAGS envar if they want to build w/ optimization, **but meson seems to still use -O0 if that's all they do**
I've observed this behavior from looking at the compile_commands.json file produced after building gamescope

(and this seems to happen even if you do :
```
export CXXFLAGS="-O2 ..."
meson setup -Dcpp_args="$CXXFLAGS"  build
```
)