### PR TITLE
make paint_all inline

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2382,7 +2382,9 @@ static void update_touch_scaling( const struct FrameInfo_t *frameInfo )
 	focusedWindowOffsetY = frameInfo->layers[ frameInfo->layerCount - 1 ].offset.y;
 }
 
-static void
+
+inline static void __attribute__((always_inline)) //yes attributes are ugly but compilers aren't able to tell the real performance difference that inlining this function will give 
+						  // (2nd highest hotpath (by plurality of cputime) for gamescope-xwm thread found thru profiling) 
 paint_all(bool async)
 {
 	gamescope_xwayland_server_t *root_server = wlserver_get_xwayland_server(0);


### PR DESCRIPTION
Profiling with Intel® VTune™ (nested session w/ latest gamescope-git (`243582c`) compiled w/ `clang++` w/ `--buildtype=debugoptimized`, also w/ `-fno-omit-frame-pointer`) shows that the `paint_all()` function in steamcompmgr is the second biggest hotspot for the gamescope-xwm thread.

![without_inline2](https://github.com/ValveSoftware/gamescope/assets/128002472/5eaf3e79-7b1b-49e1-ac96-0785d62f8ff2)


So why inline the second biggest hotspot, but not the first biggest hotspot (which is `MouseCursor::updatePosition`)?
W/ the first biggest hotspot, `MouseCursor::updatePosition`, virtually all of the time inside `MouseCursor::updatePosition` is spent calling xlib function `XQueryPointer()` (which is a blocking function it seems), so there likely won't be any benefit from inlining it.

However, for the second biggest hotspot, it seems like there's some extra compiler optimizations that inlining `paint_all()` enables (especially I think w/ the branching inside the function and whatnot). 

Here's what the flamegraph (same settings as w/ the previous image) looks like when `paint_all()` is inlined:
![with_inline2c](https://github.com/ValveSoftware/gamescope/assets/128002472/02182d0c-a647-4ecf-9fa7-a91c8075facd)


![with_inline2d](https://github.com/ValveSoftware/gamescope/assets/128002472/e6bedfc4-83d7-4ef4-a90b-f158eeda9de9)

I checked the cputime for the functions called by `paint_all()`: `vulkan_present_to_window()` and `vulkan_composite()` to try to verify that there's a performance gain: adding the two up and then dividing by the total cputime of gamescope-xwm thread (.011+.003)/.085 = 16.5% of gamescope-xwm's cputime

compared to the percent cputime of `paint_all()` when it *isn't inlined*: .166/.492=33.7% of gamescope-xwm's cputime

Also you can see that `gamescope::CWaiter` takes up a higher proportion of gamescope-xwm's cputime when `paint_all()` is inlined, which indicates that inlining it allows it to complete its tasks faster, wherein the thread spends more of its time just waiting

Also, yes, this makes use of a compiler attribute `__attribute__((always_inline))`, because clang (and I'm guessing also gcc) doesn't seem to want to inline the function if you simply add `inline`. I guess the problem is that `paint_all()` is a big function, and the compiler would need to have insight into runtime profiling for its heuristics to allow the function to be inlined w/o using `__attribute__((always_inline))`

and yes, both gcc *and* clang support `_attribute__((always_inline))`

This PR might slightly reduce the severity of (but not fix) issue: https://github.com/ValveSoftware/gamescope/issues/163