### PR TITLE
drm_blob abstraction and lifetime management fixes

### DIFF
--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -59,54 +59,63 @@ extern "C"
 extern struct drm_t g_DRM;
 void drm_destroy_blob(struct drm_t *drm, uint32_t blob);
 
-struct wlserver_hdr_metadata
+class drm_blob
+{
+public:
+	drm_blob() : blob( 0 ), owned( false )
+	{
+	}
+
+	drm_blob(uint32_t blob, bool owned = true)
+		: blob( blob ), owned( owned )
+	{
+	}
+
+	~drm_blob()
+	{
+		if (blob && owned)
+			drm_destroy_blob( &g_DRM, blob );
+	}
+
+	// No copy constructor, because we can't duplicate the blob handle.
+	drm_blob(const drm_blob&) = delete;
+	drm_blob& operator=(const drm_blob&) = delete;
+	// No move constructor, because we use shared_ptr anyway, but can be added if necessary.
+	drm_blob(drm_blob&&) = delete;
+	drm_blob& operator=(drm_blob&&) = delete;
+
+	uint32_t blob;
+	bool owned;
+};
+
+struct wlserver_hdr_metadata : drm_blob
 {
 	wlserver_hdr_metadata()
 	{
-
 	}
 
 	wlserver_hdr_metadata(hdr_output_metadata* _metadata, uint32_t blob, bool owned = true)
-		: blob(blob), owned(owned)
+		: drm_blob( blob, owned )
 	{
 		if (_metadata)
 			this->metadata = *_metadata;
 	}
 
-	~wlserver_hdr_metadata()
-	{
-		if ( blob && owned )
-			drm_destroy_blob( &g_DRM, blob );
-	}
-
 	hdr_output_metadata metadata = {};
-	uint32_t blob = 0;
-	bool owned = true;
 };
 
-struct wlserver_ctm
+struct wlserver_ctm : drm_blob
 {
 	wlserver_ctm()
 	{
-
 	}
 
 	wlserver_ctm(glm::mat3x4 ctm, uint32_t blob, bool owned = true)
-		: matrix(ctm)
-		, blob(blob)
-	    , owned(owned)
+		: drm_blob( blob, owned ), matrix( ctm )
 	{
-	}
-
-	~wlserver_ctm()
-	{
-		if ( blob && owned )
-			drm_destroy_blob( &g_DRM, blob );
 	}
 
 	glm::mat3x4 matrix{};
-	uint32_t blob = 0;
-	bool owned = true;
 };
 
 #include <wayland-server-core.h>

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -67,7 +67,7 @@ struct wlserver_hdr_metadata
 	}
 
 	wlserver_hdr_metadata(hdr_output_metadata* _metadata, uint32_t blob, bool owned = true)
-		: blob(blob)
+		: blob(blob), owned(owned)
 	{
 		if (_metadata)
 			this->metadata = *_metadata;
@@ -94,6 +94,7 @@ struct wlserver_ctm
 	wlserver_ctm(glm::mat3x4 ctm, uint32_t blob, bool owned = true)
 		: matrix(ctm)
 		, blob(blob)
+	    , owned(owned)
 	{
 	}
 

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -271,10 +271,10 @@ struct drm_t {
 	std::shared_ptr<wlserver_hdr_metadata> sdr_static_metadata;
 
 	struct {
-		uint32_t mode_id;
+		std::shared_ptr<drm_blob> mode_id;
 		uint32_t color_mgmt_serial;
-		uint32_t lut3d_id[ EOTF_Count ];
-		uint32_t shaperlut_id[ EOTF_Count ];
+		std::shared_ptr<drm_blob> lut3d_id[ EOTF_Count ];
+		std::shared_ptr<drm_blob> shaperlut_id[ EOTF_Count ];
 		enum drm_screen_type screen_type = DRM_SCREEN_TYPE_INTERNAL;
 		bool vrr_enabled = false;
 		drm_valve1_transfer_function output_tf = DRM_VALVE1_TRANSFER_FUNCTION_DEFAULT;


### PR DESCRIPTION
The first commit fixes a use-after-free and is a backport candidate.

The second is a refactor and the third uses the newly introduced drm_blob helpers to avoid leaks of mode and lut tracking.