### PR TITLE
steamcompmgr: Fix calculated refresh cycle for present timing

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8097,11 +8097,10 @@ steamcompmgr_main(int argc, char **argv)
 			int nRealRefresh = g_nNestedRefresh ? g_nNestedRefresh : g_nOutputRefresh;
 			int nTargetFPS = g_nSteamCompMgrTargetFPS ? g_nSteamCompMgrTargetFPS : nRealRefresh;
 			nTargetFPS = std::min<int>( nTargetFPS, nRealRefresh );
-			int nMultiplier = nRealRefresh / nTargetFPS;
+			int nVblankDivisor = nRealRefresh / nTargetFPS;
 
-			int nAppRefresh = nRealRefresh * nMultiplier;
 			g_SteamCompMgrAppRefreshCycle = 1'000'000'000ul / nRealRefresh;
-			g_SteamCompMgrLimitedAppRefreshCycle = 1'000'000'000ul / nAppRefresh;
+			g_SteamCompMgrLimitedAppRefreshCycle = 1'000'000'000ul / nRealRefresh * nVblankDivisor;
 		}
 
 		// Handle presentation-time stuff


### PR DESCRIPTION
The "target FPS" feature divides vblank to achieve a target refresh rate. Previously, the target frame time was divided by the divisor again, making it way too small and nonsensical. Correctly calculate this by multiplying instead of dividing.

Since the real refresh rate may be odd, apply the multiplier after dividing to avoid rounding error.