### PR TITLE
vr_session: update to OpenVR 2

### DIFF
--- a/src/vr_session.cpp
+++ b/src/vr_session.cpp
@@ -116,9 +116,6 @@ bool vr_init(int argc, char **argv)
 // Not in public headers yet.
 namespace vr
 {
-    const VROverlayFlags VROverlayFlags_EnableControlBar = (VROverlayFlags)(1 << 23);
-    const VROverlayFlags VROverlayFlags_EnableControlBarKeyboard = (VROverlayFlags)(1 << 24);
-    const VROverlayFlags VROverlayFlags_EnableControlBarClose = (VROverlayFlags)(1 << 25);
     const VROverlayFlags VROverlayFlags_EnableControlBarSteamUI = (VROverlayFlags)(1 << 26);
 
     const EVRButtonId k_EButton_Steam = (EVRButtonId)(50);


### PR DESCRIPTION
OpenVR 2.0.10 added some previously reserved enum values. *Though one still remains*

This PR makes Gamescope require OpenVR 2.0.10.
