### PR TITLE
wlserver: Fix overzealous HDR metadata validation

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -747,7 +747,7 @@ static void gamescope_swapchain_set_hdr_metadata( struct wl_client *client, stru
 
 		// Check validity of this metadata,
 		// if it's garbage, just toss it...
-		if (!max_cll || !max_fall || (!white_point_x && !white_point_y))
+		if (!max_display_mastering_luminance || (!white_point_x && !white_point_y))
 			return;
 
 		hdr_output_metadata metadata = {};


### PR DESCRIPTION
The validation added in 22618ea is a bit overzealous and discards HDR metadata that simply lacks MaxCLL or MaxFALL values. Valid HDR10 content can lack MaxCLL or MaxFALL values, particularly in cases where it's broadcast or rendered in real-time (as called out in the footnotes of CTA-861-G §6.9.1).

While CTA-861-G §6.9.1 explicitly states that an all-zero or partial-zero HDR infoframe is okay for cases where some/all metadata values are unknown, I've left some basic validation in place to hopefully avoid the issue that 22618ea was trying to fix without throwing away good HDR metadata that has both luminance range and color primary information.