### PR TITLE
steamcompmgr: Use XInput2 RawMotion events as a hint to update cursor pos

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ dep_xxf86vm = dependency('xxf86vm')
 dep_xtst = dependency('xtst')
 dep_xres = dependency('xres')
 dep_xmu = dependency('xmu')
+dep_xi = dependency('xi')
 
 drm_dep = dependency('libdrm', version: '>= 2.4.113')
 
@@ -136,7 +137,7 @@ endif
       dep_xxf86vm, dep_xres, glm_dep, drm_dep, wayland_server,
       xkbcommon, thread_dep, sdl_dep, wlroots_dep,
       vulkan_dep, liftoff_dep, dep_xtst, dep_xmu, cap_dep, epoll_dep, pipewire_dep, librt_dep,
-      stb_dep, displayinfo_dep, openvr_dep, dep_xcursor, avif_dep,
+      stb_dep, displayinfo_dep, openvr_dep, dep_xcursor, avif_dep, dep_xi
     ],
     install: true,
   )

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -49,6 +49,20 @@ extern EStreamColorspace g_ForcedNV12ColorSpace;
 // use the proper libliftoff composite plane system.
 static constexpr bool kDisablePartialComposition = true;
 
+struct CursorBarrierInfo
+{
+	int x1 = 0;
+	int y1 = 0;
+	int x2 = 0;
+	int y2 = 0;
+};
+
+struct CursorBarrier
+{
+	PointerBarrier obj = None;
+	CursorBarrierInfo info = {};
+};
+
 class MouseCursor
 {
 public:
@@ -58,9 +72,7 @@ public:
 	int y() const;
 
 	void move(int x, int y);
-	void updatePosition();
 	void constrainPosition();
-	void resetPosition();
 
 	void paint(steamcompmgr_win_t *window, steamcompmgr_win_t *fit, FrameInfo_t *frameInfo);
 	void setDirty();
@@ -72,6 +84,7 @@ public:
 	void hide() { m_lastMovedTime = 0; checkSuspension(); }
 
 	bool isHidden() { return m_hideForMovement || m_imageEmpty; }
+	bool imageEmpty() const { return m_imageEmpty; }
 
 	void forcePosition(int x, int y)
 	{
@@ -89,13 +102,12 @@ public:
 
 	void GetDesiredSize( int& nWidth, int &nHeight );
 
+	void UpdateXInputMotionMasks();
+	void UpdatePosition();
+
+	void checkSuspension();
 private:
 	void warp(int x, int y);
-	void checkSuspension();
-
-	void queryGlobalPosition(int &x, int &y);
-	void queryPositions(int &rootX, int &rootY, int &winX, int &winY);
-	void queryButtonMask(unsigned int &mask);
 
 	bool getTexture();
 
@@ -111,7 +123,9 @@ private:
 	unsigned int m_lastMovedTime = 0;
 	bool m_hideForMovement;
 
-	PointerBarrier m_scaledFocusBarriers[4] = { None };
+	bool m_bMotionMaskEnabled = false;
+
+	CursorBarrier m_barriers[4] = {};
 
 	xwayland_ctx_t *m_ctx;
 

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -70,6 +70,7 @@ struct xwayland_ctx_t final : public gamescope::IWaitable
 	int				render_event, render_error;
 	int				xshape_event, xshape_error;
 	int				composite_opcode;
+	int				xinput_opcode, xinput_event, xinput_error;
 	Window			ourWindow;
 
 	focus_t 		focus;


### PR DESCRIPTION
Taking a page out of XEyes' book to get the cursor position (even when the cursor is grabbed, etc) by only doing so when we get a RawMotion event -- and only register for those when we know there's a cursor image that we would want to render.

This is a kinda crap workaround for the fact that we cannot directly just recieve information about the cursor from the XServer, even as the X11 WM due to cursor grabbing, input masking and other such nonsense.

An alternative would be using something like libei and having XTest funnel through that -- however that needs work to be functional on nested compositors.