### PR TITLE
Prevent SDL_WaitEvent loop from running before wlserver has finished initializing

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -130,6 +130,9 @@ namespace gamescope
     public:
         virtual ~IBackend() {}
 
+	virtual void latchWait() { return; }
+    	virtual void releaseLatch() { return; } //currently only used by sdl
+
         virtual bool Init() = 0;
         virtual bool PostInit() = 0;
         virtual std::span<const char *const> GetInstanceExtensions() const = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -803,7 +803,7 @@ int main(int argc, char **argv)
 	if ( !GetBackend() )
 	{
 		fprintf( stderr, "Failed to create backend.\n" );
-		return 1;
+		exit(1);
 	}
 
 	g_ForcedNV12ColorSpace = parse_colorspace_string( getenv( "GAMESCOPE_NV12_COLORSPACE" ) );
@@ -811,13 +811,13 @@ int main(int argc, char **argv)
 	if ( !vulkan_init_formats() )
 	{
 		fprintf( stderr, "vulkan_init_formats failed\n" );
-		return 1;
+		exit(1);
 	}
 
 	if ( !vulkan_make_output() )
 	{
 		fprintf( stderr, "vulkan_make_output failed\n" );
-		return 1;
+		exit(1);
 	}
 
 	// Prevent our clients from connecting to the parent compositor
@@ -846,7 +846,7 @@ int main(int argc, char **argv)
 		if ( g_nNestedWidth != 0 )
 		{
 			fprintf( stderr, "Cannot specify -w without -h\n" );
-			return 1;
+			exit(1);
 		}
 		g_nNestedWidth = g_nOutputWidth;
 		g_nNestedHeight = g_nOutputHeight;
@@ -857,7 +857,9 @@ int main(int argc, char **argv)
 	if ( !wlserver_init() )
 	{
 		fprintf( stderr, "Failed to initialize wlserver\n" );
-		return 1;
+		exit(1);
+	} else {
+		GetBackend()->releaseLatch();
 	}
 
 	gamescope_xwayland_server_t *base_server = wlserver_get_xwayland_server(0);


### PR DESCRIPTION
(hopefully) fixes issue https://github.com/ValveSoftware/gamescope/issues/661

Uses ~~C++11 compatible~~ atomic ~~and condition~~ variable ~~(reusing the steamcompmgr "poor man's semaphore" class)~~
This PR only adds synchronization during startup, so not much overhead IMO 

I had noticed that issue https://github.com/ValveSoftware/gamescope/issues/661 would be triggered 50% of the time when running ValveSoftware/gamescope/master under intel VTune. 
Compiling and running gamescope w/ this PR under intel VTune -> haven't seen any occurrences of the issue after running gamescope under VTune 4 different times.   
