### PR TITLE
drm: Add force-drm-device option

### DIFF
--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -323,6 +323,7 @@ extern bool g_bRotated;
 extern bool g_bFlipped;
 extern bool g_bDebugLayers;
 extern const char *g_sOutputName;
+extern const char *g_sDevicePath;
 
 enum drm_mode_generation {
 	DRM_MODE_GENERATE_CVT,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "disable-layers", no_argument, nullptr, 0 },
 	{ "debug-layers", no_argument, nullptr, 0 },
 	{ "prefer-output", required_argument, nullptr, 'O' },
+	{ "force-drm-device", required_argument, nullptr, 0 },
 	{ "default-touch-mode", required_argument, nullptr, 0 },
 	{ "generate-drm-mode", required_argument, nullptr, 0 },
 	{ "immediate-flips", no_argument, nullptr, 0 },
@@ -189,6 +190,7 @@ const char usage[] =
 	"\n"
 	"Embedded mode options:\n"
 	"  -O, --prefer-output            list of connectors in order of preference\n"
+	"  --force-drm-device             DRM device path to use\n"
 	"  --default-touch-mode           0: hover, 1: left, 2: right, 3: middle, 4: passthrough\n"
 	"  --generate-drm-mode            DRM mode generation algorithm (cvt, fixed)\n"
 	"  --immediate-flips              Enable immediate flips, may result in tearing\n"
@@ -625,6 +627,8 @@ int main(int argc, char **argv)
 					sscanf( optarg, "%X:%X", &vendorID, &deviceID );
 					g_preferVendorID = vendorID;
 					g_preferDeviceID = deviceID;
+				} else if (strcmp(opt_name, "force-drm-device") == 0) {
+					g_sDevicePath = optarg;
 				} else if (strcmp(opt_name, "immediate-flips") == 0) {
 					g_nAsyncFlipsEnabled = 1;
 				} else if (strcmp(opt_name, "force-grab-cursor") == 0) {


### PR DESCRIPTION
Can be used to override the device path if the arbitrarily-chosen device is wrong.