### PR TITLE
define minimum libavif version in src/meson.build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -20,7 +20,7 @@ epoll_dep = dependency('epoll-shim', required: false)
 glm_dep = dependency('glm')
 sdl_dep = dependency('SDL2')
 stb_dep = dependency('stb')
-avif_dep = dependency('libavif')
+avif_dep = dependency('libavif', version: '>=1.0.0')
 
 wlroots_dep = dependency(
   'wlroots',


### PR DESCRIPTION
On a Debian system with `libavif-dev` version `0.11.1` compiling fails with the following errors:
```
../src/steamcompmgr.cpp: In lambda function:
../src/steamcompmgr.cpp:3205:61: error: ‘avifImage’ {aka ‘struct avifImage’} has no member named ‘clli’
 3205 |                                                 pAvifImage->clli.maxCLL = maxCLLNits;
      |                                                             ^~~~
../src/steamcompmgr.cpp:3206:61: error: ‘avifImage’ {aka ‘struct avifImage’} has no member named ‘clli’
 3206 |                                                 pAvifImage->clli.maxPALL = maxFALLNits;
      |                                                             ^~~~
../src/steamcompmgr.cpp:3221:51: error: ‘avifEncoder’ {aka ‘struct avifEncoder’} has no member named ‘quality’
 3221 |                                         pEncoder->quality = AVIF_QUALITY_LOSSLESS;
      |                                                   ^~~~~~~
../src/steamcompmgr.cpp:3221:61: error: ‘AVIF_QUALITY_LOSSLESS’ was not declared in this scope; did you mean ‘AVIF_QUANTIZER_LOSSLESS’?
 3221 |                                         pEncoder->quality = AVIF_QUALITY_LOSSLESS;
      |                                                             ^~~~~~~~~~~~~~~~~~~~~
      |                                                             AVIF_QUANTIZER_LOSSLESS
../src/steamcompmgr.cpp:3222:51: error: ‘avifEncoder’ {aka ‘struct avifEncoder’} has no member named ‘qualityAlpha’
 3222 |                                         pEncoder->qualityAlpha = AVIF_QUALITY_LOSSLESS;
      |                                                   ^~~~~~~~~~~~
```
`avifImage.clli`, `avifEncoder.quality`, `avifEncoder.qualityAlpha` and `AVIF_QUALITY_LOSSLESS` were added in libavif 1.0.0 so that should be defined as the minimum necessary version in meson.build so the old version is caught by meson.