### PR TITLE
Fix null-checking oversight in drm_get_native_colorimetry

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -3143,6 +3143,7 @@ void drm_get_native_colorimetry( struct drm_t *drm,
 	{
 		*outputEncodingColorimetry = drm->pConnector->GetDisplayColorimetry();
 		*outputEncodingEOTF = EOTF_Gamma22;
+		return;
 	}
 }
 


### PR DESCRIPTION
Fixes a small oversight in `drm_get_native_colorimetry` when checking if the connector is `nullptr`.

This can cause a crash on resume from suspend on some systems, presumably because the connector is not available for a while.