### PR TITLE
Add --vulkan-debug-extension switch to provide object names to vulkan validation layer output 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "synchronous-x11", no_argument, nullptr, 0 },
 	{ "debug-hud", no_argument, nullptr, 'v' },
 	{ "debug-events", no_argument, nullptr, 0 },
-  { "vulkan-debug-extension", no_argument, 0},
+	{ "vulkan-debug-extension", no_argument, 0},
 	{ "steam", no_argument, nullptr, 'e' },
 	{ "force-composition", no_argument, nullptr, 'c' },
 	{ "composite-debug", no_argument, nullptr, 0 },
@@ -328,7 +328,7 @@ bool BIsSDLSession( void )
 }
 
 
-static bool initOutput(int preferredWidth, int preferredHeight, int preferredRefresh);
+static bool initOutput(int preferredWidth, int preferredHeight, int preferredRefresh, bool vulkanDebugEXT = false);
 static void steamCompMgrThreadRun(int argc, char **argv);
 
 static std::string build_optstring(const struct option *options)
@@ -780,8 +780,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	VkInstance instance = vulkan_create_instance(vulkanDebugEXT);
-	VkSurfaceKHR surface = VK_NULL_HANDLE;
 	if ( !BIsNested() )
 	{
 		g_bForceRelativeMouse = false;
@@ -798,7 +796,7 @@ int main(int argc, char **argv)
 	}
 #endif
 
-	if ( !initOutput( g_nPreferredOutputWidth, g_nPreferredOutputHeight, g_nNestedRefresh ) )
+	if ( !initOutput( g_nPreferredOutputWidth, g_nPreferredOutputHeight, g_nNestedRefresh, vulkanDebugEXT ) )
 	{
 		fprintf( stderr, "Failed to initialize output\n" );
 		return 1;
@@ -922,9 +920,9 @@ static void steamCompMgrThreadRun(int argc, char **argv)
 	pthread_kill( g_mainThread, SIGINT );
 }
 
-static bool initOutput( int preferredWidth, int preferredHeight, int preferredRefresh )
+static bool initOutput( int preferredWidth, int preferredHeight, int preferredRefresh, bool vulkanDebugEXT )
 {
-	VkInstance instance = vulkan_create_instance();
+	VkInstance instance = vulkan_create_instance(vulkanDebugEXT);
 
 	if ( BIsNested() )
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,6 +434,10 @@ static void handle_signal( int sig )
 		}
 
 		fprintf( stderr, "gamescope: Received %s signal, attempting shutdown!\n", strsignal(sig) );
+		
+		if (vulkan_run_at_exit != nullptr)
+			(*vulkan_run_at_exit)();
+		
 		g_bRun = false;
 		break;
 	case SIGUSR1:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "rt", no_argument, nullptr, 0 },
 	{ "prefer-vk-device", required_argument, 0 },
 	{ "expose-wayland", no_argument, 0 },
+	{ "vulkan-debug-extension", no_argument, 0},
 
 	{ "headless", no_argument, 0 },
 
@@ -227,7 +228,8 @@ const char usage[] =
 	"  --disable-xres                 disable XRes for PID lookup\n"
 	"  --hdr-debug-force-support      forces support for HDR, etc even if the display doesn't support it. HDR clients will be outputted as SDR still in that case.\n"
 	"  --hdr-debug-force-output       forces support and output to HDR10 PQ even if the output does not support it (will look very wrong if it doesn't)\n"
-	"  --hdr-debug-heatmap            displays a heatmap-style debug view of HDR luminence across the scene in nits."
+	"  --hdr-debug-heatmap            displays a heatmap-style debug view of HDR luminence across the scene in nits.\n"
+	"  --vulkan-debug-extension	  loads vulkan debug extension(s). Supplies object names to validation layer messages." 
 	"\n"
 	"Reshade shader options:\n"
 	"  --reshade-effect               sets the name of a reshade shader to use in either /usr/share/gamescope/reshade/Shaders or ~/.local/share/gamescope/reshade/Shaders\n"
@@ -542,6 +544,7 @@ static bool CheckWaylandPresentationTime()
 int g_nPreferredOutputWidth = 0;
 int g_nPreferredOutputHeight = 0;
 bool g_bExposeWayland = false;
+bool g_vulkanDebugEXT = false;
 
 int main(int argc, char **argv)
 {
@@ -605,6 +608,8 @@ int main(int argc, char **argv)
 					g_bDebugLayers = true;
 				} else if (strcmp(opt_name, "disable-color-management") == 0) {
 					g_bForceDisableColorMgmt = true;
+				} else if (strcmp(opt_name, "vulkan-debug-extension") == 0) {
+					g_vulkanDebugEXT = true;
 				} else if (strcmp(opt_name, "xwayland-count") == 0) {
 					g_nXWaylandCount = atoi( optarg );
 				} else if (strcmp(opt_name, "composite-debug") == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -608,7 +608,14 @@ int main(int argc, char **argv)
 				} else if (strcmp(opt_name, "disable-color-management") == 0) {
 					g_bForceDisableColorMgmt = true;
 				} else if (strcmp(opt_name, "vulkan-debug-extension") == 0) {
+				#ifndef NDEBUG
 					vulkanDebugEXT = true;
+				#else
+					fprintf(stderr, "gamescope is not compiled with --vulkan-debug-extension supported\n"
+							"to enable it, recompile gamescope after reconfiguring it with:\n"
+							"meson --reconfigure build -Db_ndebug=false\n");
+					exit(1);
+				#endif
 				} else if (strcmp(opt_name, "xwayland-count") == 0) {
 					g_nXWaylandCount = atoi( optarg );
 				} else if (strcmp(opt_name, "composite-debug") == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,7 +544,6 @@ static bool CheckWaylandPresentationTime()
 int g_nPreferredOutputWidth = 0;
 int g_nPreferredOutputHeight = 0;
 bool g_bExposeWayland = false;
-bool g_vulkanDebugEXT = false;
 
 int main(int argc, char **argv)
 {
@@ -553,7 +552,7 @@ int main(int argc, char **argv)
 
 	static std::string optstring = build_optstring(gamescope_options);
 	gamescope_optstring = optstring.c_str();
-
+        bool vulkanDebugEXT = false;
 	int o;
 	int opt_index = -1;
 	while ((o = getopt_long(argc, argv, gamescope_optstring, gamescope_options, &opt_index)) != -1)
@@ -609,7 +608,7 @@ int main(int argc, char **argv)
 				} else if (strcmp(opt_name, "disable-color-management") == 0) {
 					g_bForceDisableColorMgmt = true;
 				} else if (strcmp(opt_name, "vulkan-debug-extension") == 0) {
-					g_vulkanDebugEXT = true;
+					vulkanDebugEXT = true;
 				} else if (strcmp(opt_name, "xwayland-count") == 0) {
 					g_nXWaylandCount = atoi( optarg );
 				} else if (strcmp(opt_name, "composite-debug") == 0) {
@@ -763,7 +762,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	VkInstance instance = vulkan_create_instance();
+	VkInstance instance = vulkan_create_instance(vulkanDebugEXT);
 	VkSurfaceKHR surface = VK_NULL_HANDLE;
 
 	if ( !BIsNested() )

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3359,7 +3359,7 @@ VkInstance vulkan_create_instance(const bool bShouldDebug )
 			fprintf(stderr, "SDL_Vulkan_LoadLibrary failed: %s\n", SDL_GetError());
 			return nullptr;
 		}
-		
+
 		unsigned int extCount = 0;
 		SDL_Vulkan_GetInstanceExtensions( nullptr, &extCount, nullptr );
 		sdlExtensions.resize( extCount );

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1624,8 +1624,8 @@ void CVulkanCmdBuffer::copyImage(std::shared_ptr<CVulkanTexture> src, std::share
 	
 	m_device->vk.CmdCopyImage(m_cmdBuffer, src->vkImage(), VK_IMAGE_LAYOUT_GENERAL, dst->vkImage(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
 
-	MARK(src->vkImage())
-	MARK(dst->vkImage())
+	MARK_TYPED(src->vkImage(), VK_OBJECT_TYPE_IMAGE)
+	MARK_TYPED(dst->vkImage(), VK_OBJECT_TYPE_IMAGE)
 	
 	markDirty(dst.get());
 }
@@ -1651,7 +1651,7 @@ void CVulkanCmdBuffer::copyBufferToImage(VkBuffer buffer, VkDeviceSize offset, u
 	
 	m_device->vk.CmdCopyBufferToImage(m_cmdBuffer, buffer, dst->vkImage(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
 
-	MARK(dst->vkImage())
+	MARK_TYPED(dst->vkImage(), VK_OBJECT_TYPE_IMAGE)
 	
 	markDirty(dst.get());
 }

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -11,7 +11,6 @@
 #include <bitset>
 #include <thread>
 #include <vulkan/vulkan_core.h>
-#include <vulkan/utility/vk_struct_helper.hpp>
 
 #if defined(__linux__)
 #include <sys/sysmacros.h>
@@ -4163,7 +4162,7 @@ std::shared_ptr<CVulkanTexture> vulkan_create_texture_from_wlr_buffer( struct wl
 	};
 	VkBuffer buffer;
 	result = g_device.vk.CreateBuffer( g_device.device(), &bufferCreateInfo, nullptr, &buffer );
-	MARK(buffer)
+	MARK_TYPED(buffer, VK_OBJECT_TYPE_BUFFER)
 	if ( result != VK_SUCCESS )
 	{
 		wlr_buffer_end_data_ptr_access( buf );

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -100,6 +100,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(
 }
 
 bool vulkanDebugExtSupported=false;
+static bool vulkanDebugEXT;
 VulkanOutput_t g_output;
 
 uint32_t g_uCompositeDebug = 0u;
@@ -3339,8 +3340,9 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debug_utils_messenger_callback
 	return VK_FALSE;
 }
 
-VkInstance vulkan_create_instance( void )
+VkInstance vulkan_create_instance(const bool bShouldDebug )
 {
+	vulkanDebugEXT=bShouldDebug;
 	VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
 	std::vector< const char * > sdlExtensions;
@@ -3372,14 +3374,14 @@ VkInstance vulkan_create_instance( void )
 	vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, available_instance_extensions.data());
 	
 	for (auto &available_extension : available_instance_extensions) {
-		if (g_vulkanDebugEXT == true 
+		if (vulkanDebugEXT == true 
 		     && strcmp(available_extension.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) {
 			vulkanDebugExtSupported = true;
 			sdlExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 		}
 	}
 
-	if (g_vulkanDebugEXT == true && vulkanDebugExtSupported == false)
+	if (vulkanDebugEXT == true && vulkanDebugExtSupported == false)
 	{
 		vk_log.errorf("VK_EXT_DEBUG_UTILS_EXTENSION_NAME is not supported, continuing without vulkan debug extension(s)");
 	}
@@ -3400,7 +3402,7 @@ VkInstance vulkan_create_instance( void )
 	};
 
 	VkInstance instance = nullptr;
-	if ( g_vulkanDebugEXT && vulkanDebugExtSupported)
+	if ( vulkanDebugEXT && vulkanDebugExtSupported)
 	{
 		VkDebugUtilsMessengerCreateInfoEXT debug_utils_create_info = {VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT};
 

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1040,7 +1040,7 @@ VkSampler CVulkanDevice::sampler( SamplerState key )
 	};
 
 	vk.CreateSampler( device(), &samplerCreateInfo, nullptr, &ret );
-	MARK_TYPED(ret, VK_OBJECT_TYPE_SAMPLER)
+	MARK(ret, VK_OBJECT_TYPE_SAMPLER)
 	m_samplerCache[key] = ret;
 
 	return ret;
@@ -1128,7 +1128,7 @@ VkPipeline CVulkanDevice::compilePipeline(uint32_t layerCount, uint32_t ycbcrMas
 	VkPipeline result;
 
 	VkResult res = vk.CreateComputePipelines(device(), VK_NULL_HANDLE, 1, &computePipelineCreateInfo, nullptr, &result);
-	MARK_TYPED(result, VK_OBJECT_TYPE_PIPELINE)
+	MARK(result, VK_OBJECT_TYPE_PIPELINE)
 	if (res != VK_SUCCESS) {
 		vk_errorf( res, "vkCreateComputePipelines failed" );
 		return VK_NULL_HANDLE;
@@ -1620,11 +1620,11 @@ void CVulkanCmdBuffer::copyImage(std::shared_ptr<CVulkanTexture> src, std::share
 			.depth = 1
 		},
 	};
-	
+
 	m_device->vk.CmdCopyImage(m_cmdBuffer, src->vkImage(), VK_IMAGE_LAYOUT_GENERAL, dst->vkImage(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
 
-	MARK_TYPED(src->vkImage(), VK_OBJECT_TYPE_IMAGE)
-	MARK_TYPED(dst->vkImage(), VK_OBJECT_TYPE_IMAGE)
+	MARK(src->vkImage(), VK_OBJECT_TYPE_IMAGE)
+	MARK(dst->vkImage(), VK_OBJECT_TYPE_IMAGE)
 	
 	markDirty(dst.get());
 }
@@ -1647,10 +1647,10 @@ void CVulkanCmdBuffer::copyBufferToImage(VkBuffer buffer, VkDeviceSize offset, u
 			.depth = dst->depth(),
 		},
 	};
-	
+
 	m_device->vk.CmdCopyBufferToImage(m_cmdBuffer, buffer, dst->vkImage(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
 
-	MARK_TYPED(dst->vkImage(), VK_OBJECT_TYPE_IMAGE)
+	MARK(dst->vkImage(), VK_OBJECT_TYPE_IMAGE)
 	
 	markDirty(dst.get());
 }
@@ -1717,7 +1717,7 @@ void CVulkanCmdBuffer::insertBarrier(bool flush)
 		bool isPresent = flush && state.needsPresentLayout;
 
 		VkImageLayout presentLayout = BIsVRSession() ? VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL : VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-		
+
 		if (!state.discarded && !state.dirty && !state.needsImport && !isExport && !isPresent)
 			continue;
 
@@ -1740,7 +1740,7 @@ void CVulkanCmdBuffer::insertBarrier(bool flush)
 			.subresourceRange = subResRange
 		};
 		
-		MARK_TYPED(memoryBarrier.image, VK_OBJECT_TYPE_IMAGE)
+		MARK(memoryBarrier.image, VK_OBJECT_TYPE_IMAGE)
 		
 		barriers.push_back(memoryBarrier);
 
@@ -1751,8 +1751,8 @@ void CVulkanCmdBuffer::insertBarrier(bool flush)
 
 	// TODO replace VK_PIPELINE_STAGE_ALL_COMMANDS_BIT
 	m_device->vk.CmdPipelineBarrier(m_cmdBuffer, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-								0, 0, nullptr, 0, nullptr, barriers.size(), barriers.data());
-	MARK(m_cmdBuffer);
+									0, 0, nullptr, 0, nullptr, barriers.size(), barriers.data());
+	MARK(m_cmdBuffer, VK_OBJECT_TYPE_COMMAND_BUFFER);
 }
 
 
@@ -2062,7 +2062,7 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 	m_format = imageInfo.format;
 
 	res = g_device.vk.CreateImage(g_device.device(), &imageInfo, nullptr, &m_vkImage);
-	MARK(m_vkImage)
+	MARK(m_vkImage, VK_OBJECT_TYPE_IMAGE)
 	if (res != VK_SUCCESS) {
 		vk_errorf( res, "vkCreateImage failed" );
 		return false;
@@ -4162,7 +4162,7 @@ std::shared_ptr<CVulkanTexture> vulkan_create_texture_from_wlr_buffer( struct wl
 	};
 	VkBuffer buffer;
 	result = g_device.vk.CreateBuffer( g_device.device(), &bufferCreateInfo, nullptr, &buffer );
-	MARK_TYPED(buffer, VK_OBJECT_TYPE_BUFFER)
+	MARK(buffer, VK_OBJECT_TYPE_BUFFER)
 	if ( result != VK_SUCCESS )
 	{
 		wlr_buffer_end_data_ptr_access( buf );

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3346,7 +3346,6 @@ VkInstance vulkan_create_instance(const bool bShouldDebug )
 	VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
 	std::vector< const char * > sdlExtensions;
-	unsigned int extCount = 0;
 	if ( BIsVRSession() )
 	{
 #if HAVE_OPENVR
@@ -3360,7 +3359,8 @@ VkInstance vulkan_create_instance(const bool bShouldDebug )
 			fprintf(stderr, "SDL_Vulkan_LoadLibrary failed: %s\n", SDL_GetError());
 			return nullptr;
 		}
-
+		
+		unsigned int extCount = 0;
 		SDL_Vulkan_GetInstanceExtensions( nullptr, &extCount, nullptr );
 		sdlExtensions.resize( extCount );
 		SDL_Vulkan_GetInstanceExtensions( nullptr, &extCount, sdlExtensions.data() );

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -786,7 +786,7 @@ public:
 	inline std::optional<VkResult> SetName_impl(const bool cond=false, void ** ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 
-	#define SetName(...) SetName_impl(vulkanDebugEXT == true && vulkanDebugExtSupported == true, ## __VA_ARGS__);
+	#define SetName(...)if (__builtin_expect(vulkanDebugEXT, 0)) {} else SetName_impl(vulkanDebugEXT == true && vulkanDebugExtSupported == true, ## __VA_ARGS__);
 	
 	#define _smark(name) #name
 	#define smark(name) _smark(name)
@@ -795,8 +795,13 @@ public:
 	#define _MARK_w_addr(name, ...) SetName( reinterpret_cast<void **>((&(name))), reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
 	#define _MARK(name, ...) SetName( nullptr, reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
 	
+#ifndef NDEBUG
 	#define MARK(name, ...) _MARK_w_addr(name, ## __VA_ARGS__)
 	#define MARK_TYPED(name, typeinfo, ...) _MARK(name, typeinfo, ## __VA_ARGS__)
+#else
+	#define MARK(...)
+	#define MARK_TYPED(...)
+#endif
 	
 protected:
 	friend class CVulkanCmdBuffer;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -11,7 +11,7 @@
 #include <bitset>
 #include <mutex>
 #include <optional>
-#include <type_traits>
+
 #include "main.hpp"
 
 #include "shaders/descriptor_set_constants.h"
@@ -773,7 +773,7 @@ public:
 
 	void resetCmdBuffers(uint64_t sequence);
 	
-	std::optional<VkResult> __attribute__((nothrow, no_stack_protector, visibility("protected"))) _SetName(uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept
+	std::optional<VkResult> __attribute__((nothrow, visibility("protected"))) _SetName(uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept
 	{
 		VkDebugUtilsObjectNameInfoEXT pNameInfo = {
 			.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
@@ -788,9 +788,6 @@ public:
 	inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 
-	#define CONCAT_IMPL( x, y ) x##y
-	#define MACRO_CONCAT( x, y ) CONCAT_IMPL( x, y )
-
 	#define SetName(...) SetName_impl(g_vulkanDebugEXT == true && vulkanDebugExtSupported == true, ## __VA_ARGS__);
 	
 	#define _smark(name) #name
@@ -798,7 +795,6 @@ public:
 	#define lineit_impl(line) line
 	#define lineit(line) lineit_impl(line)
 	#define MARK(name, ...) SetName( reinterpret_cast<void *>(name), reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
-	#define MARK_TYPED(name, ...) SetName( reinterpret_cast<void *>(name), reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
 
 protected:
 	friend class CVulkanCmdBuffer;
@@ -824,7 +820,6 @@ protected:
 	VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
 	VkCommandPool m_commandPool = VK_NULL_HANDLE;
 	VkCommandPool m_generalCommandPool = VK_NULL_HANDLE;
-	
 
 	uint32_t m_queueFamily = -1;
 	uint32_t m_generalQueueFamily = -1;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -874,10 +874,10 @@ protected:
 		{ (reinterpret_cast<void*>(m_pipelineLayout)), VK_OBJECT_TYPE_PIPELINE_LAYOUT},
 		{ (reinterpret_cast<void*>(m_descriptorPool)), VK_OBJECT_TYPE_DESCRIPTOR_POOL},
 		{ (reinterpret_cast<void*>(m_commandPool)), VK_OBJECT_TYPE_COMMAND_POOL},
-		{ (reinterpret_cast<void*>(m_generalCommandPool)), VK_OBJECT_TYPE_COMMAND_POOL},
-		{ (reinterpret_cast<void*>(m_uploadBuffer)), VK_OBJECT_TYPE_BUFFER},
-		{ (reinterpret_cast<void*>(m_uploadBufferMemory)), VK_OBJECT_TYPE_DEVICE_MEMORY},
-		{ (reinterpret_cast<void*>(m_scratchTimelineSemaphore)), VK_OBJECT_TYPE_SEMAPHORE}
+		{ (reinterpret_cast<void*>(m_generalCommandPool)), VK_OBJECT_TYPE_COMMAND_POOL}
+		//{ (reinterpret_cast<void*>(m_uploadBuffer)), VK_OBJECT_TYPE_BUFFER},
+		//{ (reinterpret_cast<void*>(m_uploadBufferMemory)), VK_OBJECT_TYPE_DEVICE_MEMORY},
+		//{ (reinterpret_cast<void*>(m_scratchTimelineSemaphore)), VK_OBJECT_TYPE_SEMAPHORE}
 	};
 };
 

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -785,7 +785,7 @@ public:
 		return vk.SetDebugUtilsObjectNameEXT(device(), &pNameInfo);
 	}
 	
-	inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
+	inline std::optional<VkResult> SetName_impl(const bool cond=false, void ** ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 
 	#define SetName(...) SetName_impl(g_vulkanDebugEXT == true && vulkanDebugExtSupported == true, ## __VA_ARGS__);
@@ -794,8 +794,12 @@ public:
 	#define smark(name) _smark(name)
 	#define lineit_impl(line) line
 	#define lineit(line) lineit_impl(line)
-	#define MARK(name, ...) SetName( reinterpret_cast<void *>(name), reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
-
+	#define _MARK_w_addr(name, ...) SetName( reinterpret_cast<void **>((&(name))), reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
+	#define _MARK(name, ...) SetName( nullptr, reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
+	
+	#define MARK(name, ...) _MARK_w_addr(name, ## __VA_ARGS__)
+	#define MARK_TYPED(name, typeinfo, ...) _MARK(name, typeinfo, ## __VA_ARGS__)
+	
 protected:
 	friend class CVulkanCmdBuffer;
 
@@ -856,27 +860,27 @@ protected:
 	std::vector<std::unique_ptr<CVulkanCmdBuffer>> m_unusedCmdBufs;
 	std::map<uint64_t, std::unique_ptr<CVulkanCmdBuffer>> m_pendingCmdBufs;
 	
-	const std::unordered_map<void *, VkObjectType> typeLookupTable = 
+	const std::unordered_map<void **, VkObjectType> typeLookupTable = 
 	{
-		{ (reinterpret_cast<void*>(m_device)), VK_OBJECT_TYPE_DEVICE},
-		{ (reinterpret_cast<void*>(m_physDev)), VK_OBJECT_TYPE_PHYSICAL_DEVICE},
-		{ (reinterpret_cast<void*>(m_instance)), VK_OBJECT_TYPE_INSTANCE},
-		{ (reinterpret_cast<void*>(m_queue)), VK_OBJECT_TYPE_QUEUE},
-		{ (reinterpret_cast<void*>(m_generalQueue)), VK_OBJECT_TYPE_QUEUE},
-		{ (reinterpret_cast<void*>(m_ycbcrConversion)), VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION},
-		{ (reinterpret_cast<void*>(m_ycbcrSampler)), VK_OBJECT_TYPE_SAMPLER},
-		{ (reinterpret_cast<void*>(m_descriptorSetLayout)), VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT},
-		{ (reinterpret_cast<void*>(m_pipelineLayout)), VK_OBJECT_TYPE_PIPELINE_LAYOUT},
-		{ (reinterpret_cast<void*>(m_descriptorPool)), VK_OBJECT_TYPE_DESCRIPTOR_POOL},
-		{ (reinterpret_cast<void*>(m_commandPool)), VK_OBJECT_TYPE_COMMAND_POOL},
-		{ (reinterpret_cast<void*>(m_generalCommandPool)), VK_OBJECT_TYPE_COMMAND_POOL}
-		//{ (reinterpret_cast<void*>(m_uploadBuffer)), VK_OBJECT_TYPE_BUFFER},
-		//{ (reinterpret_cast<void*>(m_uploadBufferMemory)), VK_OBJECT_TYPE_DEVICE_MEMORY},
-		//{ (reinterpret_cast<void*>(m_scratchTimelineSemaphore)), VK_OBJECT_TYPE_SEMAPHORE}
+		{ (reinterpret_cast<void**>(&m_device)), VK_OBJECT_TYPE_DEVICE},
+		{ (reinterpret_cast<void**>(&m_physDev)), VK_OBJECT_TYPE_PHYSICAL_DEVICE},
+		{ (reinterpret_cast<void**>(&m_instance)), VK_OBJECT_TYPE_INSTANCE},
+		{ (reinterpret_cast<void**>(&m_queue)), VK_OBJECT_TYPE_QUEUE},
+		{ (reinterpret_cast<void**>(&m_generalQueue)), VK_OBJECT_TYPE_QUEUE},
+		{ (reinterpret_cast<void**>(&m_ycbcrConversion)), VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION},
+		{ (reinterpret_cast<void**>(&m_ycbcrSampler)), VK_OBJECT_TYPE_SAMPLER},
+		{ (reinterpret_cast<void**>(&m_descriptorSetLayout)), VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT},
+		{ (reinterpret_cast<void**>(&m_pipelineLayout)), VK_OBJECT_TYPE_PIPELINE_LAYOUT},
+		{ (reinterpret_cast<void**>(&m_descriptorPool)), VK_OBJECT_TYPE_DESCRIPTOR_POOL},
+		{ (reinterpret_cast<void**>(&m_commandPool)), VK_OBJECT_TYPE_COMMAND_POOL},
+		{ (reinterpret_cast<void**>(&m_generalCommandPool)), VK_OBJECT_TYPE_COMMAND_POOL},
+		{ (reinterpret_cast<void**>(&m_uploadBuffer)), VK_OBJECT_TYPE_BUFFER},
+		{ (reinterpret_cast<void**>(&m_uploadBufferMemory)), VK_OBJECT_TYPE_DEVICE_MEMORY},
+		{ (reinterpret_cast<void**>(&m_scratchTimelineSemaphore)), VK_OBJECT_TYPE_SEMAPHORE}
 	};
 };
 
-inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
+inline std::optional<VkResult> SetName_impl(const bool cond=false, void ** ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 struct TextureState
 {

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -773,7 +773,7 @@ public:
 
 	void resetCmdBuffers(uint64_t sequence);
 	
-	std::optional<VkResult> __attribute__((nothrow, no_stack_protector, visibility("protected"))) _SetName(uint64_t objectHandle = NULL, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept
+	std::optional<VkResult> __attribute__((nothrow, no_stack_protector, visibility("protected"))) _SetName(uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept
 	{
 		VkDebugUtilsObjectNameInfoEXT pNameInfo = {
 			.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
@@ -785,7 +785,7 @@ public:
 		return vk.SetDebugUtilsObjectNameEXT(device(), &pNameInfo);
 	}
 	
-	inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = NULL, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
+	inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 
 	#define CONCAT_IMPL( x, y ) x##y
@@ -881,7 +881,7 @@ protected:
 	};
 };
 
-inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = NULL, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
+inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 struct TextureState
 {

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -11,7 +11,7 @@
 #include <bitset>
 #include <mutex>
 #include <optional>
-
+#include <type_traits>
 #include "main.hpp"
 
 #include "shaders/descriptor_set_constants.h"
@@ -773,26 +773,32 @@ public:
 
 	void resetCmdBuffers(uint64_t sequence);
 	
-	std::optional<VkResult> _SetName(const bool cond=false, uint64_t objectHandle = NULL, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr)
+	std::optional<VkResult> __attribute__((nothrow, no_stack_protector, visibility("protected"))) _SetName(uint64_t objectHandle = NULL, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept
 	{
-		if (cond)
-		{
-			VkDebugUtilsObjectNameInfoEXT pNameInfo = {
-				.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
-				.pNext = pNext,
-				.objectType = objectType,
-				.objectHandle = objectHandle,
-				.pObjectName = name 
-			};
-			return vk.SetDebugUtilsObjectNameEXT(device(), &pNameInfo);
-		}
+		VkDebugUtilsObjectNameInfoEXT pNameInfo = {
+			.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
+			.pNext = pNext,
+			.objectType = objectType,
+			.objectHandle = objectHandle,
+			.pObjectName = name 
+		};
+		return vk.SetDebugUtilsObjectNameEXT(device(), &pNameInfo);
 	}
+	
+	inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = NULL, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
-	#define SetName(...) g_device._SetName(g_vulkanDebugEXT == true && vulkanDebugExtSupported == true, __VA_ARGS__)
 
-	#define smark(name) #name
-	#define lineit(line) line
-	#define MARK(name, ...) SetName(name, smark(name lineit((line __LINE__))), __VA_ARGS__)
+	#define CONCAT_IMPL( x, y ) x##y
+	#define MACRO_CONCAT( x, y ) CONCAT_IMPL( x, y )
+
+	#define SetName(...) SetName_impl(g_vulkanDebugEXT == true && vulkanDebugExtSupported == true, ## __VA_ARGS__);
+	
+	#define _smark(name) #name
+	#define smark(name) _smark(name)
+	#define lineit_impl(line) line
+	#define lineit(line) lineit_impl(line)
+	#define MARK(name, ...) SetName( reinterpret_cast<void *>(name), reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
+	#define MARK_TYPED(name, ...) SetName( reinterpret_cast<void *>(name), reinterpret_cast<uint64_t>(name), smark(name lineit((line __LINE__))), ## __VA_ARGS__)
 
 protected:
 	friend class CVulkanCmdBuffer;
@@ -818,6 +824,7 @@ protected:
 	VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
 	VkCommandPool m_commandPool = VK_NULL_HANDLE;
 	VkCommandPool m_generalCommandPool = VK_NULL_HANDLE;
+	
 
 	uint32_t m_queueFamily = -1;
 	uint32_t m_generalQueueFamily = -1;
@@ -853,7 +860,28 @@ protected:
 	std::atomic<uint64_t> m_submissionSeqNo = { 0 };
 	std::vector<std::unique_ptr<CVulkanCmdBuffer>> m_unusedCmdBufs;
 	std::map<uint64_t, std::unique_ptr<CVulkanCmdBuffer>> m_pendingCmdBufs;
+	
+	const std::unordered_map<void *, VkObjectType> typeLookupTable = 
+	{
+		{ (reinterpret_cast<void*>(m_device)), VK_OBJECT_TYPE_DEVICE},
+		{ (reinterpret_cast<void*>(m_physDev)), VK_OBJECT_TYPE_PHYSICAL_DEVICE},
+		{ (reinterpret_cast<void*>(m_instance)), VK_OBJECT_TYPE_INSTANCE},
+		{ (reinterpret_cast<void*>(m_queue)), VK_OBJECT_TYPE_QUEUE},
+		{ (reinterpret_cast<void*>(m_generalQueue)), VK_OBJECT_TYPE_QUEUE},
+		{ (reinterpret_cast<void*>(m_ycbcrConversion)), VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION},
+		{ (reinterpret_cast<void*>(m_ycbcrSampler)), VK_OBJECT_TYPE_SAMPLER},
+		{ (reinterpret_cast<void*>(m_descriptorSetLayout)), VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT},
+		{ (reinterpret_cast<void*>(m_pipelineLayout)), VK_OBJECT_TYPE_PIPELINE_LAYOUT},
+		{ (reinterpret_cast<void*>(m_descriptorPool)), VK_OBJECT_TYPE_DESCRIPTOR_POOL},
+		{ (reinterpret_cast<void*>(m_commandPool)), VK_OBJECT_TYPE_COMMAND_POOL},
+		{ (reinterpret_cast<void*>(m_generalCommandPool)), VK_OBJECT_TYPE_COMMAND_POOL},
+		{ (reinterpret_cast<void*>(m_uploadBuffer)), VK_OBJECT_TYPE_BUFFER},
+		{ (reinterpret_cast<void*>(m_uploadBufferMemory)), VK_OBJECT_TYPE_DEVICE_MEMORY},
+		{ (reinterpret_cast<void*>(m_scratchTimelineSemaphore)), VK_OBJECT_TYPE_SEMAPHORE}
+	};
 };
+
+inline std::optional<VkResult> SetName_impl(const bool cond=false, void * ptr = nullptr, uint64_t objectHandle = NULL, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 struct TextureState
 {

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -16,8 +16,6 @@
 
 #include "shaders/descriptor_set_constants.h"
 
-extern bool g_vulkanDebugEXT;
-
 class CVulkanCmdBuffer;
 
 // 1: Fade Plane (Fade outs between switching focus)
@@ -367,7 +365,7 @@ namespace CompositeDebugFlag
 	static constexpr uint32_t Tonemap_Reinhard = 1u << 7;
 };
 
-VkInstance vulkan_create_instance(void);
+VkInstance vulkan_create_instance(bool bShouldDebug);
 bool vulkan_init(VkInstance instance, VkSurfaceKHR surface);
 bool vulkan_init_formats(void);
 bool vulkan_make_output(VkSurfaceKHR surface);
@@ -788,7 +786,7 @@ public:
 	inline std::optional<VkResult> SetName_impl(const bool cond=false, void ** ptr = nullptr, uint64_t objectHandle = 0, const char * name = nullptr, VkObjectType objectType = VK_OBJECT_TYPE_UNKNOWN, const void * pNext = nullptr) noexcept;
 
 
-	#define SetName(...) SetName_impl(g_vulkanDebugEXT == true && vulkanDebugExtSupported == true, ## __VA_ARGS__);
+	#define SetName(...) SetName_impl(vulkanDebugEXT == true && vulkanDebugExtSupported == true, ## __VA_ARGS__);
 	
 	#define _smark(name) #name
 	#define smark(name) _smark(name)
@@ -859,7 +857,6 @@ protected:
 	std::atomic<uint64_t> m_submissionSeqNo = { 0 };
 	std::vector<std::unique_ptr<CVulkanCmdBuffer>> m_unusedCmdBufs;
 	std::map<uint64_t, std::unique_ptr<CVulkanCmdBuffer>> m_pendingCmdBufs;
-	
 	const std::unordered_map<void **, VkObjectType> typeLookupTable = 
 	{
 		{ (reinterpret_cast<void**>(&m_device)), VK_OBJECT_TYPE_DEVICE},

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6368,6 +6368,9 @@ error(Display *dpy, XErrorEvent *ev)
 [[noreturn]] static void
 steamcompmgr_exit(void)
 {
+	if ( vulkan_run_at_exit != nullptr )
+    		(*vulkan_run_at_exit)();
+
 	g_ImageWaiter.Shutdown();
 
 	// Clean up any commits.
@@ -6388,7 +6391,7 @@ steamcompmgr_exit(void)
 		statsThreadRun = false;
 		statsThreadSem.signal();
 	}
-
+    
     sdlwindow_shutdown();
 
     wlserver_lock();


### PR DESCRIPTION
Utilizes the VK_EXT_debug_utils extension