### PR TITLE
Fix mouse input when cursor is grabbed in nested mode

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -908,6 +908,7 @@ namespace gamescope
 					else if ( event.type == GetUserEventIndex( GAMESCOPE_SDL_EVENT_GRAB ) )
 					{
 						SDL_SetRelativeMouseMode( m_bApplicationGrabbed ? SDL_TRUE : SDL_FALSE );
+						bRelativeMouse = m_bApplicationGrabbed;
 					}
 					else if ( event.type == GetUserEventIndex( GAMESCOPE_SDL_EVENT_CURSOR ) )
 					{


### PR DESCRIPTION
With the refactor in commit 88eb1b4 the `bRelativeMouse` variable didn't get updated anymore when the relative mouse mode was changed, causing the mouse input to get stuck on the borders of the window.

Fixes #1141