### PR TITLE
Fix incorrect casting of HDR metadata blob

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -7833,7 +7833,7 @@ steamcompmgr_main(int argc, char **argv)
 					std::vector<uint32_t> app_hdr_metadata_blob;
 					app_hdr_metadata_blob.resize((sizeof(hdr_metadata_infoframe) + (sizeof(uint32_t) - 1)) / sizeof(uint32_t));
 					memset(app_hdr_metadata_blob.data(), 0, sizeof(uint32_t) * app_hdr_metadata_blob.size());
-					memcpy(app_hdr_metadata_blob.data(), &app_hdr_metadata->View<hdr_metadata_infoframe>(), sizeof(hdr_metadata_infoframe));
+					memcpy(app_hdr_metadata_blob.data(), &app_hdr_metadata->View<hdr_output_metadata>().hdmi_metadata_type1, sizeof(hdr_metadata_infoframe));
 
 					XChangeProperty(root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeColorAppHDRMetadataFeedback, XA_CARDINAL, 32, PropModeReplace,
 							(unsigned char *)app_hdr_metadata_blob.data(), (int)app_hdr_metadata_blob.size() );


### PR DESCRIPTION
`hdr_metadata_blob` is stored in a `BackendBlob` as a `hdr_output_metadata` here:
https://github.com/ValveSoftware/gamescope/blob/master/src/wlserver.cpp#L772
..but is later retrieved as a `hdr_metadata_infoframe` here:
https://github.com/ValveSoftware/gamescope/blob/master/src/steamcompmgr.cpp#L7836

This causes the `memcpy` to fail with an assert, as the data is not of the expected size. Casting to the correct `hdr_output_metadata` and then passing the `hdr_metadata_infoframe` from the `hdmi_metadata_type` member fixes the copy.

This fixes a crash in Control Ultimate Edition (870780), but the issue only presents itself with the unofficial patch that is available here: https://community.pcgamingwiki.com/files/file/2581-control-hdrultrawidedlssrt-patch/, although I'd expect all games that send valid HDR metadata would hit this issue.