### PR TITLE
src/meson: include protocols_client_src

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -133,6 +133,7 @@ gamescope_cpp_args += '-DHAVE_LIBCAP=@0@'.format(cap_dep.found().to_int())
 
 src += spirv_shaders
 src += protocols_server_src
+src += protocols_client_src
 
 if pipewire_dep.found()
   src += 'pipewire.cpp'


### PR DESCRIPTION
### What?

Includes `protocols_client_src` when building gamescope's executable

### Why?

The new `wayland_backend.c` needs `xdg-shell-client-protocol.{c,h}` to build.