### PR TITLE
Add support for commit-timing-v1

### DIFF
--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -19,6 +19,7 @@ protocols = [
 	wl_protocol_dir / 'staging/single-pixel-buffer/single-pixel-buffer-v1.xml',
 	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
 	wl_protocol_dir / 'unstable/relative-pointer/relative-pointer-unstable-v1.xml',
+	wl_protocol_dir / 'staging/commit-timing/commit-timing-v1.xml',
 
 	# Frog protocols
 	'frog-color-management-v1.xml',

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4368,6 +4368,13 @@ unmap_win(xwayland_ctx_t *ctx, Window id, bool fade)
 		return;
 	w->xwayland().a.map_state = IsUnmapped;
 
+	if (w->xwayland().surface.wl_id)
+	{
+		struct wlr_output *output = ctx->xwayland_server->get_output();
+		struct wlr_surface *surface = w->xwayland().surface.current_surface();
+		ctx->xwayland_server->surface_leave_output(surface);
+	}
+
 	focusDirty = true;
 
 	finish_unmap_win(ctx, w);
@@ -4854,6 +4861,12 @@ handle_wl_surface_id(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, uint32_t surfac
 
 	if ( w == keyboardFocusWindow )
 		wlserver_keyboardfocus( main_surface );
+
+	if (w->xwayland().a.map_state == IsViewable)
+	{
+		struct wlr_output *output = ctx->xwayland_server->get_output();
+		ctx->xwayland_server->surface_enter_output(main_surface);
+	}
 
 	// Pull the first buffer out of that window, if needed
 	xwayland_surface_commit( current_surface );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2720,6 +2720,7 @@ paint_all(bool async)
 		}
 	}
 
+	wlserver_output_commit();
 	if ( GetBackend()->Present( &frameInfo, async ) != 0 )
 	{
 		return;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2450,3 +2450,11 @@ void wlserver_destroy_xwayland_server(gamescope_xwayland_server_t *server)
 
 	std::erase_if(wlserver.wlr.xwayland_servers, [=](const auto& other) { return other.get() == server; });
 }
+
+void wlserver_output_commit()
+{
+	gamescope_xwayland_server_t *server = wlserver.wlr.xwayland_servers[0].get();
+	struct wlr_output *output = server->get_output();
+	wlr_headless_output_set_vblank_phase(wlserver.wlr.headless_backend, output, g_SteamCompMgrVBlankTime.schedule.ulTargetVBlank);
+	wlr_output_commit(output);
+}

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1523,6 +1523,16 @@ gamescope_xwayland_server_t::~gamescope_xwayland_server_t()
 	wlr_output_destroy(output);
 }
 
+void gamescope_xwayland_server_t::surface_enter_output(struct wlr_surface *surface)
+{
+	wlr_surface_send_enter(surface, output);
+}
+
+void gamescope_xwayland_server_t::surface_leave_output(struct wlr_surface *surface)
+{
+	wlr_surface_send_leave(surface, output);
+}
+
 void gamescope_xwayland_server_t::update_output_info()
 {
 	const auto *info = &wlserver.output_info;
@@ -1544,16 +1554,24 @@ static void xdg_toplevel_map(struct wl_listener *listener, void *data) {
 	struct wlserver_xdg_surface_info* info =
 		wl_container_of(listener, info, map);
 
+	gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(0);
+	struct wlr_output *output = server->get_output();
+
 	info->mapped = true;
 	wlserver.xdg_dirty = true;
+	wlr_surface_send_enter(info->current_surface(), output);
 }
 
 static void xdg_toplevel_unmap(struct wl_listener *listener, void *data) {
 	struct wlserver_xdg_surface_info* info =
 		wl_container_of(listener, info, unmap);
 
+	gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(0);
+	struct wlr_output *output = server->get_output();
+
 	info->mapped = false;
 	wlserver.xdg_dirty = true;
+	wlr_surface_send_leave(info->current_surface(), output);
 }
 
 static void xdg_toplevel_destroy(struct wl_listener *listener, void *data) {

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -82,6 +82,9 @@ public:
 
 	void update_output_info();
 
+	void surface_enter_output(struct wlr_surface *surface);
+	void surface_leave_output(struct wlr_surface *surface);
+
 private:
 	struct wlr_xwayland_server *xwayland_server = NULL;
 	struct wl_listener xwayland_ready_listener = { .notify = xwayland_ready_callback };

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -115,6 +115,9 @@ struct wlserver_t {
 		struct wlr_session *session;
 		struct wlr_seat *seat;
 
+		struct wlr_timing_manager *timing_manager;
+		struct wl_listener new_commit_timer;
+
 		// Used to simulate key events and set the keymap
 		struct wlr_keyboard *virtual_keyboard_device;
 
@@ -256,6 +259,7 @@ struct wlserver_wl_surface_info
 	std::vector<struct wl_resource *> gamescope_swapchains;
 	std::optional<uint32_t> present_id = std::nullopt;
 	uint64_t desired_present_time = 0;
+	struct wl_listener timestamp;
 
 	uint64_t last_refresh_cycle = 0;
 };

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -283,3 +283,5 @@ void wlserver_send_gamescope_control( wl_resource *control );
 bool wlsession_active();
 
 void wlserver_mousewheel2( int32_t nDiscreteX, int32_t nDiscreteY, double flX, double flY, uint32_t uTime );
+
+void wlserver_output_commit();


### PR DESCRIPTION
In the same spirit as [!1026 ](https://github.com/ValveSoftware/gamescope/pull/1026), this is the WIP to add support for using wlroots' implementation of the commit-timing-v1 protocol.

wlroots implementation: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4617
protocol proposal: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/248