### PR TITLE
Workaround steam overlay's issues with attaching to wayland windows to allow steam overlay/input in nested mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,6 +116,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "debug-hud", no_argument, nullptr, 'v' },
 	{ "debug-events", no_argument, nullptr, 0 },
 	{ "steam", no_argument, nullptr, 'e' },
+	{ "overlay-workaround", no_argument, nullptr, 0 },
 	{ "force-composition", no_argument, nullptr, 'c' },
 	{ "composite-debug", no_argument, nullptr, 0 },
 	{ "disable-xres", no_argument, nullptr, 'x' },
@@ -168,6 +169,7 @@ const char usage[] =
 	"  -T, --stats-path               write statistics to path\n"
 	"  -C, --hide-cursor-delay        hide cursor image after delay\n"
 	"  -e, --steam                    enable Steam integration\n"
+	"  --overlay-workaround           workaround steam overlay's issues with wayland by allowing the overlay attach to the game rather than gamescope\n"
 	"  --xwayland-count               create N xwayland servers\n"
 	"  --prefer-vk-device             prefer Vulkan device for compositing (ex: 1002:7300)\n"
 	"  --force-orientation            rotate the internal display (left, right, normal, upsidedown)\n"

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1097,6 +1097,7 @@ static bool		debugFocus = false;
 static bool		drawDebugInfo = false;
 static bool		debugEvents = false;
 bool			steamMode = false;
+bool 			overlayWorkaround = false;
 bool		alwaysComposite = false;
 static bool		useXRes = true;
 
@@ -7419,6 +7420,8 @@ steamcompmgr_main(int argc, char **argv)
 					debugFocus = true;
 				} else if (strcmp(opt_name, "synchronous-x11") == 0) {
 					synchronize = true;
+				} else if (strcmp(opt_name, "overlay-workaround") == 0) {
+					overlayWorkaround = true;
 				} else if (strcmp(opt_name, "debug-events") == 0) {
 					debugEvents = true;
 				} else if (strcmp(opt_name, "cursor") == 0) {

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6541,6 +6541,10 @@ spawn_client( char **argv, bool bAsyncChild )
 	const char *pchCurrentPreload = getenv( "LD_PRELOAD" );
 	bool bFirst = true;
 
+	if( overlayWorkaround ){
+		xwm_log.debugf( "Working around steam overlay" );
+	}
+
 	if ( pchCurrentPreload != nullptr )
 	{
 		pchPreloadCopy = strdup( pchCurrentPreload );
@@ -6561,7 +6565,7 @@ spawn_client( char **argv, bool bAsyncChild )
 			// If there's a string and it's not gameoverlayrenderer, append it to our new LD_PRELOAD
 			if ( pchPreloadCopy[ i ] != '\0' )
 			{
-				if ( strstr( pchPreloadCopy + i, "gameoverlayrenderer.so" ) == nullptr )
+				if ( overlayWorkaround || strstr( pchPreloadCopy + i, "gameoverlayrenderer.so" ) == nullptr )
 				{
 					if ( bFirst == false )
 					{


### PR DESCRIPTION
It is a very hacky solution but is only needed until valve fixes steam overly to properly work on wayland windows. See #1225 for more info