### PR TITLE
drm: Reset drm properties when quitting

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -389,7 +389,7 @@ struct fb {
 struct drm_t {
 	bool bUseLiftoff;
 
-	int fd;
+	int fd = -1;
 
 	int preferred_width, preferred_height, preferred_refresh;
 
@@ -3060,6 +3060,8 @@ namespace gamescope
 
 		virtual ~CDRMBackend()
 		{
+			if ( g_DRM.fd != -1 )
+				finish_drm( &g_DRM );
 		}
 
 		virtual bool Init() override


### PR DESCRIPTION
gamescope sets a variety of DRM properties that Xorg is unaware of and those properties can make atomic commits fail depending on the state that Xorg proposes.

This change makes gamescope reset some of the drm properties when it quits to prevent Xorg from breaking.