### PR TITLE
all: teardown backend on exit

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -167,6 +167,7 @@ namespace gamescope
 
         virtual bool Init() = 0;
         virtual bool PostInit() = 0;
+        virtual void Finish() = 0;
         virtual std::span<const char *const> GetInstanceExtensions() const = 0;
         virtual std::span<const char *const> GetDeviceExtensions( VkPhysicalDevice pVkPhysicalDevice ) const = 0;
         virtual VkImageLayout GetPresentLayout() const = 0;

--- a/src/headless.cpp
+++ b/src/headless.cpp
@@ -135,6 +135,10 @@ namespace gamescope
 			return true;
 		}
 
+		virtual void Finish() override
+		{
+		}
+
         virtual std::span<const char *const> GetInstanceExtensions() const override
 		{
 			return std::span<const char *const>{};

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -118,6 +118,7 @@ namespace gamescope
 
 		virtual bool Init() override;
 		virtual bool PostInit() override;
+		virtual void Finish() override;
 		virtual std::span<const char *const> GetInstanceExtensions() const override;
 		virtual std::span<const char *const> GetDeviceExtensions( VkPhysicalDevice pVkPhysicalDevice ) const override;
 		virtual VkImageLayout GetPresentLayout() const override;
@@ -333,6 +334,10 @@ namespace gamescope
 	bool CSDLBackend::PostInit()
 	{
 		return true;
+	}
+
+	void CSDLBackend::Finish()
+	{
 	}
 
 	std::span<const char *const> CSDLBackend::GetInstanceExtensions() const

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6045,6 +6045,7 @@ steamcompmgr_exit(void)
 	}
 
     //sdlwindow_shutdown();
+	GetBackend()->Finish();
 
     wlserver_lock();
     wlserver_force_shutdown();

--- a/src/vr_session.cpp
+++ b/src/vr_session.cpp
@@ -387,6 +387,10 @@ namespace gamescope
             return true;
 		}
 
+        virtual void Finish() override
+		{
+		}
+
         virtual std::span<const char *const> GetInstanceExtensions() const override
 		{
             static std::vector<std::string> s_exts;

--- a/src/wayland_backend.cpp
+++ b/src/wayland_backend.cpp
@@ -454,6 +454,7 @@ namespace gamescope
 
         virtual bool Init() override;
         virtual bool PostInit() override;
+        virtual void Finish() override;
         virtual std::span<const char *const> GetInstanceExtensions() const override;
         virtual std::span<const char *const> GetDeviceExtensions( VkPhysicalDevice pVkPhysicalDevice ) const override;
         virtual VkImageLayout GetPresentLayout() const override;
@@ -1242,6 +1243,10 @@ namespace gamescope
             this->SetRelativeMouseMode( true );
 
         return true;
+    }
+
+    void CWaylandBackend::Finish()
+    {
     }
 
     std::span<const char *const> CWaylandBackend::GetInstanceExtensions() const


### PR DESCRIPTION
Gives backends a shutdown call when exiting and hook up `finish_drm()` so that subsequent sessions (e.g.  X11 etc) work properly.

drm's Finish() waits for the page flip thread so that it can close the drm fd but it looks like wlserver wants to do that anyway.