### PR TITLE
fixup: add input_emulation to meson options and clean up src/meson.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If running RadeonSI clients with older cards (GFX8 and below), currently have to
 git submodule update --init
 meson build/
 ninja -C build/
-build/gamescope -- <game>
+build/src/gamescope -- <game>
 ```
 
 Install with:

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,7 @@ option('rt_cap',                     type: 'feature', description: 'Support for 
 option('drm_backend',                type: 'feature', description: 'DRM Atomic Backend')
 option('sdl2_backend',               type: 'feature', description: 'SDL2 Window Backend')
 option('avif_screenshots',           type: 'feature', description: 'Support for saving .AVIF HDR screenshots')
+option('input_emulation',            type: 'feature', description: 'Support for xtest emulation with libei')
 option('enable_gamescope',           type : 'boolean', value : true, description: 'Build Gamescope executable')
 option('enable_gamescope_wsi_layer', type : 'boolean', value : true, description: 'Build Gamescope layer')
 option('enable_openvr_support',      type : 'boolean', value : true, description: 'OpenVR Integrations')

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,7 +11,7 @@ dep_xmu = dependency('xmu')
 dep_xi = dependency('xi')
 
 drm_dep = dependency('libdrm', version: '>= 2.4.113', required: get_option('drm_backend'))
-eis_dep = dependency('libeis-1.0', required : get_option('input_emulation'))
+eis_dep = dependency('libeis-1.0', required: get_option('input_emulation'))
 
 wayland_server = dependency('wayland-server', version: '>=1.21')
 wayland_protos = dependency('wayland-protocols', version: '>=1.17')


### PR DESCRIPTION
fixes build after 83fdf46c616f48478f1888f585d695a5939dc274 by adding input_emulation to meson_options and fixing up a minor typo in src/meson.build