### PR TITLE
feat: Tap-to-click, natural scrolling and more. Add `libinput` pointer settings.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,6 +144,12 @@ const struct option *gamescope_options = (struct option[]){
 	// Steam Deck options
 	{ "mura-map", required_argument, nullptr, 0 },
 
+	// Pointer options
+	{ "tap-to-click", no_argument, nullptr, 0 },
+	{ "tap-to-drag", no_argument, nullptr, 0 },
+	{ "drag-lock", no_argument, nullptr, 0 },
+	{ "natural-scrolling", required_argument, nullptr, 0 },
+
 	{} // keep last
 };
 
@@ -255,6 +261,16 @@ const char usage[] =
 	"Steam Deck options:\n"
 	"  --mura-map                     Set the mura compensation map to use for the display. Takes in a path to the mura map.\n"
 	"\n"
+	"Libinput Pointer options:\n"
+	"  --tap-to-click                 enable tap-to-click feature for pointer devices\n"
+	"  --tap-and-drag                 enable tap-and-drag feature for pointer devices\n"
+	"  --drag-lock                    enable drag-lock feature for pointer devices\n"
+	"  --natural-scrolling            enable natural scrolling for ...\n"
+	"                                     none => No pointer device\n"
+	"                                     touchpad => Only for touchpad\n"
+	"                                     mouse => Only for mouse\n"
+	"                                     all => All pointer device\n"
+	"\n"
 	"Keyboard shortcuts:\n"
 	"  Super + F                      toggle fullscreen\n"
 	"  Super + N                      toggle nearest neighbour filtering\n"
@@ -311,6 +327,11 @@ float g_flMaxWindowScale = FLT_MAX;
 
 uint32_t g_preferVendorID = 0;
 uint32_t g_preferDeviceID = 0;
+
+bool g_tapToClick = false;
+bool g_tapAndDrag = false;
+bool g_dragLock = false;
+SelectedPointerType g_naturalScrolling = SelectedPointerType::NONE;
 
 pthread_t g_mainThread;
 
@@ -427,6 +448,25 @@ static enum gamescope::GamescopeBackend parse_backend_name(const char *str)
 	} else {
 		fprintf( stderr, "gamescope: invalid value for --backend\n" );
 		exit(1);
+	}
+}
+
+static SelectedPointerType parse_natural_scrolling(const char *str)
+{
+	if (!str || !*str) {
+		return SelectedPointerType::NONE;
+	}
+	if (!strcmp(str, "all")) {
+		return SelectedPointerType::ALL;
+	} else if (!strcmp(str, "touchpad")) {
+		return SelectedPointerType::TOUCHPAD;
+	} else if (!strcmp(str, "mouse")) {
+		return SelectedPointerType::MOUSE;
+	} else if (!strcmp(str, "none")) {
+		return SelectedPointerType::NONE;
+	} else {
+		fprintf( stderr, "gamescope: invalid value for --natural-scrolling\n" );
+		return SelectedPointerType::NONE;
 	}
 }
 
@@ -806,6 +846,14 @@ int main(int argc, char **argv)
 					g_nCursorScaleHeight = atoi(optarg);
 				} else if (strcmp(opt_name, "mangoapp") == 0) {
 					g_bLaunchMangoapp = true;
+				} else if (strcmp(opt_name, "tap-to-click") == 0) {
+					g_tapToClick = true;
+				} else if (strcmp(opt_name, "tap-and-drag") == 0) {
+					g_tapAndDrag = true;
+				} else if (strcmp(opt_name, "drag-lock") == 0) {
+					g_dragLock = true;
+				} else if (strcmp(opt_name, "natural-scrolling") == 0) {
+					g_naturalScrolling = parse_natural_scrolling( optarg );
 				}
 				break;
 			case '?':

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -72,4 +72,17 @@ extern int g_nXWaylandCount;
 extern uint32_t g_preferVendorID;
 extern uint32_t g_preferDeviceID;
 
+enum class SelectedPointerType : uint32_t
+{
+    NONE,
+    TOUCHPAD,
+    MOUSE,
+    ALL,
+};
+
+extern bool g_tapToClick;
+extern bool g_tapAndDrag;
+extern bool g_dragLock;
+extern SelectedPointerType g_naturalScrolling;
+
 void restore_fd_limit( void );

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -484,6 +484,48 @@ static void wlserver_handle_touch_motion(struct wl_listener *listener, void *dat
 	wlserver_touchmotion( event->x, event->y, event->touch_id, event->time_msec );
 }
 
+static void wlserver_set_libinput_pointer(struct wlr_input_device *device)
+{
+#ifdef HAVE_DRM
+	if (device->type != WLR_INPUT_DEVICE_POINTER || !wlr_input_device_is_libinput(device))
+		return;
+
+	struct libinput_device* libinput_device = wlr_libinput_get_device_handle(device);
+
+	if (g_tapToClick)
+		libinput_device_config_tap_set_enabled(libinput_device, LIBINPUT_CONFIG_TAP_ENABLED);
+	else
+		libinput_device_config_tap_set_enabled(libinput_device, LIBINPUT_CONFIG_TAP_DISABLED);
+
+	if (g_tapAndDrag)
+		libinput_device_config_tap_set_drag_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_ENABLED);
+	else
+		libinput_device_config_tap_set_drag_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_DISABLED);
+
+	if (g_dragLock)
+		libinput_device_config_tap_set_drag_lock_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_LOCK_ENABLED);
+	else
+		libinput_device_config_tap_set_drag_lock_enabled(libinput_device, LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
+	
+	if (libinput_device_config_scroll_has_natural_scroll(libinput_device) != 0)
+		switch (g_naturalScrolling)
+		{
+		case SelectedPointerType::TOUCHPAD:
+			if (libinput_device_config_tap_get_finger_count(libinput_device) != 0)
+				libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, true);
+			break;
+		case SelectedPointerType::MOUSE:
+			if (libinput_device_config_tap_get_finger_count(libinput_device) == 0)
+				libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, true);
+			break;
+		case SelectedPointerType::ALL:
+			libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, true);
+		case SelectedPointerType::NONE:
+			break;
+		}
+#endif
+}
+
 static void wlserver_new_input(struct wl_listener *listener, void *data)
 {
 	struct wlr_input_device *device = (struct wlr_input_device *) data;
@@ -534,6 +576,8 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 			wl_signal_add( &pointer->wlr->events.axis, &pointer->axis);
 			pointer->frame.notify = wlserver_handle_pointer_frame;
 			wl_signal_add( &pointer->wlr->events.frame, &pointer->frame);
+
+			wlserver_set_libinput_pointer(device);
 		}
 		break;
 		case WLR_INPUT_DEVICE_TOUCH:


### PR DESCRIPTION
For better experience, I added these useful parameters to change libinput pointer configs:
- `--tap-to-click`                 enable tap-to-click feature for pointer devices
- `--tap-and-drag`                 enable tap-and-drag feature for pointer devices
- `--drag-lock`                    enable drag-lock feature for pointer devices
- `--natural-scrolling`            enable natural scrolling for ...
  - `none` => No pointer device
  - `touchpad` => Only for touchpad
  - `mouse` => Only for mouse
  - `all` => All pointer device

Btw, there are plenty of configurable things for libinput, should these options become a config file or sth else for setting up easily? (Ref. [libinput document](https://wayland.freedesktop.org/libinput/doc/latest/configuration.html))