### PR TITLE
wlserver: fix exit segfault

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -88,6 +88,8 @@ std::mutex g_wlserver_xdg_shell_windows_lock;
 
 static struct wl_list pending_surfaces = {0};
 
+static std::atomic<bool> g_bShutdownWLServer{ false };
+
 static void wlserver_x11_surface_info_set_wlr( struct wlserver_x11_surface_info *surf, struct wlr_surface *wlr_surf, bool override );
 wlserver_wl_surface_info *get_wl_surface_info(struct wlr_surface *wlr_surf);
 
@@ -1363,6 +1365,9 @@ static bool filter_global(const struct wl_client *client, const struct wl_global
 		return false;
 	}
 
+	if (g_bShutdownWLServer)
+		return false;
+
 	/* We create one wl_output global per Xwayland server, to easily have
 	 * per-server output configuration. Only expose the wl_output belonging to
 	 * the server. */
@@ -1831,7 +1836,6 @@ void wlserver_unlock(bool flush)
 extern std::mutex g_SteamCompMgrXWaylandServerMutex;
 
 static int g_wlserverNudgePipe[2] = {-1, -1};
-static std::atomic<bool> g_bShutdownWLServer{ false };
 
 void wlserver_run(void)
 {


### PR DESCRIPTION
Don't access xwayland_servers vector in global filter while clearing the vector.

Avoids a segfault due to
```
(gdb) bt
#0  gamescope_xwayland_server_t::get_client (this=0x55c403edfcb0) at ../src/wlserver.cpp:753
#1  filter_global (client=0x55c40417a3b0, global=0x55c4040ba230, data=<optimized out>) at ../src/wlserver.cpp:1371
#2  0x00007f1ce72ba750 in wl_global_remove () at /usr/lib/libwayland-server.so.0
#3  0x000055c4024b7ad7 in wlr_global_destroy_safe (global=0x55c4040ba230) at ../subprojects/wlroots/util/global.c:35
#4  0x000055c4024aada0 in wlr_output_destroy_global (output=output@entry=0x55c404101ef0) at ../subprojects/wlroots/types/output/output.c:166
#5  0x000055c4024aae30 in wlr_output_destroy_global (output=0x55c404101ef0) at ../subprojects/wlroots/types/output/output.c:151
#6  wlr_output_destroy (output=0x55c404101ef0) at ../subprojects/wlroots/types/output/output.c:390
#7  0x000055c402401fbf in gamescope_xwayland_server_t::~gamescope_xwayland_server_t (this=0x55c403c0bea0, this=<optimized out>) at ../src/wlserver.cpp:1512
#8  std::default_delete<gamescope_xwayland_server_t>::operator()(gamescope_xwayland_server_t*) const [clone .part.0] [clone .lto_priv.0] (__ptr=0x55c403c0bea0, this=<optimized out>) at /usr/include/c++/13.2.1/bits/unique_ptr.h:99
#9  0x000055c4023a734c in std::default_delete<gamescope_xwayland_server_t>::operator() (__ptr=<optimized out>, this=<optimized out>) at /usr/include/c++/13.2.1/bits/unique_ptr.h:93
#10 std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> >::~unique_ptr (this=0x55c404012de8, this=<optimized out>) at /usr/include/c++/13.2.1/bits/unique_ptr.h:404
#11 std::destroy_at<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> > > (__location=0x55c404012de8) at /usr/include/c++/13.2.1/bits/stl_construct.h:88
#12 std::_Destroy<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> > > (__pointer=0x55c404012de8) at /usr/include/c++/13.2.1/bits/stl_construct.h:149
#13 std::_Destroy_aux<false>::__destroy<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> >*> (__last=<optimized out>, __first=0x55c404012de8) at /usr/include/c++/13.2.1/bits/stl_construct.h:163
#14 std::_Destroy<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> >*> (__last=<optimized out>, __first=<optimized out>) at /usr/include/c++/13.2.1/bits/stl_construct.h:196
#15 std::_Destroy<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> >*, std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> > > (__last=<optimized out>, __first=<optimized out>) at /usr/include/c++/13.2.1/bits/alloc_traits.h:948
#16 std::vector<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> >, std::allocator<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> > > >::_M_erase_at_end (__pos=0x55c404012de0, this=<optimized out>)
    at /usr/include/c++/13.2.1/bits/stl_vector.h:1937
#17 std::vector<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> >, std::allocator<std::unique_ptr<gamescope_xwayland_server_t, std::default_delete<gamescope_xwayland_server_t> > > >::clear (this=<optimized out>) at /usr/include/c++/13.2.1/bits/stl_vector.h:1606
#18 wlserver_run () at ../src/wlserver.cpp:1906
#19 main (argc=<optimized out>, argv=<optimized out>) at ../src/main.cpp:924


(gdb) p xwayland_server
$3 = (wlr_xwayland_server *) 0x5a8c9dd18e91a82c
(gdb) up
#1  filter_global (client=0x55c40417a3b0, global=0x55c4040ba230, data=<optimized out>) at ../src/wlserver.cpp:1371
(gdb) p i
$4 = 0
(gdb) p server
$5 = (gamescope_xwayland_server_t *) 0x55c403edfcb0

```