### PR TITLE
steamcompmgr, wlserver: fix bad variant access kerfuffle ([maybe] fixes #1286)

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1639,6 +1639,8 @@ void xdg_surface_new(struct wl_listener *listener, void *data)
 			it++;
 		}
 	}
+		
+	wlr_xdg_surface_get_geometry(xdg_surface, &(window->xdg().geometry));
 }
 
 #if HAVE_LIBEIS


### PR DESCRIPTION
To simplify things, I just added a `struct wlr_box geometry` member directly to the `steamcompmgr_win_t` struct that holds the position and width & height.
 
This does add 128bits to the `steamcompmgr_win_t` struct, so I reordered the struct members in a slightly more space-efficient way, which will hopefully balance things out.

Note that this currently only updates the `geometry` member when adding a new xwayland window or new xdg surface.
IDK where else `recordWinGeometryInfo(auto&)` would need to be called, so any help on that would be appreciated.

Haven't tested this PR, only checked if it could compile...

PS: `g_ctx` in steamcompmgr.cpp doesn't seem to do anything...