### PR TITLE
Fix `sdl2_backend=disabled`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -834,8 +834,10 @@ int main(int argc, char **argv)
 
 		case gamescope::GamescopeBackend::Wayland:
 			gamescope::IBackend::Set<gamescope::CWaylandBackend>();
+#if HAVE_SDL2
 			if ( !GetBackend() )
 				gamescope::IBackend::Set<gamescope::CSDLBackend>();
+#endif
 			break;
 		default:
 			abort();

--- a/src/meson.build
+++ b/src/meson.build
@@ -108,6 +108,7 @@ src = [
   'mangoapp.cpp',
   'reshade_effect_manager.cpp',
   'backend.cpp',
+  'x11cursor.cpp',
   'wayland_backend.cpp',
   'InputEmulation.cpp',
 ]

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -28,7 +28,6 @@ static bool g_bWindowFocused = true;
 static int g_nOutputWidthPts = 0;
 static int g_nOutputHeightPts = 0;
 
-extern const char *g_pOriginalDisplay;
 extern bool g_bForceHDR10OutputDebug;
 extern bool steamMode;
 extern bool g_bFirstFrame;
@@ -37,6 +36,8 @@ extern int g_nPreferredOutputHeight;
 
 namespace gamescope
 {
+	extern std::shared_ptr<INestedHints::CursorInfo> GetX11HostCursor();
+
 	enum class SDLInitState
 	{
 		SDLInit_Waiting,
@@ -494,49 +495,6 @@ namespace gamescope
 	{
 		m_pApplicationIcon = uIconPixels;
 		PushUserEvent( GAMESCOPE_SDL_EVENT_ICON );
-	}
-
-	std::shared_ptr<INestedHints::CursorInfo> GetX11HostCursor()
-	{
-		if ( !g_pOriginalDisplay )
-			return nullptr;
-
-		Display *display = XOpenDisplay( g_pOriginalDisplay );
-		if ( !display )
-			return nullptr;
-		defer( XCloseDisplay( display ) );
-
-		int xfixes_event, xfixes_error;
-		if ( !XFixesQueryExtension( display, &xfixes_event, &xfixes_error ) )
-		{
-			xwm_log.errorf("No XFixes extension on current compositor");
-			return nullptr;
-		}
-
-		XFixesCursorImage *image = XFixesGetCursorImage( display );
-		if ( !image )
-			return nullptr;
-		defer( XFree( image ) );
-
-		// image->pixels is `unsigned long*` :/
-		// Thanks X11.
-		std::vector<uint32_t> cursorData = std::vector<uint32_t>( image->width * image->height );
-		for (uint32_t y = 0; y < image->height; y++)
-		{
-			for (uint32_t x = 0; x < image->width; x++)
-			{
-				cursorData[y * image->width + x] = static_cast<uint32_t>( image->pixels[image->height * y + x] );
-			}
-		}
-
-		return std::make_shared<INestedHints::CursorInfo>(INestedHints::CursorInfo
-		{
-			.pPixels   = std::move( cursorData ),
-			.uWidth    = image->width,
-			.uHeight   = image->height,
-			.uXHotspot = image->xhot,
-			.uYHotspot = image->yhot,
-		});
 	}
 
 	std::shared_ptr<INestedHints::CursorInfo> CSDLBackend::GetHostCursor()

--- a/src/x11cursor.cpp
+++ b/src/x11cursor.cpp
@@ -1,0 +1,53 @@
+#include <memory>
+#include <X11/extensions/Xfixes.h>
+#include "backend.h"
+#include "defer.hpp"
+#include "xwayland_ctx.hpp"
+
+extern const char *g_pOriginalDisplay;
+
+namespace gamescope
+{
+	std::shared_ptr<INestedHints::CursorInfo> GetX11HostCursor()
+	{
+		if ( !g_pOriginalDisplay )
+			return nullptr;
+
+		Display *display = XOpenDisplay( g_pOriginalDisplay );
+		if ( !display )
+			return nullptr;
+		defer( XCloseDisplay( display ) );
+
+		int xfixes_event, xfixes_error;
+		if ( !XFixesQueryExtension( display, &xfixes_event, &xfixes_error ) )
+		{
+			xwm_log.errorf("No XFixes extension on current compositor");
+			return nullptr;
+		}
+
+		XFixesCursorImage *image = XFixesGetCursorImage( display );
+		if ( !image )
+			return nullptr;
+		defer( XFree( image ) );
+
+		// image->pixels is `unsigned long*` :/
+		// Thanks X11.
+		std::vector<uint32_t> cursorData = std::vector<uint32_t>( image->width * image->height );
+		for (uint32_t y = 0; y < image->height; y++)
+		{
+			for (uint32_t x = 0; x < image->width; x++)
+			{
+				cursorData[y * image->width + x] = static_cast<uint32_t>( image->pixels[image->height * y + x] );
+			}
+		}
+
+		return std::make_shared<INestedHints::CursorInfo>(INestedHints::CursorInfo
+		{
+			.pPixels   = std::move( cursorData ),
+			.uWidth    = image->width,
+			.uHeight   = image->height,
+			.uXHotspot = image->xhot,
+			.uYHotspot = image->yhot,
+		});
+	}
+}


### PR DESCRIPTION
Fix broken build with `sdl2_backend=disabled`. See #1347.

* main: add missing condition in the Wayland fallback.
* sdlwindow: move out `GetX11HostCursor()` into a separate file.
* build: add `x11cursor.cpp`.
