### PR TITLE
main: hide disabled backends from user

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,8 +162,12 @@ const char usage[] =
 	"  -s, --mouse-sensitivity        multiply mouse movement by given decimal number\n"
 	"  --backend                      select rendering backend\n"
 	"                                     auto => autodetect (default)\n"
+#if HAVE_DRM
 	"                                     drm => use DRM backend (standalone display session)\n"
+#endif
+#if HAVE_SDL2
 	"                                     sdl => use SDL backend\n"
+#endif
 #if HAVE_OPENVR
 	"                                     openvr => use OpenVR backend (outputs as a VR overlay)\n"
 #endif
@@ -399,10 +403,14 @@ static enum gamescope::GamescopeBackend parse_backend_name(const char *str)
 {
 	if (strcmp(str, "auto") == 0) {
 		return gamescope::GamescopeBackend::Auto;
+#if HAVE_DRM
 	} else if (strcmp(str, "drm") == 0) {
 		return gamescope::GamescopeBackend::DRM;
+#endif
+#if HAVE_SDL2
 	} else if (strcmp(str, "sdl") == 0) {
 		return gamescope::GamescopeBackend::SDL;
+#endif
 #if HAVE_OPENVR
 	} else if (strcmp(str, "openvr") == 0) {
 		return gamescope::GamescopeBackend::OpenVR;


### PR DESCRIPTION
Follow up for #1321.
DRM and SDL2 backends could be disabled by build options. So we hide them from user in that case.