### PR TITLE
Apply wayland display scaling to cursor position

### DIFF
--- a/src/wayland_backend.cpp
+++ b/src/wayland_backend.cpp
@@ -2265,8 +2265,10 @@ namespace gamescope
         if ( !oState )
             return;
 
-        double flX = ( wl_fixed_to_double( fSurfaceX ) + oState->nDestX ) / g_nOutputWidth;
-        double flY = ( wl_fixed_to_double( fSurfaceY ) + oState->nDestY ) / g_nOutputHeight;
+        auto scale = m_pCurrentCursorPlane->GetScale() / 120.;
+		
+        double flX = ( wl_fixed_to_double( fSurfaceX ) * scale + oState->nDestX ) / g_nOutputWidth;
+        double flY = ( wl_fixed_to_double( fSurfaceY ) * scale + oState->nDestY ) / g_nOutputHeight;
 
         wlserver_lock();
         wlserver_touchmotion( flX, flY, 0, ++m_uFakeTimestamp );


### PR DESCRIPTION
Allows clients to receive accurate pointer positions in high dpi environments.

Example
Native resolution: 3840x2160
Wayland display scale: 2
xwayland default resolution: 1920x1080
command: `gamescope -W 3840 -H 2160`

Without this change, pointer positions received by the client are restricted to the top left quarter of the screen, at half the true XY coordinates of the cursor
With this change, clients receive pointer positions that match the on screen position of the cursor