### PR TITLE
InputEmulation: remove explicit libeis header folder

### DIFF
--- a/src/InputEmulation.cpp
+++ b/src/InputEmulation.cpp
@@ -1,6 +1,6 @@
 #if HAVE_LIBEIS
 
-#include <libei-1.0/libeis.h>
+#include <libeis.h>
 #include <stdio.h>
 
 #include "InputEmulation.h"


### PR DESCRIPTION
The libeis-1.0 pc file already adds this to the include path, so this will break the build