### PR TITLE
steamcompmgr: Advertise UTF8_STRING in clipboard TARGETS.

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4857,11 +4857,11 @@ handle_selection_request(xwayland_ctx_t *ctx, XSelectionRequestEvent *ev)
 	{
 		Atom targetList[] = {
 			ctx->atoms.targets,
-			XA_STRING,
+			ctx->atoms.utf8StringAtom,
 		};
 
 		XChangeProperty(ctx->dpy, ev->requestor, ev->property, XA_ATOM, 32, PropModeReplace,
-				(unsigned char *)&targetList, 2);
+				(unsigned char *)&targetList, sizeof(targetList) / sizeof(targetList[0]));
 		response.xselection.property = ev->property;
 		response.xselection.target = ev->target;
 	}


### PR DESCRIPTION
Software respecting ICCCM will ask for TARGETS first before asking for one of the supported formats. Advertising only STRING will break with any non-ANSI characters, especially since handle_selection_notify() process UTF8 only and gamescope only returns UTF8 strings.

This fixes non-ANSI text copied from Firefox / Chrome running on a Steam deck into any Wine app being a garbled mess.