### PR TITLE
use latest upstream wlroots

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "subprojects/wlroots"]
-	path = subprojects/wlroots
-	url = https://github.com/Joshua-Ashton/wlroots.git
 [submodule "subprojects/libliftoff"]
 	path = subprojects/libliftoff
 	url = https://gitlab.freedesktop.org/emersion/libliftoff.git
@@ -19,3 +16,7 @@
 [submodule "thirdparty/SPIRV-Headers"]
 	path = thirdparty/SPIRV-Headers
 	url = https://github.com/KhronosGroup/SPIRV-Headers/
+[submodule "subprojects/wlroots"]
+	path = subprojects/wlroots
+	url = https://gitlab.freedesktop.org/wlroots/wlroots.git
+	branch = master

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -128,7 +128,7 @@ static bool Contains( const std::span<const T> x, T value )
 }
 
 static std::map< VkFormat, std::map< uint64_t, VkDrmFormatModifierPropertiesEXT > > DRMModifierProps = {};
-static std::vector< uint32_t > sampledShmFormats{};
+static struct wlr_drm_format_set sampledShmFormats = {};
 static struct wlr_drm_format_set sampledDRMFormats = {};
 
 static LogScope vk_log("vulkan");
@@ -2588,8 +2588,11 @@ bool vulkan_init_format(VkFormat format, uint32_t drmFormat)
 		return false;
 	}
 
-	if ( std::find( sampledShmFormats.begin(), sampledShmFormats.end(), drmFormat ) == sampledShmFormats.end() ) 
-		sampledShmFormats.push_back( drmFormat );
+	if (sampledShmFormats.formats == nullptr 
+			|| std::none_of( sampledShmFormats.formats, sampledShmFormats.formats+sampledShmFormats.len, [=](wlr_drm_format format) { return format.format == drmFormat;} ) ) 
+	{ 
+		wlr_drm_format_set_add( &sampledShmFormats, drmFormat, DRM_FORMAT_MOD_INVALID );
+	}
 
 	if ( !g_device.supportsModifiers() )
 	{
@@ -3985,22 +3988,17 @@ static const struct wlr_texture_impl texture_impl = {
 	.destroy = texture_destroy,
 };
 
-static uint32_t renderer_get_render_buffer_caps( struct wlr_renderer *renderer )
-{
-	return 0;
+static const struct wlr_drm_format_set *renderer_get_texture_formats(struct wlr_renderer *wlr_renderer, uint32_t buffer_caps) {
+	if (buffer_caps & WLR_BUFFER_CAP_DMABUF) {
+		return &sampledDRMFormats;
+	} else if (buffer_caps & WLR_BUFFER_CAP_DATA_PTR) {
+		return &sampledShmFormats;
+	} else {
+		return nullptr;
+	}
 }
 
-static const uint32_t *renderer_get_shm_texture_formats( struct wlr_renderer *wlr_renderer, size_t *len
- )
-{
-	*len = sampledShmFormats.size();
-	return sampledShmFormats.data();
-}
 
-static const struct wlr_drm_format_set *renderer_get_dmabuf_texture_formats( struct wlr_renderer *wlr_renderer )
-{
-	return &sampledDRMFormats;
-}
 
 static int renderer_get_drm_fd( struct wlr_renderer *wlr_renderer )
 {
@@ -4023,18 +4021,17 @@ static struct wlr_render_pass *renderer_begin_buffer_pass( struct wlr_renderer *
 }
 
 static const struct wlr_renderer_impl renderer_impl = {
-	.get_shm_texture_formats = renderer_get_shm_texture_formats,
-	.get_dmabuf_texture_formats = renderer_get_dmabuf_texture_formats,
+	.get_texture_formats = renderer_get_texture_formats,
 	.get_drm_fd = renderer_get_drm_fd,
-	.get_render_buffer_caps = renderer_get_render_buffer_caps,
 	.texture_from_buffer = renderer_texture_from_buffer,
 	.begin_buffer_pass = renderer_begin_buffer_pass,
 };
 
 struct wlr_renderer *vulkan_renderer_create( void )
 {
+	static constexpr uint32_t render_buffer_caps = WLR_BUFFER_CAP_DMABUF | WLR_BUFFER_CAP_DATA_PTR | WLR_BUFFER_CAP_SHM;
 	VulkanRenderer_t *renderer = new VulkanRenderer_t();
-	wlr_renderer_init(&renderer->base, &renderer_impl);
+	wlr_renderer_init(&renderer->base, &renderer_impl, render_buffer_caps);
 	return &renderer->base;
 }
 

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -2,6 +2,16 @@
 
 #pragma once
 
+//two function prototypes from wlr/types/wlr_linux_drm_syncobj_v1.h would cause linker errors 
+//due to c++ vs c linkage weirdness
+//need to ignore the prototypes from the header, and instead use versions w/ 'extern "C"' :
+#define wlr_linux_drm_syncobj_v1_get_surface_state wlr_linux_drm_syncobj_v1_get_surface_state_C_LINKAGE
+#define wlr_linux_drm_syncobj_manager_v1_create wlr_linux_drm_syncobj_manager_v1_create_C_LINKAGE
+#include <wlr/types/wlr_linux_drm_syncobj_v1.h>
+
+#undef wlr_linux_drm_syncobj_v1_get_surface_state
+#undef wlr_linux_drm_syncobj_manager_v1_create
+
 #include <wayland-server-core.h>
 #include <atomic>
 #include <vector>
@@ -42,8 +52,8 @@ struct wlserver_vk_swapchain_feedback
 
 struct GamescopeTimelinePoint
 {
-	struct wlr_render_timeline *pTimeline = nullptr;
-	uint64_t ulPoint = 0;
+	decltype(wlr_linux_drm_syncobj_surface_v1_state::acquire_timeline) pTimeline = nullptr;
+	decltype(wlr_linux_drm_syncobj_surface_v1_state::acquire_point) ulPoint = 0;
 
 	void Release();
 };


### PR DESCRIPTION
Fixes issue #1364

from testing on an x11 host,
This pr works fine ~~, BUT:~~
~~when merged w/ the master branch, and running `build/sec/gamescope -- glxgears` the graphics looked glitchy (no clue what’s causing this)~~

~~I double checked running said command for~~
~~- this pr (branch `newer_wlroots`)~~
~~- branch master (without this pr)~~
~~Didn’t encounter any issue for the two above cases…~~
After re-building gamescope and testing again, I no longer encountered any issues