### PR TITLE
Update openvr version requirement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,7 @@ dep_wayland = dependency('wayland-client')
 vulkan_dep = dependency('vulkan')
 
 if get_option('enable_openvr_support')
-  openvr_dep = dependency('openvr', version: '>= 2', required : false)
+  openvr_dep = dependency('openvr', version: '>= 2.7', required : false)
   if not openvr_dep.found()
     cmake = import('cmake')
     openvr_var = cmake.subproject_options()


### PR DESCRIPTION
Since
https://github.com/ValveSoftware/gamescope/commit/84b486345a0c5c2c1fb828acba7d717694549855 introduced changes to openvr subproject (or maybe before) this package won't compile if `openvr` package is installed on ArchLinux (currently on v2.2.3). Update version requirement to use the subproject if available.