### PR TITLE
drm: Separate BOE and SDC OLED Deck panel valid refresh rates

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -554,11 +554,21 @@ static constexpr uint32_t s_kSteamDeckLCDRates[] =
 	60,
 };
 
-static constexpr uint32_t s_kSteamDeckOLEDRates[] =
+static constexpr uint32_t s_kSteamDeckOLEDSDCRates[] =
 {
 	45, 47, 48, 49, 
 	50, 51, 53, 55, 56, 59, 
 	60, 62, 64, 65, 66, 68, 
+	72, 73, 76, 77, 78, 
+	80, 81, 82, 84, 85, 86, 87, 88, 
+	90, 
+};
+
+static constexpr uint32_t s_kSteamDeckOLEDBOERates[] =
+{
+	45, 47, 48, 49, 
+	50, 53, 56, 59, 
+	60, 62, 64, 66, 68, 
 	72, 73, 76, 77, 78, 
 	80, 81, 82, 84, 85, 86, 87, 88, 
 	90, 
@@ -2128,12 +2138,12 @@ namespace gamescope
 			if ( pProduct->product == kPIDGalileoSDC )
 			{
 				m_Mutable.eKnownDisplay = GAMESCOPE_KNOWN_DISPLAY_STEAM_DECK_OLED_SDC;
-				m_Mutable.ValidDynamicRefreshRates = std::span( s_kSteamDeckOLEDRates );
+				m_Mutable.ValidDynamicRefreshRates = std::span( s_kSteamDeckOLEDSDCRates );
 			}
 			else if ( pProduct->product == kPIDGalileoBOE )
 			{
 				m_Mutable.eKnownDisplay = GAMESCOPE_KNOWN_DISPLAY_STEAM_DECK_OLED_BOE;
-				m_Mutable.ValidDynamicRefreshRates = std::span( s_kSteamDeckOLEDRates );
+				m_Mutable.ValidDynamicRefreshRates = std::span( s_kSteamDeckOLEDBOERates );
 			}
 			else
 			{


### PR DESCRIPTION
OLED Decks with BOE panels seem to struggle with a few different specific modesets (51hz/55hz/65hz) that SDC panels have no issues with. To work around this, let's make use of Gamescope recognizing each display manufacturer to correct the bad modesets while leaving SDC panel units alone.

This can be reverted if an underlying cause is identified later on. This patch causes no regressions on my BOE unit, but it's worth double checking an SDC unit as well just to be sure it doesn't affect those.

Fixes: https://github.com/ValveSoftware/gamescope/issues/1398