### PR TITLE
gamescopereaper: add missing include

### DIFF
--- a/src/Apps/gamescopereaper.cpp
+++ b/src/Apps/gamescopereaper.cpp
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 namespace gamescope
 {


### PR DESCRIPTION
```
/builddir/gamescope-3.14.23/src/Apps/gamescopereaper.cpp:87:13: error: use of undeclared identifier 'STDIN_FILENO'
   87 |             STDIN_FILENO,
      |             ^
```

etc