### PR TITLE
subprojects: update libdisplay-info to 0.2.0

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -33,7 +33,7 @@ wlroots_dep = dependency(
 
 displayinfo_dep = dependency(
   'libdisplay-info',
-  version: ['>= 0.0.0', '< 0.2.0'],
+  version: ['>= 0.0.0', '< 0.3.0'],
   fallback: ['libdisplay-info', 'di_dep'],
   default_options: ['default_library=static'],
 )


### PR DESCRIPTION
Closes: #1390

Patching gamescope-3.14.23 it build just fine:

```
# ldd /usr/x86_64-pc-linux-gnu/bin/gamescope | grep libdisplay-info
        libdisplay-info.so.2 => /usr/x86_64-pc-linux-gnu/lib/libdisplay-info.so.2 (0x00007f30246eb000)
```
A quick runtime test with a plain `$ gamescope -- vkcube` didn't show any obvious problem.