### PR TITLE
Clang warning fixes

### DIFF
--- a/src/color_bench.cpp
+++ b/src/color_bench.cpp
@@ -1,9 +1,8 @@
 #include <benchmark/benchmark.h>
 
-#include "color_helpers.h"
-
-const uint32_t nLutSize1d = 4096;
-const uint32_t nLutEdgeSize3d = 17;
+#include "color_helpers_impl.h"
+using color_bench::nLutEdgeSize3d;
+using color_bench::nLutSize1d;
 
 uint16_t lut1d[nLutSize1d*4];
 uint16_t lut3d[nLutEdgeSize3d*nLutEdgeSize3d*nLutEdgeSize3d*4];
@@ -34,7 +33,7 @@ static void BenchmarkCalcColorTransform(EOTF inputEOTF, benchmark::State &state)
     float flGain = 1.0f;
 
     for (auto _ : state) {
-        calcColorTransform( &lut1d_float, nLutSize1d, &lut3d_float, nLutEdgeSize3d, inputColorimetry, inputEOTF,
+        calcColorTransform<nLutEdgeSize3d>( &lut1d_float, nLutSize1d, &lut3d_float, inputColorimetry, inputEOTF,
             outputEncodingColorimetry, EOTF_Gamma22,
             destVirtualWhite, k_EChromaticAdapatationMethod_XYZ,
             colorMapping, nightmode, tonemapping, nullptr, flGain );

--- a/src/color_helpers.cpp
+++ b/src/color_helpers.cpp
@@ -214,7 +214,11 @@ inline void lerp_rgb(float* out, const float* a, const float* b, const float* c,
 
 inline float ClampAndSanitize( float a, float min, float max )
 {
+#ifndef __FAST_MATH__
     return std::isfinite( a ) ? std::min(std::max(min, a), max) : min;
+#else
+    return std::min(std::max(min, a), max);
+#endif
 }
 
 // Adapted from:

--- a/src/color_helpers.cpp
+++ b/src/color_helpers.cpp
@@ -1,4 +1,5 @@
-#include "color_helpers.h"
+#define COLOR_HELPERS_CPP
+#include "color_helpers_impl.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -665,8 +666,9 @@ inline T applyShaper( const T & input, EOTF source, EOTF dest, const tonemapping
 
 bool g_bHuePreservationWhenClipping = false;
 
+template <uint32_t lutEdgeSize3d>
 void calcColorTransform( lut1d_t * pShaper, int nLutSize1d,
-	lut3d_t * pLut3d, int nLutEdgeSize3d,
+	lut3d_t * pLut3d,
 	const displaycolorimetry_t & source, EOTF sourceEOTF,
 	const displaycolorimetry_t & dest,  EOTF destEOTF,
     const glm::vec2 & destVirtualWhite, EChromaticAdaptationMethod eMethod,
@@ -679,6 +681,7 @@ void calcColorTransform( lut1d_t * pShaper, int nLutSize1d,
     // The 3d lut should be considered a 'matched' pair where the transform is only complete
     // when applying both.  I.e., you can put ANY transform in here, and it should work.
 
+    static constexpr int32_t nLutEdgeSize3d = static_cast<int32_t>(lutEdgeSize3d);
     if ( pShaper )
     {
         float flScale = 1.f / ( (float) nLutSize1d - 1.f );

--- a/src/color_helpers.h
+++ b/src/color_helpers.h
@@ -363,13 +363,22 @@ bool LoadCubeLut( lut3d_t * lut3d, const char * filename );
 // If the white points differ, this performs an absolute colorimetric match
 // Look luts are optional, but if specified applied in the sourceEOTF space
 
+template <uint32_t lutEdgeSize3d>
 void calcColorTransform( lut1d_t * pShaper, int nLutSize1d,
-	lut3d_t * pLut3d, int nLutEdgeSize3d,
+	lut3d_t * pLut3d,
 	const displaycolorimetry_t & source, EOTF sourceEOTF,
 	const displaycolorimetry_t & dest,  EOTF destEOTF,
 	const glm::vec2 & destVirtualWhite, EChromaticAdaptationMethod eMethod,
 	const colormapping_t & mapping, const nightmode_t & nightmode, const tonemapping_t & tonemapping,
 	const lut3d_t * pLook, float flGain );
+
+#define REGISTER_LUT_EDGE_SIZE(size) template void calcColorTransform<(size)>( lut1d_t * pShaper, int nLutSize1d, \
+	lut3d_t * pLut3d,                                                                                                   \
+	const displaycolorimetry_t & source, EOTF sourceEOTF,                                                               \
+	const displaycolorimetry_t & dest,  EOTF destEOTF,                                                                  \
+	const glm::vec2 & destVirtualWhite, EChromaticAdaptationMethod eMethod,                                             \
+	const colormapping_t & mapping, const nightmode_t & nightmode, const tonemapping_t & tonemapping,                   \
+	const lut3d_t * pLook, float flGain )
 
 // Build colorimetry and a gamut mapping for the given SDR configuration
 // Note: the output colorimetry will use the native display's white point

--- a/src/color_helpers_impl.h
+++ b/src/color_helpers_impl.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "color_helpers.h"
+
+namespace rendervulkan {
+  static constexpr uint32_t s_nLutEdgeSize3d = 17;
+  static constexpr uint32_t s_nLutSize1d = 4096;
+}
+
+namespace color_bench {
+  static constexpr uint32_t nLutEdgeSize3d = 17;
+  static constexpr uint32_t nLutSize1d = 4096;
+}
+
+namespace ns_color_tests {
+	[[maybe_unused]] static constexpr uint32_t nLutEdgeSize3d = 17;
+}
+
+#ifdef COLOR_HELPERS_CPP
+REGISTER_LUT_EDGE_SIZE(rendervulkan::s_nLutEdgeSize3d);
+#endif

--- a/src/color_tests.cpp
+++ b/src/color_tests.cpp
@@ -1,7 +1,7 @@
 #include "color_helpers.h"
 #include <cstdio>
 
-#include <glm/ext.hpp>
+//#include <glm/ext.hpp>
 #include <glm/gtx/string_cast.hpp>
 
 /*

--- a/src/color_tests.cpp
+++ b/src/color_tests.cpp
@@ -5,8 +5,8 @@
 #include <glm/gtx/string_cast.hpp>
 
 /*
+using ns_color_tests::nLutEdgeSize3d;
 const uint32_t nLutSize1d = 4096;
-const uint32_t nLutEdgeSize3d = 17;
 
 uint16_t lut1d[nLutSize1d*4];
 uint16_t lut3d[nLutEdgeSize3d*nLutEdgeSize3d*nLutEdgeSize3d*4];
@@ -36,7 +36,7 @@ static void BenchmarkCalcColorTransform(EOTF inputEOTF, benchmark::State &state)
     float flGain = 1.0f;
 
     for (auto _ : state) {
-        calcColorTransform( &lut1d_float, nLutSize1d, &lut3d_float, nLutEdgeSize3d, inputColorimetry, inputEOTF,
+        calcColorTransform<nLutEdgeSize3d>( &lut1d_float, nLutSize1d, &lut3d_float, inputColorimetry, inputEOTF,
             outputEncodingColorimetry, EOTF_Gamma22,
             colorMapping, nightmode, tonemapping, nullptr, flGain );
         for ( size_t i=0, end = lut1d_float.dataR.size(); i<end; ++i )

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -12,7 +12,7 @@
 #include <optional>
 
 #include "main.hpp"
-#include "color_helpers.h"
+
 #include "gamescope_shared.h"
 #include "backend.h"
 
@@ -415,7 +415,7 @@ struct wlr_renderer *vulkan_renderer_create( void );
 
 using mat3x4 = std::array<std::array<float, 4>, 3>;
 
-#include "color_helpers.h"
+#include "color_helpers_impl.h"
 
 struct gamescope_color_mgmt_t
 {
@@ -453,8 +453,9 @@ struct gamescope_color_mgmt_t
 	bool operator != (const gamescope_color_mgmt_t&) const = default;
 };
 
-static constexpr uint32_t s_nLutEdgeSize3d = 17;
-static constexpr uint32_t s_nLutSize1d = 4096;
+//namespace members from "color_helpers_impl.h":
+using rendervulkan::s_nLutEdgeSize3d;
+using rendervulkan::s_nLutSize1d;
 
 struct gamescope_color_mgmt_luts
 {

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -308,7 +308,7 @@ create_color_mgmt_luts(const gamescope_color_mgmt_t& newColorMgmt, gamescope_col
 				buildPQColorimetry( &inputColorimetry, &colorMapping, displayColorimetry );
 			}
 
-			calcColorTransform( &g_tmpLut1d, s_nLutSize1d, &g_tmpLut3d, s_nLutEdgeSize3d, inputColorimetry, inputEOTF,
+			calcColorTransform<s_nLutEdgeSize3d>( &g_tmpLut1d, s_nLutSize1d, &g_tmpLut3d, inputColorimetry, inputEOTF,
 				outputEncodingColorimetry, newColorMgmt.outputEncodingEOTF,
 				newColorMgmt.outputVirtualWhite, newColorMgmt.chromaticAdaptationMode,
 				colorMapping, newColorMgmt.nightmode, tonemapping, pLook, flGain );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4996,7 +4996,11 @@ steamcompmgr_latch_frame_done( steamcompmgr_win_t *w, uint64_t vblank_idx )
 
 static inline float santitize_float( float f )
 {
+#ifndef __FAST_MATH__
 	return ( std::isfinite( f ) ? f : 0.f );
+#else
+	return f;
+#endif
 }
 
 static void


### PR DESCRIPTION
Unless I were to just add compiler flags to turn off the vla warnings, there were only two ways I saw to fix the VLA warning:
- Use a vector instead of vla
- Make the vla's length a compile time constant. 

I took the latter choice in this PR, because I was unsure of, if and/or to what extent that replacing the VLA w/ a vector could interfere w/ autovectorization. I reckon that w/ LTO, the compiler is currently able to figure out that the VLA's length is always just 17, so that it can optimize as if it was just a normal array w/ compile-time-constant length. 
So replacing the VLA could lead to the compiler making slightly worse codegen.

~~C++ template functions with Non-Type Template Parameters (what a mouthful!) don't seem to be able to be split into a declaration/function prototype in the `.h` header & definition in the `.cpp` file due to template instantiation weirdness...~~
~~So I had to consolidate `color_helpers.h` & `color_helpers.cpp` into just `color_helpers.h`...~~
~~I think this may increase compile times a bit, I dunno :/~~

Oh and as for the `std::isfinite()` stuff, turns out that all the `std::numeric_limits` stuff related to floats is completely useless for this purpose.
But checking `__FAST_MATH__` works well

**UPDATE**: I figured out a way to template-ize `calcColorTransform()` while still having the declaration in `color_helpers.h` and the definition in `color_helpers.cpp`:
I made a `color_helpers_impl.h` file containing all of the `nLutEdgeSize3d` constants, and also doing an explicit template instantiation based on the constant(s).
The only awkward part of this is that the explicit template instantiation actually has to be included into `color_helpers.cpp`  but *NOT* any other files that are including `color_helpers_impl.h`. Otherwise you'd get annoying compiler errors and/or linker errors... -_-