### PR TITLE
readme: add HDR and gamescope utility sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If running RadeonSI clients with older cards (GFX8 and below), currently have to
 git submodule update --init
 meson build/
 ninja -C build/
-build/gamescope -- <game>
+build/src/gamescope -- <game>
 ```
 
 Install with:
@@ -56,6 +56,7 @@ gamescope -r 30 -- %command%
 gamescope -w 1920 -h 1080 -W 3440 -H 1440 -b -- %command%
 ```
 
+
 ## Options
 
 See `gamescope --help` for a full list of options.
@@ -70,6 +71,65 @@ See `gamescope --help` for a full list of options.
 * `-S stretch`: use stretch scaling, the game will fill the window. (e.g. 4:3 to 16:9)
 * `-b`: create a border-less window.
 * `-f`: create a full-screen window.
+
+If your display supports HDR and it is currently enabled, gamescope will automatically enable HDR support for its own output. You can use gamescope in an embedded session running with the DRM backened for HDR output, or if your desktop environment supports HDR and runs a Wayland session, you can use the Wayland backend. HDR can be disabled with `--hdr-disabled` as a gamescope launch option or as a convar.
+
+If you want to check if HDR is working properly, the mangoapp overlay has an HDR indicator and the right side menu of Steam's GamepadUI will have an HDR badge next to the brightness and volume sliders. 
+
+## Gamescope utilities
+
+There are several utilities that get installed along with the primary gamescope binary. There are two user-interactive binaries, gamescopestream and gamescopectl, while a third binary, gamescopereaper, is used by gamescope itself.
+
+**gamescopestream**:
+
+The first binary is gamescopestream, which can be used to capture a Pipewire stream and dma-buf from a gamescope window into a new Wayland window. It can be run without any arguments as `gamescopestream`, or you can pass along a Steam AppID. For example, Counter-Strike 2 has a Steam AppID of 730. If Counter-Strike 2 is launched with gamescope, you can use `gamescopestream app_id 730` to capture your gamescope window and export it into a new window for recording or streaming purposes. This is also how Steam's Game Recording feature works within an embedded gamescope session.
+
+**gamescopectl**:
+
+The second binary is gamescopectl, which is a debugging utility that can be used to set convars, execute debugging commands, and list information about active gamescope instances.
+
+To print gamescope version and display information when filing an issue, you can run `gamescopectl` without any arguments.
+
+```sh
+gamescopectl version 3.14.23
+gamescope_control info:
+  - Connector Name: eDP-1
+  - Display Make: Valve Corporation
+  - Display Model: ANX7530 U
+  - Display Flags: 0x3
+  - ValidRefreshRates: 45, 47, 48, 49, 50, 51, 53, 55, 56, 59, 60, 62, 64, 65, 66, 68, 72, 73, 76, 77, 78, 80, 81, 82, 84, 85, 86, 87, 88, 90
+  Features:
+  - Reshade Shaders (1) - Version: 1 - Flags: 0x0
+  - Display Info (2) - Version: 1 - Flags: 0x0
+  - Pixel Filter (3) - Version: 1 - Flags: 0x0
+  - Refresh Cycle Only Change Refresh Rate (4) - Version: 1 - Flags: 0x0
+  - Mura Correction (5) - Version: 1 - Flags: 0x0
+You can execute any debug command in Gamescope using this tool.
+For a list of commands and convars, use 'gamescopectl help'
+```
+
+For a full list of convars and debugging commands, you can run `gamescopectl help` while a gamescope instance is open. Generally, convars will be set with a 0 for disabled or a 1 for enabled, although some convars will have additional values as noted in `gamescopectl help`
+
+```sh
+# Force gamescope to always composite (i.e. never use direct scan-out)
+gamescopectl composite_force 1
+
+# Stop forcing gamescope to always composite (i.e. go back to using direct scan-out when possible)
+gamescopectl composite_force 0
+
+# Print an output of gamescope backend information for debugging purposes
+gamescopectl backend_info
+```
+
+Please note that some convars must be set in code before building gamescope as `gamescopectl help` lists every possible convar, not the just the ones that can be toggled via `gamescopectl`.
+
+**gamescopereaper**:
+
+gamescopereaper is used by the primary gamescope binary to clean up after itself by taking care of shutting down child processes after the parent process ends.
+
+**mangoapp**:
+
+While this is not a shipped binary with gamescope, mangoapp is the officially supported method of adding MangoHud overlays to gamescope as it is designed to integrate MangoHud and gamescope together in a way that does not adversely affect gamescope's functionality. Any other method of using MangoHud can cause unexpected issues like Vulkan or swapchain errors.
 
 ## Reshade support
 


### PR DESCRIPTION
Leaving this as a draft for now pending:
- [ ] fill in more information for gamescopereaper and gamescopestream after testing
- [ ] verify details of all utility descriptions
- [ ] check for any stylistic changes

what I'm undecided on still:
1. should we add more information regarding which DEs currently support HDR w/ nested gamescope?
2. ~~should we include `-Dforce_fallback_for` in the readme build instructions to avoid confusion? it would get rid of any initial build errors for people just copying the website build instructions. I've included this already in the initial draft.~~ unnecessary given it's the default option in meson.build

feel free to close if you've got something going locally already, but I think this covers most of the changes that I'm aware of in the past few months.