### PR TITLE
WaylandBackend: Force update fullscreen when returning from not being visible

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1863,7 +1863,10 @@ namespace gamescope
 
     void CWaylandBackend::UpdateFullscreenState()
     {
-        if ( m_bDesiredFullscreenState != g_bFullscreen )
+        if ( !m_bVisible )
+            g_bFullscreen = false;
+
+        if ( m_bDesiredFullscreenState != g_bFullscreen && m_bVisible )
         {
             if ( m_bDesiredFullscreenState )
                 libdecor_frame_set_fullscreen( m_Planes[0].GetFrame(), nullptr );


### PR DESCRIPTION
For nested wayland
Very simple little thing so that if the gamescope window goes invisible (from there being no windows to draw or whatever), if it was fullscreen before, then when it comes back up it'll return to being fullscreen

Yeah, that's all