### PR TITLE
mangoapp: only set env in steammode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -613,7 +613,7 @@ static void UpdateCompatEnvVars()
 	setenv( "GAMESCOPE_NV12_COLORSPACE", "k_EStreamColorspace_BT601", 0 );
 
 	const char *pszMangoConfigPath = getenv( "MANGOHUD_CONFIGFILE" );
-	if ( g_bLaunchMangoapp && ( !pszMangoConfigPath || !*pszMangoConfigPath ) )
+	if ( (g_bLaunchMangoapp && steamMode) && ( !pszMangoConfigPath || !*pszMangoConfigPath ) )
 	{
 		char szMangoConfigPath[ PATH_MAX ];
 		FILE *pMangoConfigFile = gamescope::MakeTempFile( szMangoConfigPath, gamescope::k_szGamescopeTempMangoappTemplate, "w", true );


### PR DESCRIPTION
`MANGOHUD_CONFIGFILE` should only be set by gamescope if we're in steamMode. This is causing confusion for regular users as it prevents usage of the standard mangohud config paths