### PR TITLE
wlserver: fix nullptr dereference on oPoint->pTimeline

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -131,7 +131,7 @@ void GamescopeTimelinePoint::Release()
 
 static std::optional<GamescopeAcquireTimelineState> TimelinePointToEventFd( const std::optional<GamescopeTimelinePoint>& oPoint )
 {
-	if (!oPoint)
+	if (!oPoint || !(oPoint->pTimeline) )
 		return std::nullopt;
 
 	uint64_t uSignalledPoint = 0;


### PR DESCRIPTION
For whatever reason, when working on upgrading to wlroots .18, I had previously noticed that gamescope would sometimes still segfault (issue  #1364 ), due to a nullptr deref on oPoint->pTimeline.
I had put in a nullptr check for that in my previous wlroots .18 PR, but the check was left out when Joshua Ashton manually merged in my PR.
I can't seem to be able to reproduce the issue myself in upstream gamescope, tho I had been able to previously (and by previously, I mean before the update to wlroots .18).
But @matte-schwartz said that they still were experience crashing wrt issue #1364 after the upstream gamescope update to wlroots .18, so I'm putting up this PR in case this might fix the rest of the issue

See: 
https://github.com/ValveSoftware/gamescope/issues/1364#issuecomment-2261342586
and
https://github.com/ValveSoftware/gamescope/issues/1364#issuecomment-2261569887