### PR TITLE
Add clipboard support from SDL backend

### DIFF
--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -893,7 +893,11 @@ namespace gamescope
                 vr::VROverlay()->ClearOverlayTexture( GetPrimaryPlane()->GetOverlayThumbnail() );
             }
         }
-		virtual std::shared_ptr<INestedHints::CursorInfo> GetHostCursor() override
+        virtual void SetSelection( std::shared_ptr<std::string> szContents, GamescopeSelection eSelection ) override
+        {
+            // Do nothing.
+        }
+        virtual std::shared_ptr<INestedHints::CursorInfo> GetHostCursor() override
         {
             return nullptr;
         }

--- a/src/Backends/SDLBackend.cpp
+++ b/src/Backends/SDLBackend.cpp
@@ -11,6 +11,7 @@
 
 #include "SDL_clipboard.h"
 #include "SDL_events.h"
+#include "gamescope_shared.h"
 #include "main.hpp"
 #include "wlserver.hpp"
 #include <SDL.h>
@@ -162,7 +163,8 @@ namespace gamescope
         virtual void SetVisible( bool bVisible ) override;
         virtual void SetTitle( std::shared_ptr<std::string> szTitle ) override;
         virtual void SetIcon( std::shared_ptr<std::vector<uint32_t>> uIconPixels ) override;
-		virtual std::shared_ptr<INestedHints::CursorInfo> GetHostCursor() override;
+        virtual void SetSelection( std::shared_ptr<std::string> szContents, GamescopeSelection eSelection ) override;
+        virtual std::shared_ptr<INestedHints::CursorInfo> GetHostCursor() override;
 	protected:
 		virtual void OnBackendBlobDestroyed( BackendBlob *pBlob ) override;
 	private:
@@ -496,7 +498,13 @@ namespace gamescope
 		m_pApplicationIcon = uIconPixels;
 		PushUserEvent( GAMESCOPE_SDL_EVENT_ICON );
 	}
-
+	void CSDLBackend::SetSelection( std::shared_ptr<std::string> szContents, GamescopeSelection eSelection )
+	{
+		if (eSelection == GAMESCOPE_SELECTION_CLIPBOARD)
+			SDL_SetClipboardText(szContents->c_str());
+		else if (eSelection == GAMESCOPE_SELECTION_PRIMARY)
+			SDL_SetPrimarySelectionText(szContents->c_str());
+	}
 	std::shared_ptr<INestedHints::CursorInfo> CSDLBackend::GetHostCursor()
 	{
 		return GetX11HostCursor();

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -545,6 +545,7 @@ namespace gamescope
         virtual void SetVisible( bool bVisible ) override;
         virtual void SetTitle( std::shared_ptr<std::string> szTitle ) override;
         virtual void SetIcon( std::shared_ptr<std::vector<uint32_t>> uIconPixels ) override;
+        virtual void SetSelection( std::shared_ptr<std::string> szContents, GamescopeSelection eSelection ) override;
         virtual std::shared_ptr<INestedHints::CursorInfo> GetHostCursor() override;
     protected:
         virtual void OnBackendBlobDestroyed( BackendBlob *pBlob ) override;
@@ -1975,6 +1976,10 @@ namespace gamescope
         {
             xdg_toplevel_icon_manager_v1_set_icon( m_pToplevelIconManager, m_Planes[0].GetXdgToplevel(), nullptr );
         }
+    }
+    void CWaylandBackend::SetSelection( std::shared_ptr<std::string> szContents, GamescopeSelection eSelection )
+    {
+        // Do nothing
     }
 
     std::shared_ptr<INestedHints::CursorInfo> CWaylandBackend::GetHostCursor()

--- a/src/backend.h
+++ b/src/backend.h
@@ -127,6 +127,7 @@ namespace gamescope
         virtual void SetVisible( bool bVisible ) = 0;
         virtual void SetTitle( std::shared_ptr<std::string> szTitle ) = 0;
         virtual void SetIcon( std::shared_ptr<std::vector<uint32_t>> uIconPixels ) = 0;
+        virtual void SetSelection( std::shared_ptr<std::string> szContents, GamescopeSelection eSelection ) = 0;
         virtual std::shared_ptr<CursorInfo> GetHostCursor() = 0;
     };
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -29,6 +29,7 @@
  *   says above. Not that I can really do anything about it
  */
 
+#include "gamescope_shared.h"
 #include "xwayland_ctx.hpp"
 #include <X11/X.h>
 #include <X11/Xlib.h>
@@ -4918,13 +4919,14 @@ handle_selection_notify(xwayland_ctx_t *ctx, XSelectionEvent *ev)
 				&actual_type, &actual_format, &nitems, &bytes_after, &data);
 		if (data) {
 			const char *contents = (const char *) data;
+			auto szContents = std::make_shared<std::string>(contents);
 			defer( XFree( data ); );
 
 			if (ev->selection == ctx->atoms.clipboard)
 			{
 				if ( GetBackend()->GetNestedHints() )
 				{
-					//GetBackend()->GetNestedHints()->SetSelection()
+					GetBackend()->GetNestedHints()->SetSelection( szContents, GAMESCOPE_SELECTION_CLIPBOARD );
 				}
 				else
 				{
@@ -4935,7 +4937,7 @@ handle_selection_notify(xwayland_ctx_t *ctx, XSelectionEvent *ev)
 			{
 				if ( GetBackend()->GetNestedHints() )
 				{
-					//GetBackend()->GetNestedHints()->SetSelection()
+					GetBackend()->GetNestedHints()->SetSelection( szContents, GAMESCOPE_SELECTION_PRIMARY );
 				}
 				else
 				{


### PR DESCRIPTION
Looks like as part of the backend refactor, copy and paste was partially broken with the SDL backend.  This fixes that broken functionality and lays some groundwork for copy and paste in the wayland backend.

Fixes #1440 