### PR TITLE
Add Wayland protocol C++-y mechanism, and implement linux_drm_syncobj ourselves

### DIFF
--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -20,6 +20,7 @@ protocols = [
 	wl_protocol_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml',
 	wl_protocol_dir / 'unstable/relative-pointer/relative-pointer-unstable-v1.xml',
 	wl_protocol_dir / 'staging/fractional-scale/fractional-scale-v1.xml',
+	wl_protocol_dir / 'staging/linux-drm-syncobj/linux-drm-syncobj-v1.xml',
 
 	# Wayland Protocols not yet in a release.
 	'xdg-toplevel-icon-v1.xml',

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -415,7 +415,7 @@ namespace gamescope
 	class CDRMFb final : public CBaseBackendFb
 	{
 	public:
-		CDRMFb( uint32_t uFbId, wlr_buffer *pClientBuffer );
+		CDRMFb( uint32_t uFbId );
 		~CDRMFb();
 
 		uint32_t GetFbId() const { return m_uFbId; }
@@ -1473,7 +1473,7 @@ gamescope::OwningRc<gamescope::IBackendFb> drm_fbid_from_dmabuf( struct drm_t *d
 
 	drm_log.debugf("make fbid %u", fb_id);
 
-	pBackendFb = new gamescope::CDRMFb( fb_id, buf );
+	pBackendFb = new gamescope::CDRMFb( fb_id );
 
 out:
 	for ( int i = 0; i < dma_buf->n_planes; i++ ) {
@@ -2334,9 +2334,8 @@ namespace gamescope
 	/////////////////////////
 	// CDRMFb
 	/////////////////////////
-	CDRMFb::CDRMFb( uint32_t uFbId, wlr_buffer *pClientBuffer )
-		: CBaseBackendFb( pClientBuffer )
-		, m_uFbId{ uFbId }
+	CDRMFb::CDRMFb( uint32_t uFbId )
+		: m_uFbId{ uFbId }
 	{
 
 	}

--- a/src/Backends/HeadlessBackend.cpp
+++ b/src/Backends/HeadlessBackend.cpp
@@ -178,7 +178,7 @@ namespace gamescope
 
 		virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_buffer *pBuffer, wlr_dmabuf_attributes *pDmaBuf ) override
 		{
-			return new CBaseBackendFb( pBuffer );
+			return new CBaseBackendFb();
 		}
 
 		virtual bool UsesModifiers() const override

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -266,7 +266,7 @@ namespace gamescope
     class COpenVRFb final : public CBaseBackendFb
     {
     public:
-        COpenVRFb( COpenVRBackend *pBackend, vr::SharedTextureHandle_t ulHandle, wlr_buffer *pClientBuffer );
+        COpenVRFb( COpenVRBackend *pBackend, vr::SharedTextureHandle_t ulHandle );
         ~COpenVRFb();
 
         vr::SharedTextureHandle_t GetSharedTextureHandle() const { return m_ulHandle; }
@@ -701,11 +701,11 @@ namespace gamescope
                 if ( !m_pIPCResourceManager->RefResource( ulSharedHandle, nullptr ) )
                     return nullptr;
 
-                return new COpenVRFb{ this, ulSharedHandle, pBuffer };
+                return new COpenVRFb{ this, ulSharedHandle };
             }
             else
             {
-                return new COpenVRFb{ this, 0, pBuffer };
+                return new COpenVRFb{ this, 0 };
             }
 		}
 
@@ -1164,8 +1164,8 @@ namespace gamescope
 	// COpenVRFb
 	/////////////////////////
 
-    COpenVRFb::COpenVRFb( COpenVRBackend *pBackend, vr::SharedTextureHandle_t ulHandle, wlr_buffer *pClientBuffer )
-        : CBaseBackendFb{ pClientBuffer }
+    COpenVRFb::COpenVRFb( COpenVRBackend *pBackend, vr::SharedTextureHandle_t ulHandle )
+        : CBaseBackendFb{}
         , m_pBackend{ pBackend }
         , m_ulHandle{ ulHandle }
     {

--- a/src/Backends/SDLBackend.cpp
+++ b/src/Backends/SDLBackend.cpp
@@ -397,7 +397,7 @@ namespace gamescope
 
 	OwningRc<IBackendFb> CSDLBackend::ImportDmabufToBackend( wlr_buffer *pBuffer, wlr_dmabuf_attributes *pDmaBuf )
 	{
-		return new CBaseBackendFb( pBuffer );
+		return new CBaseBackendFb();
 	}
 
 	bool CSDLBackend::UsesModifiers() const

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -337,7 +337,7 @@ namespace gamescope
     class CWaylandFb final : public CBaseBackendFb
     {
     public:
-        CWaylandFb( CWaylandBackend *pBackend, wl_buffer *pHostBuffer, wlr_buffer *pClientBuffer );
+        CWaylandFb( CWaylandBackend *pBackend, wl_buffer *pHostBuffer );
         ~CWaylandFb();
 
         void OnCompositorAcquire();
@@ -743,8 +743,8 @@ namespace gamescope
     // CWaylandFb
     //////////////////
 
-    CWaylandFb::CWaylandFb( CWaylandBackend *pBackend, wl_buffer *pHostBuffer, wlr_buffer *pClientBuffer )
-        : CBaseBackendFb( pClientBuffer )
+    CWaylandFb::CWaylandFb( CWaylandBackend *pBackend, wl_buffer *pHostBuffer )
+        : CBaseBackendFb()
         , m_pBackend     { pBackend }
         , m_pHostBuffer  { pHostBuffer }
     {
@@ -1498,7 +1498,7 @@ namespace gamescope
         if ( m_pSinglePixelBufferManager )
         {
             wl_buffer *pBlackBuffer = wp_single_pixel_buffer_manager_v1_create_u32_rgba_buffer( m_pSinglePixelBufferManager, 0, 0, 0, ~0u );
-            m_pOwnedBlackFb = new CWaylandFb( this, pBlackBuffer, nullptr );
+            m_pOwnedBlackFb = new CWaylandFb( this, pBlackBuffer );
             m_BlackFb = m_pOwnedBlackFb.get();
         }
         else
@@ -1752,7 +1752,7 @@ namespace gamescope
 
         zwp_linux_buffer_params_v1_destroy( pBufferParams );
 
-        return new CWaylandFb{ this, pImportedBuffer, pClientBuffer };
+        return new CWaylandFb{ this, pImportedBuffer };
     }
 
     bool CWaylandBackend::UsesModifiers() const

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1,0 +1,130 @@
+#include <xf86drm.h>
+#include <sys/eventfd.h>
+
+#include "Timeline.h"
+#include "wlserver.hpp"
+#include "rendervulkan.hpp"
+
+#include "wlr_begin.hpp"
+#include <wlr/render/drm_syncobj.h>
+#include <wlr/types/wlr_linux_drm_syncobj_v1.h>
+#include "wlr_end.hpp"
+
+namespace gamescope
+{
+    static LogScope s_TimelineLog( "timeline" );
+
+    CTimeline::CTimeline( int32_t nSyncobjFd, uint32_t uSyncobjHandle )
+        : m_nSyncobjFd{ nSyncobjFd }
+        , m_uSyncobjHandle{ uSyncobjHandle }
+    {
+    }
+
+    CTimeline::~CTimeline()
+    {
+        if ( m_uSyncobjHandle )
+            drmSyncobjDestroy( GetDrmRenderFD(), m_uSyncobjHandle );
+        if ( m_nSyncobjFd >= 0 )
+            close( m_nSyncobjFd );
+    }
+
+    int32_t CTimeline::GetDrmRenderFD() const
+    {
+        return g_device.drmRenderFd();
+    }
+
+    // CTimelinePoint
+
+    template <TimelinePointType Type>
+    CTimelinePoint<Type>::CTimelinePoint( std::shared_ptr<CTimeline> pTimeline, uint64_t ulPoint  )
+        : m_pTimeline{ std::move( pTimeline ) }
+        , m_ulPoint{ ulPoint }
+    {
+    }
+
+    template <TimelinePointType Type>
+    CTimelinePoint<Type>::~CTimelinePoint()
+    {
+        if ( ShouldSignalOnDestruction() )
+        {
+            const uint32_t uHandle = m_pTimeline->GetSyncobjHandle();
+
+            drmSyncobjTimelineSignal( m_pTimeline->GetDrmRenderFD(), &uHandle, &m_ulPoint, 1 );
+        }
+    }
+
+    template <TimelinePointType Type>
+    bool CTimelinePoint<Type>::Wait( int64_t lTimeout )
+    {
+        uint32_t uHandle = m_pTimeline->GetSyncobjHandle();
+
+        int nRet = drmSyncobjTimelineWait(
+            m_pTimeline->GetDrmRenderFD(),
+            &uHandle,
+            &m_ulPoint,
+            1,
+            lTimeout,
+            DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL,
+            nullptr );
+
+        return nRet == 0;
+    }
+
+    //
+    // Fence flags tl;dr
+    // 0                                      -> Wait for signal on a materialized fence, -ENOENT if not materialized
+    // DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE  -> Wait only for materialization
+    // DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT -> Wait for materialization + signal
+    //
+    template <TimelinePointType Type>
+    std::pair<int32_t, bool> CTimelinePoint<Type>::CreateEventFd()
+    {
+        assert( Type == TimelinePointType::Acquire );
+
+        uint32_t uHandle = m_pTimeline->GetSyncobjHandle();
+        uint64_t ulSignalledPoint = 0;
+        int nRet = drmSyncobjQuery( m_pTimeline->GetDrmRenderFD(), &uHandle, &ulSignalledPoint, 1u );
+        if ( nRet != 0 )
+        {
+            s_TimelineLog.errorf_errno( "drmSyncobjQuery failed (%d)", nRet );
+            return k_InvalidEvent;
+        }
+
+        if ( ulSignalledPoint >= m_ulPoint )
+        {
+            return k_AlreadySignalledEvent;
+        }
+        else
+        {
+            const int32_t nExplicitSyncEventFd = eventfd( 0, EFD_CLOEXEC );
+            if ( nExplicitSyncEventFd < 0 )
+            {
+                s_TimelineLog.errorf_errno( "Failed to create eventfd (%d)", nExplicitSyncEventFd );
+                return k_InvalidEvent;
+            }
+
+            drm_syncobj_eventfd syncobjEventFd =
+            {
+                .handle = m_pTimeline->GetSyncobjHandle(),
+                // Only valid flags are: DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE
+                // -> Wait for fence materialization rather than signal.
+                .flags  = 0u,
+                .point  = m_ulPoint,
+                .fd     = nExplicitSyncEventFd,
+            };
+
+            if ( drmIoctl( m_pTimeline->GetDrmRenderFD(), DRM_IOCTL_SYNCOBJ_EVENTFD, &syncobjEventFd ) != 0 )
+            {
+                s_TimelineLog.errorf_errno( "DRM_IOCTL_SYNCOBJ_EVENTFD failed" );
+                close( nExplicitSyncEventFd );
+                return k_InvalidEvent;
+            }
+
+            return { nExplicitSyncEventFd, false };
+        }
+    }
+
+    template class CTimelinePoint<TimelinePointType::Acquire>;
+    template class CTimelinePoint<TimelinePointType::Release>;
+
+}

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -14,6 +14,21 @@ namespace gamescope
 {
     static LogScope s_TimelineLog( "timeline" );
 
+    static uint32_t SyncobjFdToHandle( int32_t nFd )
+    {
+        int32_t nRet;
+        uint32_t uHandle = 0;
+        if ( ( nRet = drmSyncobjFDToHandle( g_device.drmRenderFd(), nFd, &uHandle ) ) < 0 )
+            return 0;
+
+        return uHandle;
+    }
+
+    CTimeline::CTimeline( int32_t nSyncobjFd )
+        : CTimeline( nSyncobjFd, SyncobjFdToHandle( nSyncobjFd ) )
+    {
+    }
+
     CTimeline::CTimeline( int32_t nSyncobjFd, uint32_t uSyncobjHandle )
         : m_nSyncobjFd{ nSyncobjFd }
         , m_uSyncobjHandle{ uSyncobjHandle }
@@ -28,7 +43,7 @@ namespace gamescope
             close( m_nSyncobjFd );
     }
 
-    int32_t CTimeline::GetDrmRenderFD() const
+    int32_t CTimeline::GetDrmRenderFD()
     {
         return g_device.drmRenderFd();
     }

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -18,6 +18,7 @@ namespace gamescope
     class CTimeline : public NonCopyable
     {
     public:
+        CTimeline( int32_t nSyncobjFd );
         CTimeline( int32_t nSyncobjFd, uint32_t uSyncobjHandle );
 
         CTimeline( CTimeline &&other )
@@ -27,7 +28,11 @@ namespace gamescope
         }
         ~CTimeline();
 
-        int32_t GetDrmRenderFD() const;
+        static std::shared_ptr<CTimeline> CreateFromSyncobjFd( int32_t nSyncobjFd );
+
+        static int32_t GetDrmRenderFD();
+
+        bool IsValid() const { return m_uSyncobjHandle != 0; }
 
         int32_t GetSyncobjFd() const { return m_nSyncobjFd; }
         uint32_t GetSyncobjHandle() const { return m_uSyncobjHandle; }

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <memory>
+#include <limits>
+
+#include "Utils/NonCopyable.h"
+
+namespace gamescope
+{
+    enum class TimelinePointType
+    {
+        Acquire,
+        Release,
+    };
+
+    class CTimeline : public NonCopyable
+    {
+    public:
+        CTimeline( int32_t nSyncobjFd, uint32_t uSyncobjHandle );
+
+        CTimeline( CTimeline &&other )
+            : m_nSyncobjFd{ std::exchange( other.m_nSyncobjFd, -1 ) }
+            , m_uSyncobjHandle{ std::exchange( other.m_uSyncobjHandle, 0 ) }
+        {
+        }
+        ~CTimeline();
+
+        int32_t GetDrmRenderFD() const;
+
+        int32_t GetSyncobjFd() const { return m_nSyncobjFd; }
+        uint32_t GetSyncobjHandle() const { return m_uSyncobjHandle; }
+    private:
+        int32_t m_nSyncobjFd = -1;
+        uint32_t m_uSyncobjHandle = 0;
+    };
+
+    template <TimelinePointType Type>
+    class CTimelinePoint : public NonCopyable
+    {
+    public:
+        static constexpr std::pair<int32_t, bool> k_InvalidEvent = { -1, false };
+        static constexpr std::pair<int32_t, bool> k_AlreadySignalledEvent = { -1, true };
+
+        CTimelinePoint( std::shared_ptr<CTimeline> pTimeline, uint64_t ulPoint );
+        ~CTimelinePoint();
+
+        void SetPoint( uint64_t ulPoint ) { m_ulPoint = ulPoint; }
+
+              std::shared_ptr<CTimeline> &GetTimeline()       { return m_pTimeline; }
+        const std::shared_ptr<CTimeline> &GetTimeline() const { return m_pTimeline; }
+
+        constexpr bool ShouldSignalOnDestruction() const { return Type == TimelinePointType::Release; }
+
+        bool Wait( int64_t lTimeout = std::numeric_limits<int64_t>::max() );
+
+        std::pair<int32_t, bool> CreateEventFd();
+    private:
+
+        std::shared_ptr<CTimeline> m_pTimeline;
+        uint64_t m_ulPoint = 0;
+
+    };
+
+    using CAcquireTimelinePoint = CTimelinePoint<TimelinePointType::Acquire>;
+    using CReleaseTimelinePoint = CTimelinePoint<TimelinePointType::Release>;
+
+}

--- a/src/Utils/NonCopyable.h
+++ b/src/Utils/NonCopyable.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace gamescope
+{
+
+    class NonCopyable
+    {
+    public:
+        NonCopyable() = default;
+        NonCopyable(const NonCopyable &) = delete;
+
+        void operator = (const NonCopyable &) = delete;
+    };
+
+}

--- a/src/WaylandServer/LinuxDrmSyncobj.h
+++ b/src/WaylandServer/LinuxDrmSyncobj.h
@@ -1,0 +1,172 @@
+#include "WaylandProtocol.h"
+#include "WaylandServerLegacy.h"
+#include "../Timeline.h"
+
+#include "linux-drm-syncobj-v1-protocol.h"
+
+namespace gamescope::WaylandServer
+{
+
+	class CLinuxDrmSyncobjTimeline : public CWaylandResource
+	{
+	public:
+		WL_PROTO_DEFINE( wp_linux_drm_syncobj_timeline_v1, 1 );
+
+		CLinuxDrmSyncobjTimeline( WaylandResourceDesc_t desc, std::shared_ptr<CTimeline> pTimeline )
+			: CWaylandResource( desc )
+			, m_pTimeline{ std::move( pTimeline ) }
+		{
+		}
+
+		std::shared_ptr<CTimeline> GetTimeline() const
+		{
+			return m_pTimeline;
+		}
+
+	private:
+		std::shared_ptr<CTimeline> m_pTimeline;
+	};
+
+	const struct wp_linux_drm_syncobj_timeline_v1_interface CLinuxDrmSyncobjTimeline::Implementation = 
+	{
+		.destroy = WL_PROTO_DESTROY(),
+	};
+
+	class CLinuxDrmSyncobjSurface : public CWaylandResource
+	{
+	public:
+		WL_PROTO_DEFINE( wp_linux_drm_syncobj_surface_v1, 1 );
+
+		CLinuxDrmSyncobjSurface( WaylandResourceDesc_t desc, wlserver_wl_surface_info *pWlSurfaceInfo )
+			: CWaylandResource( desc )
+			, m_pWlSurfaceInfo{ pWlSurfaceInfo }
+		{
+		}
+
+		~CLinuxDrmSyncobjSurface()
+		{
+			assert( m_pWlSurfaceInfo->pSyncobjSurface == this );
+			m_pWlSurfaceInfo->pSyncobjSurface = nullptr;
+		}
+
+		bool HasExplicitSync() const
+		{
+			return m_pAcquireTimeline || m_pReleaseTimeline;
+		}
+
+		std::shared_ptr<CAcquireTimelinePoint> ExtractAcquireTimelinePoint() const
+		{
+			if ( !m_pAcquireTimeline )
+				return nullptr;
+
+			return std::make_shared<CAcquireTimelinePoint>( m_pAcquireTimeline, m_ulAcquirePoint );
+		}
+
+		std::shared_ptr<CReleaseTimelinePoint> ExtractReleaseTimelinePoint() const
+		{
+			if ( !m_pReleaseTimeline )
+				return nullptr;
+
+			return std::make_shared<CReleaseTimelinePoint>( m_pReleaseTimeline, m_ulReleasePoint );
+		}
+
+	protected:
+
+		void SetAcquirePoint( wl_resource *pWlTimeline, uint32_t uPointHi, uint32_t uPointLo )
+		{
+			if ( !pWlTimeline )
+			{
+				m_pAcquireTimeline = nullptr;
+				return;
+			}
+
+			CLinuxDrmSyncobjTimeline *pTimeline = CWaylandResource::FromWlResource<CLinuxDrmSyncobjTimeline>( pWlTimeline );
+			m_pAcquireTimeline = pTimeline->GetTimeline();
+			m_ulAcquirePoint = ToUint64( uPointHi, uPointLo );
+		}
+
+		void SetReleasePoint( wl_resource *pWlTimeline, uint32_t uPointHi, uint32_t uPointLo )
+		{
+			if ( !pWlTimeline )
+			{
+				m_pReleaseTimeline = nullptr;
+				return;
+			}
+
+			CLinuxDrmSyncobjTimeline *pTimeline = CWaylandResource::FromWlResource<CLinuxDrmSyncobjTimeline>( pWlTimeline );
+			m_pReleaseTimeline = pTimeline->GetTimeline();
+			m_ulReleasePoint = ToUint64( uPointHi, uPointLo );
+		}
+
+	private:
+		wlserver_wl_surface_info *m_pWlSurfaceInfo = nullptr;
+
+		std::shared_ptr<CTimeline> m_pAcquireTimeline;
+		uint64_t m_ulAcquirePoint = 0;
+
+		std::shared_ptr<CTimeline> m_pReleaseTimeline;
+		uint64_t m_ulReleasePoint = 0;
+	};
+
+	const struct wp_linux_drm_syncobj_surface_v1_interface CLinuxDrmSyncobjSurface::Implementation = 
+	{
+		.destroy = WL_PROTO_DESTROY(),
+		.set_acquire_point = WL_PROTO( CLinuxDrmSyncobjSurface, SetAcquirePoint ),
+		.set_release_point = WL_PROTO( CLinuxDrmSyncobjSurface, SetReleasePoint ),
+	};
+
+	class CLinuxDrmSyncobjManager : public CWaylandResource
+	{
+	public:
+		WL_PROTO_DEFINE( wp_linux_drm_syncobj_manager_v1, 1 );
+		WL_PROTO_DEFAULT_CONSTRUCTOR();
+
+		void GetSurface( uint32_t uId, wl_resource *pSurfaceResource )
+		{
+			struct wlr_surface *pWlrSurface = wlr_surface_from_resource( pSurfaceResource );
+			struct wlserver_wl_surface_info *pWlSurfaceInfo = get_wl_surface_info( pWlrSurface );
+			if ( !pWlSurfaceInfo )
+			{
+				wl_client_post_implementation_error( m_pClient, "No wl_surface" );
+				return;
+			}
+
+			if ( pWlSurfaceInfo->pSyncobjSurface )
+			{
+				wl_resource_post_error( m_pResource,
+					WP_LINUX_DRM_SYNCOBJ_MANAGER_V1_ERROR_SURFACE_EXISTS,
+					"wp_linux_drm_syncobj_surface_v1 already created for this surface" );
+				return;
+			}
+
+			pWlSurfaceInfo->pSyncobjSurface = CWaylandResource::Create<CLinuxDrmSyncobjSurface>( m_pClient, m_uVersion, uId, pWlSurfaceInfo );
+		}
+
+		void ImportTimeline( uint32_t uId, int32_t nFd )
+		{
+			// Transfer nFd to a new CTimeline.
+			std::shared_ptr<CTimeline> pTimeline = std::make_shared<CTimeline>( nFd );
+			if ( !CheckAllocation( pTimeline ) )
+				return;
+
+            if ( !pTimeline->IsValid() )
+            {
+                wl_resource_post_error( m_pResource,
+                    WP_LINUX_DRM_SYNCOBJ_MANAGER_V1_ERROR_INVALID_TIMELINE,
+                    "Failed to import syncobj timeline" );
+                return;
+            }
+
+			CWaylandResource::Create<CLinuxDrmSyncobjTimeline>( m_pClient, m_uVersion, uId, std::move( pTimeline ) );
+		}
+
+	};
+
+	const struct wp_linux_drm_syncobj_manager_v1_interface CLinuxDrmSyncobjManager::Implementation =
+	{
+		.destroy = WL_PROTO_DESTROY(),
+		.get_surface = WL_PROTO( CLinuxDrmSyncobjManager, GetSurface ),
+		.import_timeline = WL_PROTO( CLinuxDrmSyncobjManager, ImportTimeline ),
+	};
+
+}

--- a/src/WaylandServer/WaylandDecls.h
+++ b/src/WaylandServer/WaylandDecls.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace gamescope::WaylandServer
+{
+    class CWaylandResource;
+
+    template <typename... Types>
+	class CWaylandProtocol;
+
+    class CLinuxDrmSyncobjManager;
+    class CLinuxDrmSyncobjSurface;
+    class CLinuxDrmSyncobjTimeline;
+    using CLinuxDrmSyncobj = CWaylandProtocol<CLinuxDrmSyncobjManager>;
+
+}

--- a/src/WaylandServer/WaylandProtocol.h
+++ b/src/WaylandServer/WaylandProtocol.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "WaylandResource.h"
+#include <vector>
+
+namespace gamescope::WaylandServer
+{
+
+	template <typename... Types>
+	class CWaylandProtocol : public NonCopyable
+	{
+	public:
+		CWaylandProtocol( wl_display *pDisplay )
+            : m_pDisplay{ pDisplay }
+		{
+            ( CreateGlobal<Types>(), ... );
+		}
+	private:
+
+        template <typename T>
+        void CreateGlobal()
+        {
+			wl_global *pGlobal = wl_global_create( m_pDisplay, T::Interface, T::Version, this,
+			[]( struct wl_client *pClient, void *pData, uint32_t uVersion, uint32_t uId )
+			{
+				CWaylandProtocol *pProtocol = reinterpret_cast<CWaylandProtocol *>( pData );
+				pProtocol->Bind<T>( pClient, uVersion, uId );
+			} );
+
+            m_pGlobals.emplace_back( pGlobal );
+        }
+
+        template <typename T>
+		void Bind( struct wl_client *pClient, uint32_t uVersion, uint32_t uId )
+		{
+			CWaylandResource::Create<T>( pClient, uVersion, uId );
+		}
+
+        wl_display *m_pDisplay = nullptr;
+        std::vector<wl_global *> m_pGlobals;
+	};
+
+}

--- a/src/WaylandServer/WaylandResource.h
+++ b/src/WaylandServer/WaylandResource.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <cstdint>
+#include <wayland-server-core.h>
+#include "../Utils/NonCopyable.h"
+
+namespace gamescope::WaylandServer
+{
+
+	#define WL_PROTO_NULL() [] <typename... Args> ( Args... args ) { }
+	#define WL_PROTO_DESTROY() [] <typename... Args> ( wl_client *pClient, wl_resource *pResource, Args... args ) { wl_resource_destroy( pResource ); }
+	#define WL_PROTO( type, name ) \
+		[] <typename... Args> ( wl_client *pClient, wl_resource *pResource, Args... args ) \
+		{ \
+			type *pThing = reinterpret_cast<type *>( wl_resource_get_user_data( pResource ) ); \
+			pThing->name( std::forward<Args>(args)... ); \
+		}
+
+	#define WL_PROTO_DEFINE( type, version ) \
+		static constexpr uint32_t Version = version; \
+		static constexpr const struct wl_interface *Interface = & type##_interface; \
+		static const struct type##_interface Implementation;
+
+	#define WL_PROTO_DEFAULT_CONSTRUCTOR() \
+		using CWaylandResource::CWaylandResource;
+
+	struct WaylandResourceDesc_t
+	{
+		wl_client *pClient;
+		wl_resource *pResource;
+		uint32_t uVersion;
+	};
+
+	class CWaylandResource : public NonCopyable
+	{
+	public:
+
+		CWaylandResource( WaylandResourceDesc_t desc )
+			: m_pClient{ desc.pClient }
+			, m_pResource{ desc.pResource }
+			, m_uVersion{ desc.uVersion }
+		{
+		}
+
+		~CWaylandResource()
+		{
+		}
+
+		void OnResourceDestroy()
+		{
+			m_pResource = nullptr;
+			m_pClient = nullptr;
+			m_uVersion = 0;
+
+			delete this;
+		}
+
+		template <typename T>
+		static bool CheckAllocation( const T &object, wl_client *pClient )
+		{
+			if ( !object )
+			{
+				wl_client_post_no_memory( pClient );
+				return false;
+			}
+
+			return true;
+		}
+
+		template <typename T>
+		bool CheckAllocation( const T &object )
+		{
+			return CheckAllocation( object, m_pClient );
+		}
+
+		template <typename T>
+		static T *FromWlResource( wl_resource *pResource )
+		{
+			T *pObject = reinterpret_cast<T*>( wl_resource_get_user_data( pResource ) );
+			return pObject;
+		}
+
+		template <typename T, typename... Args>
+		static T *Create( wl_client *pClient, uint32_t uVersion, uint32_t uId, Args... args )
+		{
+			wl_resource *pResource = wl_resource_create( pClient, T::Interface, uVersion, uId );
+			if ( !CheckAllocation( pResource, pClient ) )
+				return nullptr;
+
+			WaylandResourceDesc_t desc =
+			{
+				.pClient = pClient,
+				.pResource = pResource,
+				.uVersion = uVersion,
+			};
+			T *pThing = new T{ desc, std::forward<Args>(args)... };
+			if ( !CheckAllocation( pThing, pClient ) )
+				return nullptr;
+
+			wl_resource_set_implementation( pResource, &T::Implementation, pThing,
+			[]( wl_resource *pResource )
+			{
+				T *pObject = CWaylandResource::FromWlResource<T>( pResource );
+				pObject->OnResourceDestroy();
+			});
+
+			return pThing;
+		}
+
+		static uint64_t ToUint64( uint32_t uHi, uint32_t uLo )
+		{
+			return (uint64_t(uHi) << 32) | uLo;
+		}
+
+		wl_client *GetClient() const { return m_pClient; }
+		wl_resource *GetResource() const { return m_pResource; }
+		uint32_t GetVersion() const { return m_uVersion; }
+	protected:
+		wl_client *m_pClient = nullptr;
+		wl_resource *m_pResource = nullptr;
+		uint32_t m_uVersion = 0;
+	};
+
+}

--- a/src/WaylandServer/WaylandServerLegacy.h
+++ b/src/WaylandServer/WaylandServerLegacy.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <wayland-server-core.h>
+#include <memory>
+#include <optional>
+#include <vector>
+#include "vulkan_include.h"
+
+
+#include "wlr_begin.hpp"
+#include <wlr/types/wlr_compositor.h>
+#include "wlr_end.hpp"
+
+
+namespace gamescope
+{
+    class BackendBlob;
+}
+
+struct wlserver_x11_surface_info;
+struct wlserver_xdg_surface_info;
+
+struct wlserver_vk_swapchain_feedback
+{
+	uint32_t image_count;
+	VkFormat vk_format;
+	VkColorSpaceKHR vk_colorspace;
+	VkCompositeAlphaFlagBitsKHR vk_composite_alpha;
+	VkSurfaceTransformFlagBitsKHR vk_pre_transform;
+	VkBool32 vk_clipped;
+
+	std::shared_ptr<gamescope::BackendBlob> hdr_metadata_blob;
+};
+
+
+struct wlserver_wl_surface_info
+{
+	wlserver_x11_surface_info *x11_surface = nullptr;
+	wlserver_xdg_surface_info *xdg_surface = nullptr;
+
+	struct wlr_surface *wlr = nullptr;
+	struct wl_listener commit;
+	struct wl_listener destroy;
+
+	std::shared_ptr<wlserver_vk_swapchain_feedback> swapchain_feedback = {};
+	std::optional<VkPresentModeKHR> oCurrentPresentMode;
+
+	uint64_t sequence = 0;
+	std::vector<struct wl_resource*> pending_presentation_feedbacks;
+
+	std::vector<struct wl_resource *> gamescope_swapchains;
+	std::optional<uint32_t> present_id = std::nullopt;
+	uint64_t desired_present_time = 0;
+
+	uint64_t last_refresh_cycle = 0;
+};
+
+wlserver_wl_surface_info *get_wl_surface_info(struct wlr_surface *wlr_surf);

--- a/src/WaylandServer/WaylandServerLegacy.h
+++ b/src/WaylandServer/WaylandServerLegacy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <wayland-server-core.h>
+#include "WaylandDecls.h"
 #include <memory>
 #include <optional>
 #include <vector>
@@ -37,6 +38,8 @@ struct wlserver_wl_surface_info
 {
 	wlserver_x11_surface_info *x11_surface = nullptr;
 	wlserver_xdg_surface_info *xdg_surface = nullptr;
+
+	gamescope::WaylandServer::CLinuxDrmSyncobjSurface *pSyncobjSurface = nullptr;
 
 	struct wlr_surface *wlr = nullptr;
 	struct wl_listener commit;

--- a/src/backend.h
+++ b/src/backend.h
@@ -3,6 +3,7 @@
 #include "color_helpers.h"
 #include "gamescope_shared.h"
 #include "vulkan_include.h"
+#include "Timeline.h"
 #include "convar.h"
 #include "rc.h"
 
@@ -146,23 +147,25 @@ namespace gamescope
     class IBackendFb : public IRcObject
     {
     public:
-        virtual void SetReleasePoint( const GamescopeTimelinePoint &point ) = 0;
+        virtual void SetBuffer( wlr_buffer *pClientBuffer ) = 0;
+        virtual void SetReleasePoint( std::shared_ptr<CReleaseTimelinePoint> pReleasePoint ) = 0;
     };
 
     class CBaseBackendFb : public IBackendFb
     {
     public:
-        CBaseBackendFb( wlr_buffer *pClientBuffer );
+        CBaseBackendFb();
         virtual ~CBaseBackendFb();
 
         uint32_t IncRef() override;
         uint32_t DecRef() override;
 
-        void SetReleasePoint( const GamescopeTimelinePoint &point ) override;
+        void SetBuffer( wlr_buffer *pClientBuffer ) override;
+        void SetReleasePoint( std::shared_ptr<CReleaseTimelinePoint> pReleasePoint ) override;
 
     private:
         wlr_buffer *m_pClientBuffer = nullptr;
-        std::optional<GamescopeTimelinePoint> m_oPoint;
+        std::shared_ptr<CReleaseTimelinePoint> m_pReleasePoint;
     };
 
     class IBackend

--- a/src/commit.cpp
+++ b/src/commit.cpp
@@ -29,8 +29,6 @@ commit_t::~commit_t()
         // presentation_feedbacks cleared by wlserver_presentation_feedback_discard
     }
     wlr_buffer_unlock( buf );
-    if ( m_oReleasePoint )
-        m_oReleasePoint->Release();
     wlserver_unlock();
 }
 
@@ -128,7 +126,3 @@ void commit_t::SetFence( int nFence, bool bMangoNudge, CommitDoneList_t *pDoneCo
     m_pDoneCommits = pDoneCommits;
 }
 
-void commit_t::SetReleasePoint( const std::optional<GamescopeTimelinePoint>& oReleasePoint )
-{
-    m_oReleasePoint = oReleasePoint;
-}

--- a/src/commit.h
+++ b/src/commit.h
@@ -18,7 +18,6 @@ struct commit_t final : public gamescope::RcObject, public gamescope::IWaitable
 	// Returns true if we had a fence that was closed.
 	bool CloseFenceInternal();
 	void SetFence( int nFence, bool bMangoNudge, CommitDoneList_t *pDoneCommits );
-	void SetReleasePoint( const std::optional<GamescopeTimelinePoint>& oReleasePoint );
 
 	struct wlr_buffer *buf = nullptr;
 	gamescope::Rc<CVulkanTexture> vulkanTex;
@@ -42,5 +41,4 @@ struct commit_t final : public gamescope::RcObject, public gamescope::IWaitable
 	int m_nCommitFence = -1;
 	bool m_bMangoNudge = false;
 	CommitDoneList_t *m_pDoneCommits = nullptr; // I hate this
-	std::optional<GamescopeTimelinePoint> m_oReleasePoint;
 };

--- a/src/gamescope_shared.h
+++ b/src/gamescope_shared.h
@@ -64,14 +64,6 @@ enum GamescopePanelOrientation
 	GAMESCOPE_PANEL_ORIENTATION_AUTO,
 };
 
-struct GamescopeTimelinePoint
-{
-	struct wlr_drm_syncobj_timeline *pTimeline = nullptr;
-	uint64_t ulPoint = 0;
-
-	void Release();
-};
-
 // Disable partial composition for now until we get
 // composite priorities working in libliftoff + also
 // use the proper libliftoff composite plane system.

--- a/src/meson.build
+++ b/src/meson.build
@@ -111,6 +111,7 @@ src = [
   'log.cpp',
   'ime.cpp',
   'mangoapp.cpp',
+  'Timeline.cpp',
   'reshade_effect_manager.cpp',
   'backend.cpp',
   'x11cursor.cpp',

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -672,6 +672,8 @@ static inline uint32_t div_roundup(uint32_t x, uint32_t y)
 	VK_FUNC(CreateSampler) \
 	VK_FUNC(CreateSamplerYcbcrConversion) \
 	VK_FUNC(CreateSemaphore) \
+	VK_FUNC(GetSemaphoreFdKHR) \
+	VK_FUNC(ImportSemaphoreFdKHR) \
 	VK_FUNC(CreateShaderModule) \
 	VK_FUNC(CreateSwapchainKHR) \
 	VK_FUNC(DestroyBuffer) \
@@ -680,6 +682,7 @@ static inline uint32_t div_roundup(uint32_t x, uint32_t y)
 	VK_FUNC(DestroyImage) \
 	VK_FUNC(DestroyImageView) \
 	VK_FUNC(DestroyPipeline) \
+	VK_FUNC(DestroySemaphore) \
 	VK_FUNC(DestroyPipelineLayout) \
 	VK_FUNC(DestroySampler) \
 	VK_FUNC(DestroySwapchainKHR) \
@@ -713,6 +716,18 @@ constexpr T align(T what, U to) {
 return (what + to - 1) & ~(to - 1);
 }
 
+class CVulkanDevice;
+
+struct VulkanTimelineSemaphore_t
+{
+	~VulkanTimelineSemaphore_t();
+
+	CVulkanDevice *pDevice = nullptr;
+	VkSemaphore pVkSemaphore = VK_NULL_HANDLE;
+	int nFd = -1; // Syncobj FD, not renderer fd. Get that from pDevice.
+	uint32_t uHandle = 0;
+};
+
 class CVulkanDevice
 {
 public:
@@ -733,6 +748,9 @@ public:
 		m_currentDescriptorSet = (m_currentDescriptorSet + 1) % m_descriptorSets.size();
 		return ret;
 	}
+
+	std::shared_ptr<VulkanTimelineSemaphore_t> CreateTimelineSemaphore( uint64_t ulStartingPoint );
+	std::shared_ptr<VulkanTimelineSemaphore_t> ImportTimelineSemaphore( uint32_t uHandle );
 
 	static const uint32_t upload_buffer_size = 1920 * 1080 * 4;
 

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -46,8 +46,8 @@ struct ResListEntry_t {
 	std::vector<struct wl_resource*> presentation_feedbacks;
 	std::optional<uint32_t> present_id;
 	uint64_t desired_present_time;
-	std::optional<GamescopeAcquireTimelineState> oAcquireState;
-	std::optional<GamescopeTimelinePoint> oReleasePoint;
+	std::shared_ptr<gamescope::CAcquireTimelinePoint> pAcquirePoint;
+	std::shared_ptr<gamescope::CReleaseTimelinePoint> pReleasePoint;
 };
 
 struct wlserver_content_override;
@@ -116,7 +116,6 @@ struct wlserver_t {
 		struct wlr_compositor *compositor;
 		struct wlr_session *session;
 		struct wlr_seat *seat;
-		struct wlr_linux_drm_syncobj_manager_v1 *drm_syncobj_manager_v1;
 
 		// Used to simulate key events and set the keymap
 		struct wlr_keyboard *virtual_keyboard_device;
@@ -266,8 +265,6 @@ void wlserver_set_output_info( const wlserver_output_info *info );
 
 gamescope_xwayland_server_t *wlserver_get_xwayland_server( size_t index );
 const char *wlserver_get_wl_display_name( void );
-
-wlserver_wl_surface_info *get_wl_surface_info(struct wlr_surface *wlr_surf);
 
 void wlserver_x11_surface_info_init( struct wlserver_x11_surface_info *surf, gamescope_xwayland_server_t *server, uint32_t x11_id );
 void wlserver_x11_surface_info_finish( struct wlserver_x11_surface_info *surf );

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -13,6 +13,9 @@
 #include <unordered_map>
 #include <optional>
 
+#include "WaylandServer/WaylandDecls.h"
+#include "WaylandServer/WaylandServerLegacy.h"
+
 #include <pixman-1/pixman.h>
 
 #include "vulkan_include.h"
@@ -27,18 +30,6 @@
 
 struct _XDisplay;
 struct xwayland_ctx_t;
-
-struct wlserver_vk_swapchain_feedback
-{
-	uint32_t image_count;
-	VkFormat vk_format;
-	VkColorSpaceKHR vk_colorspace;
-	VkCompositeAlphaFlagBitsKHR vk_composite_alpha;
-	VkSurfaceTransformFlagBitsKHR vk_pre_transform;
-	VkBool32 vk_clipped;
-
-	std::shared_ptr<gamescope::BackendBlob> hdr_metadata_blob;
-};
 
 struct GamescopeAcquireTimelineState
 {
@@ -276,28 +267,6 @@ void wlserver_set_output_info( const wlserver_output_info *info );
 gamescope_xwayland_server_t *wlserver_get_xwayland_server( size_t index );
 const char *wlserver_get_wl_display_name( void );
 
-struct wlserver_wl_surface_info
-{
-	wlserver_x11_surface_info *x11_surface = nullptr;
-	wlserver_xdg_surface_info *xdg_surface = nullptr;
-
-
-	struct wlr_surface *wlr = nullptr;
-	struct wl_listener commit;
-	struct wl_listener destroy;
-
-	std::shared_ptr<wlserver_vk_swapchain_feedback> swapchain_feedback = {};
-	std::optional<VkPresentModeKHR> oCurrentPresentMode;
-
-	uint64_t sequence = 0;
-	std::vector<struct wl_resource*> pending_presentation_feedbacks;
-
-	std::vector<struct wl_resource *> gamescope_swapchains;
-	std::optional<uint32_t> present_id = std::nullopt;
-	uint64_t desired_present_time = 0;
-
-	uint64_t last_refresh_cycle = 0;
-};
 wlserver_wl_surface_info *get_wl_surface_info(struct wlr_surface *wlr_surf);
 
 void wlserver_x11_surface_info_init( struct wlserver_x11_surface_info *surf, gamescope_xwayland_server_t *server, uint32_t x11_id );


### PR DESCRIPTION
The wlroots protocol is incredibly limiting... In such a way we would need a wlserver lock when we release timeline points, which is totally dumb.

wlroots refcounts not being atomic makes them totally useless for us.