### PR TITLE
Check if current GPU supports Vulkan DRM modifiers when `--backend=auto` is used

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -817,9 +817,13 @@ int main(int argc, char **argv)
 	if ( eCurrentBackend == gamescope::GamescopeBackend::Auto )
 	{
 		if ( g_pOriginalWaylandDisplay != NULL )
-			eCurrentBackend = gamescope::GamescopeBackend::Wayland;
-		else if ( g_pOriginalDisplay != NULL )
-			eCurrentBackend = gamescope::GamescopeBackend::SDL;
+			// Additional check if the current GPU supports Vulkan DRM modifiers
+			// Fallback to SDL if not supported (e.g Older AMD GPUs like Polaris 10/20)
+			if ( vulkan_supports_modifiers() ) 
+				eCurrentBackend = gamescope::GamescopeBackend::Wayland;
+			else
+				eCurrentBackend = gamescope::GamescopeBackend::SDL;
+
 		else
 			eCurrentBackend = gamescope::GamescopeBackend::DRM;
 	}


### PR DESCRIPTION
This works around #1218 by making use of the new backend option added in #1321, but adds a check to automatically fall back to the SDL backend if the current GPU does not support Vulkan DRM modifiers.