### PR TITLE
rendervulkan: address several warnings from GCC's new -Wnrvo warning

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1199,8 +1199,13 @@ int32_t CVulkanDevice::findMemoryType( VkMemoryPropertyFlags properties, uint32_
 }
 
 std::unique_ptr<CVulkanCmdBuffer> CVulkanDevice::commandBuffer()
-{
-	std::unique_ptr<CVulkanCmdBuffer> cmdBuffer;
+{	
+	auto finalizeCmdBuffer = [this](std::unique_ptr<CVulkanCmdBuffer> cmdBuffer, void (*preInitHook)(CVulkanDevice*) = [](CVulkanDevice*) { return; } ) {
+		preInitHook(this);
+		cmdBuffer->begin();
+		return cmdBuffer;
+	};
+
 	if (m_unusedCmdBufs.empty())
 	{
 		VkCommandBuffer rawCmdBuffer;
@@ -1218,16 +1223,14 @@ std::unique_ptr<CVulkanCmdBuffer> CVulkanDevice::commandBuffer()
 			return nullptr;
 		}
 
-		cmdBuffer = std::make_unique<CVulkanCmdBuffer>(this, rawCmdBuffer, queue(), queueFamily());
+		return finalizeCmdBuffer(std::make_unique<CVulkanCmdBuffer>(this, rawCmdBuffer, queue(), queueFamily()));
 	}
 	else
 	{
-		cmdBuffer = std::move(m_unusedCmdBufs.back());
-		m_unusedCmdBufs.pop_back();
+		return finalizeCmdBuffer(std::move(m_unusedCmdBufs.back()), [](CVulkanDevice* obj) {
+			obj->m_unusedCmdBufs.pop_back();
+		});
 	}
-
-	cmdBuffer->begin();
-	return cmdBuffer;
 }
 
 uint64_t CVulkanDevice::submitInternal( CVulkanCmdBuffer* cmdBuffer )
@@ -1337,8 +1340,8 @@ int VulkanTimelineSemaphore_t::GetFd() const
 
 std::shared_ptr<VulkanTimelineSemaphore_t> CVulkanDevice::CreateTimelineSemaphore( uint64_t ulStartPoint, bool bShared )
 {
-	std::shared_ptr<VulkanTimelineSemaphore_t> pSemaphore = std::make_unique<VulkanTimelineSemaphore_t>();
-	pSemaphore->pDevice = this;
+	VulkanTimelineSemaphore_t semaphore{};
+	semaphore.pDevice = this;
 
 	VkSemaphoreCreateInfo createInfo =
 	{
@@ -1362,19 +1365,20 @@ std::shared_ptr<VulkanTimelineSemaphore_t> CVulkanDevice::CreateTimelineSemaphor
 	};
 
 	VkResult res;
-	if ( ( res = vk.CreateSemaphore( m_device, &createInfo, nullptr, &pSemaphore->pVkSemaphore ) ) != VK_SUCCESS )
+	if ( ( res = vk.CreateSemaphore( m_device, &createInfo, nullptr, &semaphore.pVkSemaphore ) ) != VK_SUCCESS )
 	{
 		vk_errorf( res, "vkCreateSemaphore failed" );
 		return nullptr;
 	}
 
-	return pSemaphore;
+	return std::make_shared<VulkanTimelineSemaphore_t>( semaphore );
 }
 
 std::shared_ptr<VulkanTimelineSemaphore_t> CVulkanDevice::ImportTimelineSemaphore( gamescope::CTimeline *pTimeline )
 {
-	std::shared_ptr<VulkanTimelineSemaphore_t> pSemaphore = std::make_unique<VulkanTimelineSemaphore_t>();
-	pSemaphore->pDevice = this;
+	VulkanTimelineSemaphore_t semaphore{};
+	semaphore.pDevice = this;
+	
 
 	const VkSemaphoreTypeCreateInfo typeInfo =
 	{
@@ -1389,7 +1393,7 @@ std::shared_ptr<VulkanTimelineSemaphore_t> CVulkanDevice::ImportTimelineSemaphor
 	};
 
 	VkResult res;
-	if ( ( res = vk.CreateSemaphore( m_device, &createInfo, nullptr, &pSemaphore->pVkSemaphore ) ) != VK_SUCCESS )
+	if ( ( res = vk.CreateSemaphore( m_device, &createInfo, nullptr, &semaphore.pVkSemaphore ) ) != VK_SUCCESS )
 	{
 		vk_errorf( res, "vkCreateSemaphore failed" );
 		return nullptr;
@@ -1406,7 +1410,7 @@ std::shared_ptr<VulkanTimelineSemaphore_t> CVulkanDevice::ImportTimelineSemaphor
 	{
 		.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR,
 		.pNext = nullptr,
-		.semaphore = pSemaphore->pVkSemaphore,
+		.semaphore = semaphore.pVkSemaphore,
 		.flags = 0, // not temporary
 		.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT,
 		.fd = dup( pTimeline->GetSyncobjFd() ),
@@ -1417,7 +1421,7 @@ std::shared_ptr<VulkanTimelineSemaphore_t> CVulkanDevice::ImportTimelineSemaphor
 		return nullptr;
 	}
 
-	return pSemaphore;
+	return std::make_shared<VulkanTimelineSemaphore_t>( semaphore );
 }
 
 void CVulkanCmdBuffer::AddDependency( std::shared_ptr<VulkanTimelineSemaphore_t> pTimelineSemaphore, uint64_t ulPoint )


### PR DESCRIPTION
Three functions edited to enable complete (n)rvo

I checked the differences this PR made to the codegen when building w/ gcc & `--buildtype=release -Db_lto=on`

For `CVulkanDevice::commandBuffer()`, this removes one or more conditional deletion checks on a temporary empty unique_ptr (which I'm pretty sure is unreachable, but the compiler is not aware of that fact)

For `CVulkanDevice::CreateTimelineSemaphore` and `CVulkanDevice::ImportTimelineSemaphore` this PR removes one or more atomic adds from said functions (when building w/ lto for gcc, the two functions are inlined, but in the places that they were inlined into, there's still a reduction in the amount of atomic adds compared to before this PR)

There are still some remaining warnings from -Wnrvo, but they either don't seem to be worth the effort, at least for now...