### PR TITLE
build: add compiler information to gamescope_version

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -161,10 +161,22 @@ foreach feat : required_wlroots_features
   endif
 endforeach
 
-gamescope_version = vcs_tag(
-  command : ['git', 'describe', '--always', '--tags', '--dirty=+'],
-  input   : 'GamescopeVersion.h.in',
-  output  : 'GamescopeVersion.h')
+cc = meson.get_compiler('c')
+compiler_name = cc.get_id()
+compiler_version = cc.version()
+
+vcs_tag_cmd = ['git', 'describe', '--always', '--tags', '--dirty=+']
+vcs_tag = run_command(vcs_tag_cmd).stdout().strip()
+version_tag = vcs_tag + ' (' + compiler_name + ' ' + compiler_version + ')'
+
+gamescope_version_conf = configuration_data()
+gamescope_version_conf.set('VCS_TAG', version_tag)
+
+gamescope_version = configure_file(
+  input : 'GamescopeVersion.h.in',
+  output : 'GamescopeVersion.h',
+  configuration : gamescope_version_conf
+)
 
   executable(
     'gamescope',


### PR DESCRIPTION
Seems helpful for diagnosing future issues that may come up in one build that may not be present in the same build with a different compiler.

Reports as:
```
❯ gamescope --version
[gamescope] [Info]  console: gamescope version 3.15.5 (clang 18.1.8)
```
for tagged versions but still captures git information properly when between tags or when the tree is dirty
```
❯ gamescope --version
[gamescope] [Info]  console: gamescope version 3.15.0-5-g81d8f8e+ (gcc 14.2.1)
```

could also drop off the compiler version number to keep it cleaner if that's preferable