### PR TITLE
build: fix meson warning for run_command

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -166,7 +166,7 @@ compiler_name = cc.get_id()
 compiler_version = cc.version()
 
 vcs_tag_cmd = ['git', 'describe', '--always', '--tags', '--dirty=+']
-vcs_tag = run_command(vcs_tag_cmd).stdout().strip()
+vcs_tag = run_command(vcs_tag_cmd, check: false).stdout().strip()
 version_tag = vcs_tag + ' (' + compiler_name + ' ' + compiler_version + ')'
 
 gamescope_version_conf = configuration_data()


### PR DESCRIPTION
fixes:
```
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
Configuring GamescopeVersion.h using configuration
```
my bad :frog: easy to miss while doing `meson install -C build/` every time. definitely don't want this eventually failing builds compared to the original behavior.