### PR TITLE
Fix how the gamescope-reshade server clears effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Gamescope supports a subset of Reshade effects/shaders using the `--reshade-effe
 
 This provides an easy way to do shader effects (ie. CRT shader, film grain, debugging HDR with histograms, etc) on top of whatever is being displayed in Gamescope without having to hook into the underlying process.
 
-There is currently no way to set the value of uniforms/options, they will just be their initializer values currently.
+Uniform/shader options can be modified programmatically via the `gamescope-reshade` wayland interface. Otherwise, they will just use their initializer values.
 
 Using Reshade effects will increase latency as there will be work performed on the general gfx + compute queue as opposed to only using the realtime async compute queue which can run in tandem with the game's gfx work.
 

--- a/src/reshade_effect_manager.cpp
+++ b/src/reshade_effect_manager.cpp
@@ -1949,5 +1949,5 @@ void reshade_effect_manager_enable_effect()
 
 void reshade_effect_manager_disable_effect() 
 {
-    gamescope_set_reshade_effect(nullptr);
+    gamescope_clear_reshade_effect();
 }

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2955,20 +2955,22 @@ std::string get_string_prop( xwayland_ctx_t *ctx, Window win, Atom prop )
 	return value;
 }
 
-void set_string_prop( xwayland_ctx_t *ctx, Window win, Atom prop, const std::string &value )
+void set_string_prop( xwayland_ctx_t *ctx, Atom prop, const std::string &value )
 {
-	if ( value.empty() )
-		XDeleteProperty( ctx->dpy, win, prop );
-	else {
-		XTextProperty text_property =
-		{
-			.value = ( unsigned char * )value.c_str(),
-			.encoding = ctx->atoms.utf8StringAtom,
-			.format = 8,
-			.nitems = strlen( value.c_str() )
-		};
-		XSetTextProperty( ctx->dpy, ctx->root, &text_property, prop);
-	}
+	XTextProperty text_property =
+	{
+		.value = ( unsigned char * )value.c_str(),
+		.encoding = ctx->atoms.utf8StringAtom,
+		.format = 8,
+		.nitems = strlen( value.c_str() )
+	};
+	XSetTextProperty( ctx->dpy, ctx->root, &text_property, prop);
+	XFlush( ctx->dpy );
+}
+
+void clear_prop( xwayland_ctx_t *ctx, Atom prop )
+{
+	XDeleteProperty( ctx->dpy, ctx->root, prop );
 	XFlush( ctx->dpy );
 }
 
@@ -4896,7 +4898,12 @@ void gamescope_set_selection(std::string contents, GamescopeSelection eSelection
 void gamescope_set_reshade_effect(std::string effect_path)
 {
 	gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(0);
-	set_string_prop(server->ctx.get(), server->ctx->ourWindow, server->ctx->atoms.gamescopeReshadeEffect, effect_path);
+	set_string_prop(server->ctx.get(), server->ctx->atoms.gamescopeReshadeEffect, effect_path);
+}
+
+void gamescope_clear_reshade_effect() {
+	gamescope_xwayland_server_t *server = wlserver_get_xwayland_server(0);
+	clear_prop(server->ctx.get(), server->ctx->atoms.gamescopeReshadeEffect);
 }
 
 static void

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -148,6 +148,7 @@ extern pid_t focusWindow_pid;
 void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_server);
 void gamescope_set_selection(std::string contents, GamescopeSelection eSelection);
 void gamescope_set_reshade_effect(std::string effect_path);
+void gamescope_clear_reshade_effect();
 
 MouseCursor *steamcompmgr_get_current_cursor();
 MouseCursor *steamcompmgr_get_server_cursor(uint32_t serverId);

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -58,7 +58,6 @@
 #include "steamcompmgr.hpp"
 #include "log.hpp"
 #include "ime.hpp"
-#include "reshade_effect_manager.hpp"
 #include "xwayland_ctx.hpp"
 #include "refresh_rate.h"
 #include "InputEmulation.h"


### PR DESCRIPTION
The current approach crashes when attempting to pass `nullptr` to effect path.