### PR TITLE
update actions/checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
             libxtst libxkbcommon libdrm libinput wayland-protocols benchmark \
             xorg-xwayland pipewire cmake \
             libavif libheif aom rav1e libdecor libxdamage
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Build with gcc


### PR DESCRIPTION
https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/

> Following our [change to default customers to use Node20](https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/), Node16 will reach end of life in the Actions runner on the 15th of October 2024.
> 
> From the 15th of October, we will no longer include Node16 in the Actions runner and customers will no longer be able to use Node16 Actions or operating systems that do not support Node20.
> 
> To prevent disruption to your Actions workflows, if you’re an Actions maintainer, update your actions to run on Node20 instead of Node16. If you’re an Actions user, update your workflows with latest versions of the actions, which run on Node20.