### PR TITLE
readme: Fix Meson deprecated command warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If running RadeonSI clients with older cards (GFX8 and below), currently have to
 
 ```
 git submodule update --init
-meson build/
+meson setup build/
 ninja -C build/
 build/gamescope -- <game>
 ```


### PR DESCRIPTION
```
# meson build/
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```

https://mesonbuild.com/Commands.html#setup
> Deprecated since 0.64.0: This is the default Meson command (invoked if there was no COMMAND supplied). However, supplying the command is necessary to avoid clashes with future added commands, so "setup" should be used explicitly.