### PR TITLE
script: use "display" instead of "value" in debug output

### DIFF
--- a/scripts/00-gamescope/displays/asus.rogally.lcd.lua
+++ b/scripts/00-gamescope/displays/asus.rogally.lcd.lua
@@ -66,7 +66,7 @@ gamescope.config.known_displays.rogally_lcd = {
     -- ROG Ally + ROG Ally X.
     matches = function(display)
         if display.vendor == "TMX" and display.model == "TL070FVXS01-0" and display.product == 0x0002 then
-            debug("[rogally_lcd] Matched vendor: "..value.vendor.." model: "..value.model.." product:"..value.product)
+            debug("[rogally_lcd] Matched vendor: "..display.vendor.." model: "..display.model.." product:"..display.product)
             return 5000
         end
         return -1

--- a/scripts/00-gamescope/displays/deckhd.steamdeck.deckhd-lcd.lua
+++ b/scripts/00-gamescope/displays/deckhd.steamdeck.deckhd-lcd.lua
@@ -39,7 +39,7 @@ gamescope.config.known_displays.steamdeck_deckhd_lcd = {
     end,
     matches = function(display)
         if display.vendor == "DHD" and display.model == "DeckHD-1200p" and display.product == 0x4001 then
-            debug("[steamdeck_deckhd_lcd] Matched vendor: "..value.vendor.." model: "..value.model.." product:"..value.product)
+            debug("[steamdeck_deckhd_lcd] Matched vendor: "..display.vendor.." model: "..display.model.." product:"..display.product)
             return 5000
         end
 


### PR DESCRIPTION
"value" is not used or defined in either device's lua config for the matches function. Instead, use "display" for the debug output string.

Fixes a coredump when entering gamescope-session on ROG Ally. whoops