### PR TITLE
script: Lenovo Legion Go display configuration

### DIFF
--- a/scripts/00-gamescope/displays/lenovo.legiongo.lcd.lua
+++ b/scripts/00-gamescope/displays/lenovo.legiongo.lcd.lua
@@ -1,0 +1,48 @@
+gamescope.config.known_displays.lenovo_legiongo_lcd = {
+    pretty_name = "Lenovo Legion Go LCD",
+    dynamic_refresh_rates = {
+        60,
+        125, 126, 127, 128, 129,
+        130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+        140, 141, 142, 143, 144
+    },
+    hdr = {
+        -- Setup some fallbacks for undocking with HDR, meant
+        -- for the internal panel. It does not support HDR.
+        supported = false,
+        force_enabled = false,
+        eotf = gamescope.eotf.gamma22,
+        max_content_light_level = 500,
+        max_frame_average_luminance = 500,
+        min_content_light_level = 0.5
+    },
+    -- Use the EDID colorimetry for now, but someone should check
+    -- if the EDID colorimetry truly matches what the display is capable of.
+    dynamic_modegen = function(base_mode, refresh)
+        debug("Generating mode "..refresh.."Hz for Lenovo Legion Go LCD")
+        local mode = base_mode
+
+        -- These are only tuned for 1600x2560
+        gamescope.modegen.set_resolution(mode, 1600, 2560)
+
+        -- Horizontal timings: Hfront, Hsync, Hback
+        gamescope.modegen.set_h_timings(mode, 60, 30, 130)
+        -- Vertical timings: Vfront, Vsync, Vback
+        gamescope.modegen.set_v_timings(mode, 30, 4, 96)
+
+        mode.clock = gamescope.modegen.calc_max_clock(mode, refresh)
+        mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)
+
+        return mode
+    end,
+    matches = function(display)
+        -- There is only a single panel in use on Lenovo Legion Go devices.
+        if display.vendor == "LEN" and display.model == "Go Display" and display.product == 0x0001 then
+            debug("[lenovo_legiongo_lcd] Matched vendor: "..display.vendor.." model: "..display.model.." product: "..display.product)
+            return 5000
+        end
+        return -1
+    end
+}
+debug("Registered Lenovo Legion Go LCD as a known display")
+--debug(inspect(gamescope.config.known_displays.lenovo_legiongo_lcd))


### PR DESCRIPTION
Add support for the Lenovo Legion Go handheld, which features a rotated 1600x2560 panel that reports 60hz and 144hz in the EDID. VRR and HDR are not supported, and only one panel model is known to be in use.

Starting with every integer between 60hz and 144hz, valid refresh rates for the panel were tested one-by-one in two games:

* Hades II
* Portal 2

With dynamic modegen, the range of valid refresh rates can be expanded to 60hz + 125hz -> 144hz, offering more frame limit notches in the lower range of the Steam UI unified slider. This new range is what was used for further validation across several units.

Linux setups tested include:

* Bazzite 40 with kernel 6.9.12-210.fsync
* SteamOS Main 20240919.1002 with kernel 6.8.12-valve2-1

Games tested with the new range include:

* Hades II
* Portal 2
* Left 4 Dead 2
* Metro Exodus
* Outer Wilds
* God of War: Ragnarok
* Hi-Fi Rush
* Manor Lords
* Nine Sols

All games tested were able to run with the slider behaving like SteamOS on a Steam Deck LCD when modesetting and maintaining a frame limit. 

---

At this point further validation would be welcome on additional machines, but the configuration has proven stable thus far.

To read up on the new config system that makes all this possible, as well as some general words of warning, you can refer to the readme in the scripts folder and the existing display configurations:
https://github.com/ValveSoftware/gamescope/blob/master/scripts/README.md

A full Steam System Report from gamescope-session on my unit is available for reference:
https://gist.github.com/matte-schwartz/e7723214478de5122216874621bc22d2
