### PR TITLE
Removed GAMESCOPE_NV12_COLORSPACE default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -611,9 +611,6 @@ static void UpdateCompatEnvVars()
 	// Don't minimise stuff on focus loss with SDL.
 	setenv( "SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", "0", 1 );
 
-	// A sane default here.
-	setenv( "GAMESCOPE_NV12_COLORSPACE", "k_EStreamColorspace_BT601", 0 );
-
 	const char *pszMangoConfigPath = getenv( "MANGOHUD_CONFIGFILE" );
 	if ( (g_bLaunchMangoapp && steamMode) && ( !pszMangoConfigPath || !*pszMangoConfigPath ) )
 	{


### PR DESCRIPTION
This was being set in UpdateCompatEnvVars(), which is called after the environment variable is already read. The default in rendervulkan.cpp if the environment variable isn't set is BT.709 full-range, which is a sane default, so this isn't necessary.