### PR TITLE
build: allow disabling script installation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,4 +97,6 @@ if get_option('enable_gamescope')
 endif
 
 # Handle default script/config stuff
-meson.add_install_script('default_scripts_install.sh')
+if get_option('include_scripts')
+  meson.add_install_script('default_scripts_install.sh')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('enable_gamescope',           type : 'boolean', value : true, description
 option('enable_gamescope_wsi_layer', type : 'boolean', value : true, description: 'Build Gamescope layer')
 option('enable_openvr_support',      type : 'boolean', value : true, description: 'OpenVR Integrations')
 option('benchmark', type: 'feature', description: 'Benchmark tools')
+option('include_scripts',            type : 'boolean', value : true, description: 'Install Lua Scripts')


### PR DESCRIPTION
Should fix: #1575 

actually now that i'm taking a closer look at `src/meson.build` there's probably a better way to do this change... 