### PR TITLE
wlserver: Re-hook pausing on session pause

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1340,8 +1340,7 @@ bool wlsession_active()
 
 static void handle_session_active( struct wl_listener *listener, void *data )
 {
-	if (wlserver.wlr.session->active)
-		GetBackend()->DirtyState( true, true );
+	GetBackend()->DirtyState( wlserver.wlr.session->active, wlserver.wlr.session->active );
 	wl_log.infof( "Session %s", wlserver.wlr.session->active ? "resumed" : "paused" );
 }
 #endif


### PR DESCRIPTION
During the refactor in 88eb1b477d8b1efbe6d7087dcde74052dad84049, the handle_session_active function lost the ultimate role of *causing a pause* when the session became inactive.

The duty of pausing the session was given the `DirtyState` function on the backend, which now uses the same "moral" condition to set the paused state (`g_DRM.paused = !wlsession_active();`)...

... except that now `DirtyState` state is only called when the session is resumed. In turn, this means that on session suspend, nothing ends-up pausing the DRM backend anymore!

This change unconditionally calls `DirtyState`, which in turn does the accounting for pausing the backend. Actually, it conditionally passes `false` to the argument to force nothing.

This fixes what ends-up causing `drmModeAtomicCommit: Permission denied` when moving to another VT from gamescope's.

* * *

Hi again! :wave:

Hot off the heels of #1584 I was writing-up a bug report to solve the cause of the symptom I was observing.

As it turns out, while showing where my knowledge about the situation ended, I realized the solution was within the scope of my knowledge.

I'm not 100% sure of the actual current implementation (passing the `active` flag to `DirtyState`), there may be something more apt to do nowadays to actually pause the renderer, but looking [at the change that AFAIUI introduced this regression](https://github.com/ValveSoftware/gamescope/commit/88eb1b477d8b1efbe6d7087dcde74052dad84049#diff-d0b47055f30698065d0eec7b888329d6244667245b6f19c8bd2119de71f18a20L1254-R1296), this is recovering the initial intent.

Anyways, the fact all the hard work was already done made it trivial to add the feature to “Handle seat disable/resume for VT switching”.

Don't hesitate to discuss changes, or even directly send them here if anything trivial.

### How this was tested

Manually, using a Jovian NixOS system (SteamOS UI and system semantics) on my Steam Deck. It was on top of gamescope `3.15.11`, but it shouldn't really matter compared to the current revision on master.

I'm using the symptom (the libliftoff message) as a success metric.

Going from:

```
[gamescope] [Info]  wlserver: [libseat] [libseat/backend/logind.c:382] Disabling seat                                                                       
[gamescope] [Info]  wlserver: Session paused                                                                                                                
drmModeAtomicCommit: Permission denied
drmModeAtomicCommit: Permission denied
< snipped the many repeats >
drmModeAtomicCommit: Permission denied
drmModeAtomicCommit: Permission denied
[gamescope] [Info]  wlserver: [libseat] [libseat/backend/logind.c:379] Enabling seat                                                                        
[gamescope] [Info]  wlserver: Session resumed
```

To:

```
[gamescope] [Info]  wlserver: [libseat] [libseat/backend/logind.c:382] Disabling seat                                                                       
[gamescope] [Info]  wlserver: Session paused                                                                                                                
[gamescope] [Info]  drm: Connector eDP-1 -> VLV - ANX7530 U            
[gamescope] [Info]  drm: [colorimetry]: EDID with colorimetry detected. Using it                                                                            
[gamescope] [Info]  drm: [colorimetry]: r 0.684570 0.314453                                               
[gamescope] [Info]  drm: [colorimetry]: g 0.245117 0.714844                                                    
[gamescope] [Info]  drm: [colorimetry]: b 0.137695 0.049805                                          
[gamescope] [Info]  drm: [colorimetry]: w 0.312500 0.329102                                               
[gamescope] [Info]  wlserver: [libseat] [libseat/backend/logind.c:379] Enabling seat
[gamescope] [Info]  wlserver: Session resumed                                                                                                               
```

Note that **there are** messages that are being shown on pause that wouldn't beforehand. I believe it may come from my "misuse" of simply calling `DirtyState`. That might be inconsequential in the end.