### PR TITLE
WaylandBackend: Ignore events on unknown surfaces

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -53,6 +53,8 @@ using namespace std::literals;
 
 static LogScope xdg_log( "xdg_backend" );
 
+static const char *GAMESCOPE_plane_tag = "gamescope-plane";
+
 template <typename Func, typename... Args>
 auto CallWithAllButLast(Func pFunc, Args&&... args)
 {
@@ -895,6 +897,7 @@ namespace gamescope
     {
         m_pParent = pParent;
         m_pSurface = wl_compositor_create_surface( m_pBackend->GetCompositor() );
+        wl_proxy_set_tag( (wl_proxy *)m_pSurface, &GAMESCOPE_plane_tag );
         wl_surface_set_user_data( m_pSurface, this );
         wl_surface_add_listener( m_pSurface, &s_SurfaceListener, this );
 
@@ -2573,6 +2576,9 @@ namespace gamescope
 
     void CWaylandInputThread::Wayland_Pointer_Enter( wl_pointer *pPointer, uint32_t uSerial, wl_surface *pSurface, wl_fixed_t fSurfaceX, wl_fixed_t fSurfaceY )
     {
+        if ( !( wl_proxy_get_tag( (wl_proxy *)pSurface ) == &GAMESCOPE_plane_tag ) )
+            return;
+
         CWaylandPlane *pPlane = (CWaylandPlane *)wl_surface_get_user_data( pSurface );
         if ( !pPlane )
             return;
@@ -2584,6 +2590,9 @@ namespace gamescope
     }
     void CWaylandInputThread::Wayland_Pointer_Leave( wl_pointer *pPointer, uint32_t uSerial, wl_surface *pSurface )
     {
+        if ( !( wl_proxy_get_tag( (wl_proxy *)pSurface ) == &GAMESCOPE_plane_tag ) )
+            return;
+
         CWaylandPlane *pPlane = (CWaylandPlane *)wl_surface_get_user_data( pSurface );
         if ( !pPlane )
             return;


### PR DESCRIPTION
wl_pointer enter/leave events are being processed for libdecor surfaces (they have the tag `libdecor-gtk`), this means the surface user_data is being miscast as CWaylandPlane.

Fixes #1445, fixes #1558, fixes #1434