### PR TITLE
Fix a CVulkanCmdBuffer leak that could result in screenshot request f…

### DIFF
--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <stdint.h>
 #include <memory>
+#include <map>
 #include <unordered_map>
 #include <array>
 #include <bitset>
@@ -863,7 +864,7 @@ protected:
 	VkSemaphore m_scratchTimelineSemaphore;
 	std::atomic<uint64_t> m_submissionSeqNo = { 0 };
 	std::vector<std::unique_ptr<CVulkanCmdBuffer>> m_unusedCmdBufs;
-	std::unordered_map<uint64_t, std::unique_ptr<CVulkanCmdBuffer>> m_pendingCmdBufs;
+	std::map<uint64_t, std::unique_ptr<CVulkanCmdBuffer>> m_pendingCmdBufs;
 };
 
 struct TextureState


### PR DESCRIPTION
…ailures

CVulkanDevice::resetCmdBuffers expects m_pendingCmdBufs to be sorted. Using an unordered_map can result in cases where we eagerly exit out of the loop without fully cleaning all the relevant resources. This will result in leaking the command buffer and any resources it transitively references.

This can be a problem for screenshots as there are only two screenshot image slots available. If we leak references to these images, at some point we won't be able to allocate new images for screenshot capture and the operation will fail.