### PR TITLE
README.md: Exclude end of life distributions in Repology status

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Pull requests for improving Reshade compatibility support are appreciated.
 
 ## Status of Gamescope Packages
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/gamescope.svg)](https://repology.org/project/gamescope/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/gamescope.svg?exclude_unsupported=1)](https://repology.org/project/gamescope/versions)


### PR DESCRIPTION
Applies `?exclude_unsupported=1` to the Repology view. 

There is no reason to show, for example, 6 dead versions of Fedora (from a total of 9).


Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/b2c9103c-5b64-4039-9fba-42b8a264ff53)  |  ![image](https://github.com/user-attachments/assets/a2c20edb-0aa9-416a-9214-39bad1c53960)
