### PR TITLE
CI: re-enable input emulation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,15 @@ jobs:
       - name: Build with gcc
         run: |
           export CC=gcc CXX=g++
-          meson build-gcc/ -Dinput_emulation=disabled --werror --auto-features=enabled
+          meson build-gcc/ --werror --auto-features=enabled
           ninja -C build-gcc/
       - name: Build with gcc (no vr)
         run: |
           export CC=gcc CXX=g++
-          meson build-gcc-novr/ -Dinput_emulation=disabled -Denable_openvr_support=false --werror --auto-features=enabled
+          meson build-gcc-novr/ -Denable_openvr_support=false --werror --auto-features=enabled
           ninja -C build-gcc-novr/
 #      - name: Build with clang
 #        run: |
 #          export CC=clang CXX=clang++
-#          meson build-clang/ -Dinput_emulation=disabled --werror --auto-features=enabled
+#          meson build-clang/ --werror --auto-features=enabled
 #          ninja -C build-clang/


### PR DESCRIPTION
I don't think there's any reason to keep this disabled in the CI unless this PR fails to pass the build test. It builds locally when testing this workflow.