### PR TITLE
steamcompmgr: fix FSR badge status when using preemptive scaling

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6471,7 +6471,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 				newCommit->feedback->vk_colorspace = upscaledFrameInfo.outputEncodingEOTF == EOTF_Gamma22 ? VK_COLOR_SPACE_SRGB_NONLINEAR_KHR : VK_COLOR_SPACE_HDR10_ST2084_EXT;
 
 			paint_window_commit( newCommit, w, w, &upscaledFrameInfo, nullptr );
-			upscaledFrameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR;
+			upscaledFrameInfo.useFSRLayer0 = g_bFSRActive = ( g_upscaleFilter == GamescopeUpscaleFilter::FSR );
 			upscaledFrameInfo.useNISLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::NIS;
 
 			TempUpscaleImage_t *pTempImage = GetTempUpscaleImage( g_nOutputWidth, g_nOutputHeight, newCommit->vulkanTex->drmFormat() );


### PR DESCRIPTION
mangoapp relies on g_bFSRActive to determine if it should show FSR as on or off in the overlay, but this was not being set when using the new preemptive upscaling logic w/ explicit sync.

Reported in: https://github.com/ValveSoftware/gamescope/issues/1535