### PR TITLE
wlserver: wlserver_run(): ensure waylock is released when wl_event_lo…

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1956,6 +1956,7 @@ void wlserver_run(void)
 			wl_display_flush_clients(wlserver.display);
 			int ret = wl_event_loop_dispatch(wlserver.event_loop, 0);
 			if (ret < 0) {
+				wlserver_unlock();
 				break;
 			}
 


### PR DESCRIPTION
…op_dispatch returns ret<0


@matte-schwartz reported that they found another bug w/ gamescope hanging, which wasn’t fixed by https://github.com/ValveSoftware/gamescope/pull/1335
When looking at matt’s backtrace for wlserver, it appeared to be stuck waiting on mutex `g_SteamCompMgrXWaylandServerMutex`

This makes me think that said hang is due to a deadlock w/ the mutexes `g_SteamCompMgrXWaylandServerMutex` and `waylock`
Which hopefully will be fixed by this PR which will prevent wlserver from trying to lock `g_SteamCompMgrXWaylandServerMutex` while having currently locked `waylock`