### PR TITLE
mangoapp: plumb engineName

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -302,6 +302,7 @@ namespace GamescopeWSILayer {
   struct GamescopeInstanceData {
     wl_display* display;
     uint32_t appId = 0;
+    std::string engineName;
     GamescopeLayerClient::Flags flags = 0;
   };
   VKROOTS_DEFINE_SYNCHRONIZED_MAP_TYPE(GamescopeInstance, VkInstance);
@@ -524,9 +525,14 @@ namespace GamescopeWSILayer {
       {
         uint32_t appId = clientAppId();
 
+        std::string engineName;
+        if (pCreateInfo->pApplicationInfo && pCreateInfo->pApplicationInfo->pEngineName)
+          engineName = pCreateInfo->pApplicationInfo->pEngineName;
+
         auto state = GamescopeInstance::create(*pInstance, GamescopeInstanceData {
           .display = display,
           .appId   = appId,
+          .engineName = engineName,
           .flags   = defaultLayerClientFlags(pCreateInfo->pApplicationInfo, appId),
         });
 
@@ -1211,7 +1217,8 @@ namespace GamescopeWSILayer {
         uint32_t(pCreateInfo->imageColorSpace),
         uint32_t(pCreateInfo->compositeAlpha),
         uint32_t(pCreateInfo->preTransform),
-        uint32_t(pCreateInfo->clipped));
+        uint32_t(pCreateInfo->clipped),
+        gamescopeInstance->engineName.c_str());
 
       return VK_SUCCESS;
     }

--- a/protocol/gamescope-swapchain.xml
+++ b/protocol/gamescope-swapchain.xml
@@ -89,6 +89,7 @@
       <arg name="vk_composite_alpha" type="uint" summary="VkCompositeAlphaFlagBitsKHR of swapchain"/>
       <arg name="vk_pre_transform" type="uint" summary="VkSurfaceTransformFlagBitsKHR of swapchain"/>
       <arg name="vk_clipped" type="uint" summary="clipped (VkBool32) of swapchain"/>
+      <arg name="vk_engine_name" type="string" summary="Engine name"/>
     </request>
 
     <request name="set_present_mode">

--- a/src/WaylandServer/WaylandServerLegacy.h
+++ b/src/WaylandServer/WaylandServerLegacy.h
@@ -29,6 +29,7 @@ struct wlserver_vk_swapchain_feedback
 	VkCompositeAlphaFlagBitsKHR vk_composite_alpha;
 	VkSurfaceTransformFlagBitsKHR vk_pre_transform;
 	VkBool32 vk_clipped;
+	std::shared_ptr<std::string> vk_engine_name;
 
 	std::shared_ptr<gamescope::BackendBlob> hdr_metadata_blob;
 };

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -31,6 +31,7 @@ struct mangoapp_msg_v1 {
     uint16_t displayRefresh;
     bool bAppWantsHDR : 1;
     bool bSteamFocused : 1;
+    char engineName[40];
     
     // WARNING: Always ADD fields, never remove or repurpose fields
 } __attribute__((packed)) mangoapp_msg_v1;
@@ -60,6 +61,11 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
     mangoapp_msg_v1.displayRefresh = (uint16_t) gamescope::ConvertmHzToHz( g_nOutputRefresh );
     mangoapp_msg_v1.bAppWantsHDR = g_bAppWantsHDRCached;
     mangoapp_msg_v1.bSteamFocused = g_focusedBaseAppId == 769;
+    memset(mangoapp_msg_v1.engineName, 0, sizeof(mangoapp_msg_v1.engineName));
+    if (focusWindow_engine)
+        focusWindow_engine->copy(mangoapp_msg_v1.engineName, sizeof(mangoapp_msg_v1.engineName) / sizeof(char));
+    else
+        std::string("gamescope").copy(mangoapp_msg_v1.engineName, sizeof(mangoapp_msg_v1.engineName) / sizeof(char));
     msgsnd(msgid, &mangoapp_msg_v1, sizeof(mangoapp_msg_v1) - sizeof(mangoapp_msg_v1.hdr.msg_type), IPC_NOWAIT);
 }
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -882,6 +882,7 @@ int g_BlurRadius = 5;
 unsigned int g_BlurFadeStartTime = 0;
 
 pid_t focusWindow_pid;
+std::shared_ptr<std::string> focusWindow_engine = nullptr;
 
 focus_t g_steamcompmgr_xdg_focus;
 std::vector<std::shared_ptr<steamcompmgr_win_t>> g_steamcompmgr_xdg_wins;
@@ -6033,6 +6034,9 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 	uint32_t j;
 	for ( j = 0; j < w->commit_queue.size(); j++ )
 	{
+		if (w->commit_queue[ j ]->feedback.has_value())
+			w->engineName = w->commit_queue[ j ]->feedback->vk_engine_name;
+
 		if ( w->commit_queue[ j ]->commitID == commitID )
 		{
 			gpuvis_trace_printf( "commit %lu done", w->commit_queue[ j ]->commitID );
@@ -6072,6 +6076,7 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 				if ( !cv_paint_debug_pause_base_plane )
 					g_HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
 				hasRepaint = true;
+				focusWindow_engine = w->engineName;
 			}
 
 			if ( w == global_focus.overrideWindow )

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -144,6 +144,7 @@ struct wlserver_x11_surface_info *lookup_x11_surface_info_from_xid( gamescope_xw
 
 extern gamescope::VBlankTime g_SteamCompMgrVBlankTime;
 extern pid_t focusWindow_pid;
+extern std::shared_ptr<std::string> focusWindow_engine;
 
 void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_server);
 void gamescope_set_selection(std::string contents, GamescopeSelection eSelection);

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -140,6 +140,8 @@ struct steamcompmgr_win_t {
 	bool unlockedForFrameCallback = false;
 	bool receivedDoneCommit = false;
 
+	std::shared_ptr<std::string> engineName;
+
 	std::vector< gamescope::Rc<commit_t> > commit_queue;
 	std::shared_ptr<std::vector< uint32_t >> icon;
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -840,7 +840,8 @@ static void gamescope_swapchain_swapchain_feedback( struct wl_client *client, st
 	uint32_t vk_colorspace,
 	uint32_t vk_composite_alpha,
 	uint32_t vk_pre_transform,
-	uint32_t vk_clipped)
+	uint32_t vk_clipped,
+	const char *vk_engine_name)
 {
 	wlserver_wl_surface_info *wl_info = (wlserver_wl_surface_info *)wl_resource_get_user_data( resource );
 	if ( wl_info )
@@ -852,6 +853,7 @@ static void gamescope_swapchain_swapchain_feedback( struct wl_client *client, st
 			.vk_composite_alpha = VkCompositeAlphaFlagBitsKHR(vk_composite_alpha),
 			.vk_pre_transform = VkSurfaceTransformFlagBitsKHR(vk_pre_transform),
 			.vk_clipped = VkBool32(vk_clipped),
+			.vk_engine_name = std::make_shared<std::string>(vk_engine_name),
 			.hdr_metadata_blob = nullptr,
 		});
 	}


### PR DESCRIPTION
This PR modifies gamescope to use the swapchain feedback internal extension to send the `engineName` field of `VkApplicationInfo` to gamescope which will in turn send it to mangoapp for displaying it.

I'm not entirely sure on whether the `focusWindow_engine` global would require some locking, I assumed it wouldn't since the pid in the previous implementation of this feature is read and written without any locks.

Mangohud side: https://github.com/flightlessmango/MangoHud/pull/1498