### PR TITLE
WaylandBackend: Fix hotkeys failing to bind on Wayland desktops

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2730,7 +2730,7 @@ namespace gamescope
         defer( close( nFd ) );
         assert( uFormat == WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1 );
 
-        char *pMap = (char *)mmap( nullptr, uSize, PROT_READ, MAP_SHARED, nFd, 0 );
+        char *pMap = (char *)mmap( nullptr, uSize, PROT_READ, MAP_PRIVATE, nFd, 0 );
         if ( !pMap || pMap == MAP_FAILED )
         {
             xdg_log.errorf( "Failed to map keymap fd." );


### PR DESCRIPTION
Per Wayland protocol specsheet regarding keymapping: "From version 7 onwards, the fd must be mapped with MAP_PRIVATE by the recipient, as MAP_SHARED may fail."
https://wayland.app/protocols/wayland#wl_keyboard:event:keymap

This matches up exactly with what we're seeing with this error: `[gamescope] [Error] xdg_backend: Failed to map keymap fd.`

Changing MAP_SHARED to MAP_PRIVATE per the spec addresses this error.

Fixes: #1658
(hopefully) fixes: #1637