### PR TITLE
scripts: Derive script path from meson prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ endif
 add_project_arguments(
   '-DHAVE_PIPEWIRE=@0@'.format(pipewire_dep.found().to_int()),
   '-DHAVE_OPENVR=@0@'.format(openvr_dep.found().to_int()),
+  '-DSCRIPT_DIR="@0@"'.format(prefix / data_dir / 'gamescope/scripts'),
   language: 'cpp',
 )
 

--- a/src/Script/Script.cpp
+++ b/src/Script/Script.cpp
@@ -130,7 +130,7 @@ namespace gamescope
         }
         else
         {
-            RunFolder( "/usr/share/gamescope/scripts", true );
+            RunFolder( SCRIPT_DIR, true );
             RunFolder( "/etc/gamescope/scripts", true );
         }
 


### PR DESCRIPTION
This change adds the directory scripts are installed to by `default_scripts_install.sh` to the list of scripts directories in place of the hardcoded `/usr/share/gamescope/scripts`.

For the flatpak the script dir is `/usr/lib/extensions/vulkan/gamescope/share/gamescope/scripts/`