### PR TITLE
scripts: Search GAMESCOPE_SCRIPT_PATH for scripts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,3 +99,7 @@ endif
 
 # Handle default script/config stuff
 meson.add_install_script('default_scripts_install.sh')
+
+devenv = environment()
+devenv.set('GAMESCOPE_SCRIPT_PATH', join_paths(meson.current_source_dir(), 'scripts'))
+meson.add_devenv(devenv)

--- a/src/Script/Script.cpp
+++ b/src/Script/Script.cpp
@@ -124,9 +124,19 @@ namespace gamescope
 
     void CScriptManager::RunDefaultScripts()
     {
+        const char *sScriptPathEnv = getenv("GAMESCOPE_SCRIPT_PATH");
+
         if ( cv_script_use_local_scripts )
         {
             RunFolder( "../scripts", true );
+        }
+        else if ( sScriptPathEnv )
+        {
+            std::vector<std::string_view> sScriptPaths = gamescope::Split( sScriptPathEnv, ":" );
+            for ( const auto &sScriptPath : sScriptPaths )
+            {
+                RunFolder( sScriptPath, true );
+            }
         }
         else
         {


### PR DESCRIPTION
Adds `GAMESCOPE_SCRIPT_PATH` as a colon separated list of paths to search for scripts in.

It's also added to the meson devenv which allows developers to test changes by running:
```
meson devenv -C _build
gamescope -- glxgears
```

I'm not sure whether gamescope should exclude all other search paths when `GAMESCOPE_SCRIPT_PATH` is set.