### PR TITLE
Consistent indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,4 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = false
 indent_style = tab
+tab_width = 4


### PR DESCRIPTION
The codebase has lots of inconsistent indentation between 1 tab or 4
spaces. Rather than having massive diffs by fixing all that, this sets
the editorconfig tab width to 4, so it's at least visually consistent,
even on editors that default to 8-wide tabs.
