### PR TITLE
wlserver: Create a keyboard group to keep all externally connected keyboards in sync

### DIFF
--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -187,18 +187,16 @@ struct wlserver_t {
 	std::vector<wl_resource*> gamescope_controls;
 
 	std::atomic<bool> bWaylandServerRunning = { false };
+
+    // Share one single keymap and state between all connected physical keyboards
+    struct wlr_keyboard_group *keyboard_group;
+    struct wl_listener keyboard_group_modifiers;
+    struct wl_listener keyboard_group_key;
 };
 
 extern struct wlserver_t wlserver;
 
 std::vector<ResListEntry_t> wlserver_xdg_commit_queue();
-
-struct wlserver_keyboard {
-	struct wlr_keyboard *wlr;
-	
-	struct wl_listener modifiers;
-	struct wl_listener key;
-};
 
 struct wlserver_pointer {
 	struct wlr_pointer *wlr;


### PR DESCRIPTION
This ensures that all externally connected keyboards share a common layout and state. If a lock modifier (such as Caps Lock or Num Lock) is enabled or disabled on one keyboard, the state will be propagated to all of them.
If a keyboard is disconnected and then reconnected, the layout and state are preserved.

This behavior is consistent with KWin, which is used in desktop mode.

Fixes: ValveSoftware/steam-for-linux#11529