### PR TITLE
WaylandBackend: Don't assert on non-xkb-v1 keymaps

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2904,7 +2904,8 @@ namespace gamescope
         // Ideally we'd use this to influence our keymap to clients, eg. x server.
 
         defer( close( nFd ) );
-        assert( uFormat == WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1 );
+        if ( uFormat != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1 )
+		return;
 
         char *pMap = (char *)mmap( nullptr, uSize, PROT_READ, MAP_PRIVATE, nFd, 0 );
         if ( !pMap || pMap == MAP_FAILED )


### PR DESCRIPTION
Long story short, there are some edge cases where sway may send no_keymap to clients when a virtual keyboard is created on the seat, in specific circumstances. It will later send the xkb keymap before any key events are sent. Other clients simply ignore non-xkb-v1 keymaps (or the lack of a keymap), they don't assert. So gamescope should do the same.