### PR TITLE
steamcompmgr: Accept any requested iconic state change.

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4923,11 +4923,8 @@ handle_wm_change_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessag
 	long state = ev->data.l[0];
 
 	if (state == ICCCM_ICONIC_STATE) {
-		/* Wine will request iconic state and cannot ensure that the WM has
-		 * agreed on it; immediately revert to normal state to avoid being
-		 * stuck in a paused state. */
-		xwm_log.debugf("Rejecting WM_CHANGE_STATE to ICONIC for window 0x%lx", w->xwayland().id);
-		set_wm_state( ctx, w->xwayland().id, ICCCM_NORMAL_STATE );
+		xwm_log.debugf("Faking WM_CHANGE_STATE to ICONIC for window 0x%lx", w->xwayland().id);
+		set_wm_state( ctx, w->xwayland().id, ICCCM_ICONIC_STATE );
 	} else {
 		xwm_log.debugf("Unhandled WM_CHANGE_STATE to %ld for window 0x%lx", state, w->xwayland().id);
 	}


### PR DESCRIPTION
Depends on https://github.com/ValveSoftware/gamescope/pull/1730 to be merged first, I made a separate MR as it is a different problem.

This will let Wine support minimized windows with gamescope, even though the windows will not be really minimized from the window manager point of view. We now have a better window state tracker and we rely on the WM_STATE property being consistent. Gamescope already restores WM_STATE to NormalState when focus is gained, which will trigger a window restore on the Win32 side on any previously minimized window.