### PR TITLE
WaylandBackend: prevent crash after closing window

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -76,7 +76,9 @@ static inline uint32_t WaylandScaleToLogical( uint32_t pValue, uint32_t pFactor 
 }
 
 static bool IsSurfacePlane( wl_surface *pSurface ) {
-    return wl_proxy_get_tag( (wl_proxy *)pSurface ) == &GAMESCOPE_plane_tag;
+    // HACK: this probably should never be called with a null pointer, but it
+    // was happening after a window was closed.
+    return pSurface && (wl_proxy_get_tag( (wl_proxy *)pSurface ) == &GAMESCOPE_plane_tag);
 }
 
 #define WAYLAND_NULL() []<typename... Args> ( void *pData, Args... args ) { }


### PR DESCRIPTION
This addresses two related issues around closing windows in the Wayland backend.

1. ~~"Zombie windows":~~ This fix is no longer necessary for me as of 3.16.3.

   ~~When the last gamescope client closes, the wayland backend tries to
   close the window until a new client appears. However, this is done in
   the destructor for the connector for the window, which is stored in
   a `shared_ptr`. This `shared_ptr` was held by both `steamcompmgr` (which
   correctly dropped it) and by the wayland backend, which would never drop
   it. This led to the first window being kept around as a "zombie window",
   which would show the last frame from the previous client, but otherwise
   never update (the backend would only hold a reference to the first
   window, and no subsequent ones).~~

   ~~This fixes this issue by downgrading the `shared_ptr` held by the backend
   into a `weak_ptr`. Thus, the only owning reference to the backend at
   (almost) any given point is held by `steamcompmgr`, which allows the
   window to be correctly closed when `steamcompmgr` drops it. This also
   allows for the connector held by the wayland backend to be updated when
   a new window is created.~~

   ~~HACK: This is **NOT** memory-safe, and will result in a segmentation fault
   if the connector held by the wayland backend is used (e.g., via
   `::GetCurrentConnector`) after it was dropped by `steamcompmgr`. The code
   already included a TODO to remove the need for the backend to hold
   a reference to the connection, and this is still necessary.~~

2. Crashing on window close:

   Whenever a window was *truly* closed (i.e., not left behind as a zombie
   window), gamescope would segfault due to calling
   `IsSurfacePlane` with null (from `Wayland_Pointer_Leave`, and maybe a few
   other places). This is addressed by having `IsSurfacePlane` short-circuit
   if it's passed null.

   HACK: I feel like `IsSurfacePlane` shouldn't ever be called with a null
   pointer, but this is the easiest way to solve this for now, and the code
   needs refactoring anyway.

See also #1611 and #1456.
