### PR TITLE
rendervulkan: Append VK_STRUCTURE_TYPE_WSI_MEMORY_ALLOCATE_INFO_MESA when creating scanout VkImages

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -163,6 +163,7 @@ Target *pNextFind(const Base *base, VkStructureType sType)
 }
 
 #define VK_STRUCTURE_TYPE_WSI_IMAGE_CREATE_INFO_MESA (VkStructureType)1000001002
+#define VK_STRUCTURE_TYPE_WSI_MEMORY_ALLOCATE_INFO_MESA (VkStructureType)1000001003
 
 struct wsi_image_create_info {
 	VkStructureType sType;
@@ -173,6 +174,11 @@ struct wsi_image_create_info {
 	const uint64_t *modifiers;
 };
 
+struct wsi_memory_allocate_info {
+    VkStructureType sType;
+    const void *pNext;
+    bool implicit_sync;
+};
 
 // DRM doesn't have 32bit floating point formats, so add our own
 #define DRM_FORMAT_ABGR32323232F fourcc_code('A', 'B', '8', 'F')
@@ -2215,6 +2221,15 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 		VkImportMemoryFdInfoKHR importMemoryInfo = {};
 		VkExportMemoryAllocateInfo memory_export_info = {};
 		VkMemoryDedicatedAllocateInfo memory_dedicated_info = {};
+		struct wsi_memory_allocate_info memory_wsi_info = {};
+
+		if ( flags.bFlippable == true )
+		{
+			memory_wsi_info = {
+				.sType = VK_STRUCTURE_TYPE_WSI_MEMORY_ALLOCATE_INFO_MESA,
+				.pNext = std::exchange(allocInfo.pNext, &memory_wsi_info),
+			};
+		}
 
 		if ( flags.bExportable == true || pDMA != nullptr )
 		{


### PR DESCRIPTION
It already appends VK_STRUCTURE_TYPE_WSI_IMAGE_CREATE_INFO_MESA when creating scanout images to make other Vulkan drivers works, so lets also append VK_STRUCTURE_TYPE_WSI_MEMORY_ALLOCATE_INFO_MESA to make ANV+Xe KMD work.

Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12633