### PR TITLE
WaylandBackend: allow gamescope to run under vulkan

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -315,10 +315,14 @@ namespace gamescope
 
         virtual bool UsesModifiers() const = 0;
         virtual std::span<const uint64_t> GetSupportedModifiers( uint32_t uDrmFormat ) const = 0;
-        inline bool SupportsFormat( uint32_t uDrmFormat ) const
-        {
-            return Algorithm::Contains( this->GetSupportedModifiers( uDrmFormat ), DRM_FORMAT_MOD_INVALID );
-        }
+		inline bool SupportsFormat( uint32_t uDrmFormat ) const
+		{
+			return !this->GetSupportedModifiers( uDrmFormat ).empty();
+		}
+		inline bool SupportsInvalidModifier( uint32_t uDrmFormat ) const
+		{
+			return Algorithm::Contains( this->GetSupportedModifiers( uDrmFormat ), DRM_FORMAT_MOD_INVALID );
+		}
 
         virtual IBackendConnector *GetCurrentConnector() = 0;
         virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) = 0;

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2833,7 +2833,7 @@ bool vulkan_init_format(VkFormat format, uint32_t drmFormat)
 	}
 	else
 	{
-		if ( GetBackend()->UsesModifiers() && !GetBackend()->SupportsFormat( drmFormat ) )
+		if ( GetBackend()->UsesModifiers() && !GetBackend()->SupportsInvalidModifier( drmFormat ) )
 			return false;
 
 		wlr_drm_format_set_add( &sampledDRMFormats, drmFormat, DRM_FORMAT_MOD_INVALID );


### PR DESCRIPTION
The invalid modifier is not supported under vulkan, so fall back to any other modifier if a format does not support the invalid modifier.

Closes #1604