### PR TITLE
Allow to override window's app_id/classname for embedded backends

### DIFF
--- a/src/Backends/SDLBackend.cpp
+++ b/src/Backends/SDLBackend.cpp
@@ -34,6 +34,7 @@ extern bool steamMode;
 extern bool g_bFirstFrame;
 extern int g_nPreferredOutputWidth;
 extern int g_nPreferredOutputHeight;
+extern const char *g_nClassName;
 
 namespace gamescope
 {
@@ -562,6 +563,10 @@ namespace gamescope
 
 		SDL_SetHint( SDL_HINT_APP_NAME, "Gamescope" );
 		SDL_SetHint( SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1" );
+		if ( g_nClassName != nullptr ) {
+			setenv("SDL_VIDEO_WAYLAND_WMCLASS", g_nClassName, 1);
+			setenv("SDL_VIDEO_X11_WMCLASS", g_nClassName, 1);
+		}
 
 		if ( SDL_Init( SDL_INIT_VIDEO | SDL_INIT_EVENTS ) != 0 )
 		{

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -43,6 +43,7 @@
 
 extern int g_nPreferredOutputWidth;
 extern int g_nPreferredOutputHeight;
+extern const char *g_nClassName;
 extern bool g_bForceHDR10OutputDebug;
 extern bool g_bBorderlessOutputWindow;
 extern gamescope::ConVar<bool> cv_adaptive_sync;
@@ -1363,7 +1364,7 @@ namespace gamescope
         {
             m_pFrame = libdecor_decorate( m_pBackend->GetLibDecor(), m_pSurface, &s_LibDecorFrameInterface, this );
             libdecor_frame_set_title( m_pFrame, "Gamescope" );
-            libdecor_frame_set_app_id( m_pFrame, "gamescope" );
+            libdecor_frame_set_app_id( m_pFrame, (g_nClassName == nullptr) ? "gamescope" : g_nClassName );
             libdecor_frame_map( m_pFrame );
         }
         else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "grab", no_argument, nullptr, 'g' },
 	{ "force-grab-cursor", no_argument, nullptr, 0 },
 	{ "display-index", required_argument, nullptr, 0 },
+	{ "class-name", required_argument, nullptr, 0 },
 
 	// embedded mode options
 	{ "disable-layers", no_argument, nullptr, 0 },
@@ -216,7 +217,8 @@ const char usage[] =
 	"  -f, --fullscreen               make the window fullscreen\n"
 	"  -g, --grab                     grab the keyboard\n"
 	"  --force-grab-cursor            always use relative mouse mode instead of flipping dependent on cursor visibility.\n"
-	"  --display-index                forces gamescope to use a specific display in nested mode."
+	"  --display-index                forces gamescope to use a specific display in nested mode.\n"
+	"  --class-name                   changes gamescope's app id/class name\n"
 	"\n"
 	"Embedded mode options:\n"
 	"  -O, --prefer-output            list of connectors in order of preference (ex: DP-1,DP-2,DP-3,HDMI-A-1)\n"
@@ -283,6 +285,7 @@ int g_nNestedHeight = 0;
 int g_nNestedRefresh = 0;
 int g_nNestedUnfocusedRefresh = 0;
 int g_nNestedDisplayIndex = 0;
+const char *g_nClassName = nullptr;
 
 uint32_t g_nOutputWidth = 0;
 uint32_t g_nOutputHeight = 0;
@@ -821,6 +824,8 @@ int main(int argc, char **argv)
 								
 						}
 					}
+				} else if (strcmp(opt_name, "class-name") == 0) {
+					g_nClassName = optarg;
 				}
 				break;
 			case '?':

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -14,6 +14,7 @@ extern int g_nNestedHeight;
 extern int g_nNestedRefresh; // mHz
 extern int g_nNestedUnfocusedRefresh; // mHz
 extern int g_nNestedDisplayIndex;
+extern const char *g_nClassName;
 
 extern uint32_t g_nOutputWidth;
 extern uint32_t g_nOutputHeight;


### PR DESCRIPTION
References #793, similar to #794.

While changing `SDL_VIDEO_X11_WMCLASS` is possible to achieve such results in the SDL backend, the Wayland backend does not have that feature AFAIK.