### PR TITLE
build: Pull in glm in the same way we pull in stb

### DIFF
--- a/subprojects/glm.wrap
+++ b/subprojects/glm.wrap
@@ -1,11 +1,8 @@
-[wrap-file]
-directory = glm-0.9.9.8
-source_url = https://github.com/g-truc/glm/archive/0.9.9.8.tar.gz
-source_filename = 0.9.9.8.tar.gz
-source_hash = 7d508ab72cb5d43227a3711420f06ff99b0a0cb63ee2f93631b162bfe1fe9592
-patch_url = https://wrapdb.mesonbuild.com/v2/glm_0.9.9.8-2/get_patch
-patch_filename = glm-0.9.9.8-2-wrap.zip
-patch_hash = d930a1fcd3a28d84be4e92cc4c71ff59e170a1ebbd3dbfce631eba19e478d83d
+[wrap-git]
+directory = glm
 
-[provide]
-glm = glm_dep
+url = https://github.com/g-truc/glm.git
+revision = 0af55ccecd98d4e5a8d1fad7de25ba429d60e863
+depth = 1
+
+patch_directory = glm

--- a/subprojects/packagefiles/glm/meson.build
+++ b/subprojects/packagefiles/glm/meson.build
@@ -1,0 +1,7 @@
+project('glm', 'cpp', version: '1.0.1', license: 'MIT')
+
+glm_dep = declare_dependency(
+  include_directories: include_directories('.')
+)
+
+meson.override_dependency('glm', glm_dep)


### PR DESCRIPTION
This allows us to correctly override this package for SteamOS builds.