### PR TITLE
build: Add options to override subproject paths

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,10 +50,23 @@ dep_x11 = dependency('x11')
 dep_wayland = dependency('wayland-client')
 vulkan_dep = dependency('vulkan')
 
-glm_proj = subproject('glm')
-glm_dep = glm_proj.get_variable('glm_dep')
-stb_proj = subproject('stb')
-stb_dep = stb_proj.get_variable('stb_dep')
+glm_include_dir = get_option('glm_include_dir')
+if glm_include_dir != ''
+  glm_inc = include_directories(glm_include_dir)
+  glm_dep = declare_dependency(include_directories : glm_inc)
+else
+  glm_proj = subproject('glm')
+  glm_dep = glm_proj.get_variable('glm_dep')
+endif
+
+stb_include_dir = get_option('stb_include_dir')
+if stb_include_dir != ''
+  stb_inc = include_directories(stb_include_dir)
+  stb_dep = declare_dependency(include_directories : stb_inc)
+else
+  stb_proj = subproject('stb')
+  stb_dep = stb_proj.get_variable('stb_dep')
+endif
 
 if get_option('enable_openvr_support')
   openvr_dep = dependency('openvr', version: '>= 2.7', required : false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,5 @@ option('enable_gamescope',           type : 'boolean', value : true, description
 option('enable_gamescope_wsi_layer', type : 'boolean', value : true, description: 'Build Gamescope layer')
 option('enable_openvr_support',      type : 'boolean', value : true, description: 'OpenVR Integrations')
 option('benchmark', type: 'feature', description: 'Benchmark tools')
+option('glm_include_dir',            type : 'string',  value : '', description: 'Custom path to override GLM headers')
+option('stb_include_dir',            type : 'string',  value : '', description: 'Custom path to override STB headers')


### PR DESCRIPTION
The PR adds two Meson string options for developers—such as distro packagers—who often have up-to-date or patched libraries installed system-wide or in custom paths:

  • `-Dglm_include_dir=…`  
  • `-Dstb_include_dir=…`

If either option is non-empty, Meson will use the specified include path; otherwise, it falls back to the wrapped subproject setup.

**Usage example**  
```bash
meson setup builddir \
  -Dglm_include_dir=/path/to/include/glm \
  -Dstb_include_dir=/path/to/include/stb \
```