### PR TITLE
steamcompmgr: workaround bug with mangohud repaints and VRR

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6267,8 +6267,15 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 					hasRepaintNonBasePlane = true;
 				}
 
-				// If this is an external overlay, repaint
-				if ( w == pFocus->externalOverlayWindow && w->opacity != TRANSLUCENT )
+				// matt: the performance overlay in Steam will interfere with VRR if we let this repaint.
+				// This has been broken since the logic for external overlay repaints was moved out of
+				// outdatedInteractiveFocus. It can cause displays to jump between the focused app's
+				// refresh rate and the maximum panel refresh rate when presenting any type of overlay,
+				// creating noticeable VRR flicker in the process.
+				// TODO: fix this properly for all overlays, including Steam notifications and QAM
+				// HACK: If VRR is active, prevent external overlays, i.e. mangoapp, from repainting the base plane
+				if ( ( w == pFocus->externalOverlayWindow && w->opacity != TRANSLUCENT ) &&
+				     ( GetBackend()->GetCurrentConnector() && !GetBackend()->GetCurrentConnector()->IsVRRActive() ) )
 				{
 					hasRepaintNonBasePlane = true;
 				}


### PR DESCRIPTION
Ever since external overlay repaint logic was moved outside of outdatedInteractiveFocus, drawing mangohud on top of the base plane while VRR is enabled can cause the display to jump between different refresh rates. This only seems to happen once a game runs at ~60% or less of the display panel's maximum refresh rate, but it leads to very choppy frame pacing and noticeable VRR flicker.

This choppy VRR effect can actually happen with every type of overlay, including the Steam quick access menus, but mangohud is by far the biggest culprit as it is the only visible overlay that is constantly being drawn on top of the base plane.

This commit adds a workaround to avoid the worst flickering caused by this phenomenon, but the underlying issue will still be present and should be looked into.

Fixes: "steamcompmgr: Move outdatedInteractiveFocus to window"
Closes: #1513