### PR TITLE
WaylandBackend: Check features before using color management

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1990,13 +1990,14 @@ namespace gamescope
                     return false;
                 if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_SET_LUMINANCES ) )
                     return false;
+                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_WINDOWS_SCRGB ) )
+                    return false;
 
                 // Transfer Functions
                 if ( !Algorithm::Contains( m_WPColorManagerFeatures.eTransferFunctions, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB ) )
                     return false;
                 if ( !Algorithm::Contains( m_WPColorManagerFeatures.eTransferFunctions, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ ) )
                     return false;
-                // TODO: Need scRGB
 
                 // Primaries
                 if ( !Algorithm::Contains( m_WPColorManagerFeatures.ePrimaries, WP_COLOR_MANAGER_V1_PRIMARIES_SRGB ) )
@@ -2006,6 +2007,22 @@ namespace gamescope
 
                 return true;
             }();
+
+            if ( m_WPColorManagerFeatures.bSupportsGamescopeColorManagement )
+            {
+                // HDR10.
+                {
+                    wp_image_description_creator_params_v1 *pParams = wp_color_manager_v1_create_parametric_creator( m_pWPColorManager );
+                    wp_image_description_creator_params_v1_set_primaries_named( pParams, WP_COLOR_MANAGER_V1_PRIMARIES_BT2020 );
+                    wp_image_description_creator_params_v1_set_tf_named( pParams, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ );
+                    m_pWPImageDescriptions[ GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ ] = wp_image_description_creator_params_v1_create( pParams );
+                }
+
+                // scRGB
+                {
+                    m_pWPImageDescriptions[ GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB ] = wp_color_manager_v1_create_windows_scrgb( m_pWPColorManager );
+                }
+            }
         }
 
         m_pLibDecor = libdecor_new( m_pDisplay, &s_LibDecorInterface );
@@ -2476,19 +2493,6 @@ namespace gamescope
         {
             m_pWPColorManager = (wp_color_manager_v1 *)wl_registry_bind( pRegistry, uName, &wp_color_manager_v1_interface, 1u );
             wp_color_manager_v1_add_listener( m_pWPColorManager, &s_WPColorManagerListener, this );
-
-            // HDR10.
-            {
-                wp_image_description_creator_params_v1 *pParams = wp_color_manager_v1_create_parametric_creator( m_pWPColorManager );
-                wp_image_description_creator_params_v1_set_primaries_named( pParams, WP_COLOR_MANAGER_V1_PRIMARIES_BT2020 );
-                wp_image_description_creator_params_v1_set_tf_named( pParams, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ );
-                m_pWPImageDescriptions[ GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ ] = wp_image_description_creator_params_v1_create( pParams );
-            }
-
-            // scRGB
-            {
-                m_pWPImageDescriptions[ GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB ] = wp_color_manager_v1_create_windows_scrgb( m_pWPColorManager );
-            }
         }
         else if ( !strcmp( pInterface, zwp_pointer_constraints_v1_interface.name ) )
         {


### PR DESCRIPTION
This branch adds a check for `windows_scrgb` support when setting the `bSupportsGamescopeColorManagement` flag.
It also moves unchecked use of the `wp_color_manager_v1` protocol out of the `registry::global` callback so that the compositor has an opportunity to send information on what features are supported during the subsequent roundtrip.

This fixes a wayland protocol error and allows gamescope on gnome/mutter.

### Old description
~This avoids using windows_scrgb where unsupported. `m_pWPImageDescriptions[ GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB ]` won't be set if the feature isn't reported. It should still crash in `CWaylandPlane::Present` if switching to `GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB`, however now it logs an error explaining why.~

~The color-management-v1 protocol says that surfaces without a set image description should be treated by the compositor as sRGB.~


~This is my first time using the color management protocol so I'm sorry if it's wrong in some obvious way.
I've tested it on mutter with `vkmark` and `glxgears`. `vkmark` looked a little darker than outside of gamescope, but that seems in line with gamescope `3.16.4` that's available in my distro.~

![Screenshot From 2025-05-28 11-40-23](https://github.com/user-attachments/assets/72a48c75-cc17-48d8-9aed-3ade78ebfcd7)

If I specify a pixel format the issue goes away:
```
vkmark --size 300x300 -b vertex --run-forever --pixel-format B8G8R8A8SRGB
```

![Screenshot From 2025-05-28 15-25-06](https://github.com/user-attachments/assets/80b7685d-02fb-4725-a3a0-911de4db1704)

Or `--pixel-format B8G8R8A8UNORM` if you prefer a dark horse:

![Screenshot From 2025-05-28 15-31-38](https://github.com/user-attachments/assets/3dd169b3-3a79-43c1-8d18-3f3465c4c0a3)

Resolves #1825