### PR TITLE
CI: fix CI build after wlroots rename

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           pacman-key --init
           pacman -Syu --noconfirm
-          pacman -S --noconfirm git meson clang glslang libcap wlroots \
+          pacman -S --noconfirm git meson clang glslang libcap wlroots0.18 \
             sdl2 vulkan-headers libx11 libxmu libxcomposite libxrender libxres \
             libxtst libxkbcommon libdrm libinput wayland-protocols benchmark \
             xorg-xwayland pipewire cmake \


### PR DESCRIPTION
The upstream Arch package naming switched from wlroots to wlroot0.18.

Passes CI again locally after fixing the name:

```
[CI/build]   ✅  Success - Main Build with gcc (no vr) [11.329688204s]
[CI/build] ⭐ Run Complete job
[CI/build] Cleaning up container for job build
[CI/build]   ✅  Success - Complete job
[CI/build] 🏁  Job succeeded
```