### PR TITLE
steamcompmgr: track FSR state with preemptive upscaling

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2688,6 +2688,9 @@ paint_all( global_focus_t *pFocus, bool async )
 	}
 
 	g_bFSRActive = frameInfo.useFSRLayer0;
+	if ( const auto& heldCommit = g_HeldCommits[HELD_COMMIT_BASE]; heldCommit && heldCommit->upscaledTexture ) {
+		g_bFSRActive = ( heldCommit->upscaledTexture->eFilter == GamescopeUpscaleFilter::FSR );
+	}
 
 	g_bFirstFrame = false;
 


### PR DESCRIPTION
g_bFSRActive was only being applied to the first frame of preemptive upscaling, which meant that the FSR badge would quickly flicker from on to off when preemptive upscaling was active.

To account for this, track the state of preemptive upscaling and use it to activate g_bFSRActive when applicable.

Closes: #1780 