### PR TITLE
steamcompmgr: fix vrr frame limiter CPU usage

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -7797,7 +7797,7 @@ void LaunchNestedChildren( char **ppPrimaryChildArgv )
 
 static gamescope::CTimerFunction g_FPSLimitVRRTimer{ []
 {
-	// do nothing.
+	g_FPSLimitVRRTimer.DisarmTimer();
 }};
 
 void


### PR DESCRIPTION
When I run gamescope with adaptive sync and frame limiting enabled the process is always at 100% CPU usage. It has to do with the fact that `g_FPSLimitVRRTimer` is never explicitly disarmed. This means that `PollEvents` almost always returns immediately.  `g_FPSLimitVRRTimer` is only rearmed when there is at least 1 done commit from my understanding. So between the timer being fired and rearmed we are essentially in a busy waiting situation. Also note that if you disable adaptive sync, the timer is never rearmed. 

I'm not very familiar with the codebase or C++ in general so please let me know if there is a better way to address this issue.