### PR TITLE
fix(steamcompmgr): Add `Drain()` to `IWaitable` to fix that FPS limit with VRR may cause high CPU usage

### DIFF
--- a/src/waitable.h
+++ b/src/waitable.h
@@ -54,7 +54,7 @@ namespace gamescope
                 if ( read( nFD, buf, sizeof( buf ) ) < 0 )
                 {
                     if ( errno != EAGAIN )
-                        g_WaitableLog.errorf_errno( "Failed to drain CNudgeWaitable" );
+                        g_WaitableLog.errorf_errno( "Failed to drain IWaitable" );
                     break;
                 }
             }
@@ -155,6 +155,16 @@ namespace gamescope
             Shutdown();
         }
 
+        void Drain()
+        {
+            IWaitable::Drain( m_nFD );
+        }
+
+        void OnPollIn()
+        {
+            Drain();
+        }
+
         void Shutdown()
         {
             if ( m_nFD >= 0 )
@@ -200,6 +210,7 @@ namespace gamescope
 
         void OnPollIn() final
         {
+            ITimerWaitable::OnPollIn();
             m_fnPollFunc();
         }
     private:


### PR DESCRIPTION
## What's fixed

`g_FPSLimitVRRTimer` is defined to limit FPS when VRR enabled. It uses `timefd` to act as a timer-triggered function. However, its `timefd` is never consumed by `read(fd)`.

Hence event polling at [`src/steamcompmgr.cpp#L8024`](https://github.com/ValveSoftware/gamescope/blob/91f63ea98360b0c6309d6d19182aee50c195331f/src/steamcompmgr.cpp#L8024) will never block, then this loop comes with high frequency that results in high CPU usage.