### PR TITLE
gamescope-control: add interface to query performance stats for an appid

### DIFF
--- a/protocol/gamescope-control.xml
+++ b/protocol/gamescope-control.xml
@@ -29,7 +29,7 @@
     it.
   </description>
 
-  <interface name="gamescope_control" version="5">
+  <interface name="gamescope_control" version="6">
     <request name="destroy" type="destructor"></request>
 
     <enum name="feature">
@@ -43,6 +43,7 @@
       <entry name="refresh_cycle_only_change_refresh_rate" value="4"/>
       <entry name="mura_correction" value="5"/>
       <entry name="look" value="6"/>
+      <entry name="perf_query" value="7"/>
     </enum>
 
     <event name="feature_support">
@@ -130,6 +131,17 @@
     <request name="unset_look" since="5">
       <description summary="Unsets the current look."></description>
     </request>
+
+    <request name="request_app_performance_stats" since="6">
+      <description summary="Asks the compositor to send the most recent performance stats"></description>
+      <arg name="app_id" type="uint" summary="Appid "></arg>
+    </request>
+
+    <event name="app_performance_stats" since="6">
+      <arg name="app_id" type="uint" summary="Appid for this request"></arg>
+      <arg name="frametime_ns_lo" type="uint" summary="Time delta between the two most recent frames"></arg>
+      <arg name="frametime_ns_hi" type="uint" summary="frametime_ns high bits"></arg>
+    </event>
 
   </interface>
 </protocol>

--- a/src/commit.cpp
+++ b/src/commit.cpp
@@ -66,10 +66,12 @@ void commit_t::OnPollIn()
 
 void commit_t::Signal()
 {
+    uint64_t now = get_time_in_nanos();
+    present_time = now;
+
     uint64_t frametime;
     if ( m_bMangoNudge )
     {
-        uint64_t now = get_time_in_nanos();
         static uint64_t lastFrameTime = now;
         frametime = now - lastFrameTime;
         lastFrameTime = now;

--- a/src/commit.h
+++ b/src/commit.h
@@ -73,6 +73,7 @@ struct commit_t final : public gamescope::RcObject, public gamescope::IWaitable,
 	uint64_t desired_present_time = 0;
 	uint64_t earliest_present_time = 0;
 	uint64_t present_margin = 0;
+	uint64_t present_time = 0;
 
 	std::mutex m_WaitableCommitStateMutex;
 	int m_nCommitFence = -1;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6610,6 +6610,17 @@ void handle_presented_for_window( steamcompmgr_win_t* w )
 	commit_t *lastCommit = get_window_last_done_commit_peek(w);
 	if (lastCommit)
 	{
+		// We might present the same commit multiple times. In these cases
+		// there will be no frametime delta as the last frame was just re-used.
+		uint64_t frametime_ns = lastCommit->present_time - w->last_commit_present_time;
+		if ( frametime_ns > 0 )
+		{
+			if ( w->appID > 0 )
+				wlserver_app_presented( w->appID, frametime_ns );
+
+			w->last_commit_present_time = lastCommit->present_time;
+		}
+
 		if (!lastCommit->presentation_feedbacks.empty() || lastCommit->present_id)
 		{
 			if (!lastCommit->presentation_feedbacks.empty())

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -134,6 +134,7 @@ struct steamcompmgr_win_t {
 	bool outdatedInteractiveFocus = false;
 
 	uint64_t last_commit_first_latch_time = 0;
+	uint64_t last_commit_present_time = 0;
 
 	bool hasHwndStyle = false;
 	uint32_t hwndStyle = 0;

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -185,6 +185,7 @@ struct wlserver_t {
 	std::vector<ResListEntry_t> xdg_commit_queue;
 
 	std::vector<wl_resource*> gamescope_controls;
+	std::unordered_map< uint32_t, std::vector<wl_resource*> > app_perf_requests;
 
 	std::atomic<bool> bWaylandServerRunning = { false };
 
@@ -281,6 +282,8 @@ void wlserver_presentation_feedback_discard( struct wlr_surface *surface, std::v
 
 void wlserver_past_present_timing( struct wlr_surface *surface, uint32_t present_id, uint64_t desired_present_time, uint64_t actual_present_time, uint64_t earliest_present_time, uint64_t present_margin );
 void wlserver_refresh_cycle( struct wlr_surface *surface, uint64_t refresh_cycle );
+
+void wlserver_app_presented( uint32_t app_id, uint64_t frametime_ns );
 
 void wlserver_shutdown();
 


### PR DESCRIPTION
A client can now call request_app_performance_stats( app_id ) to query an app's performance details.