### PR TITLE
attempt to fix bug where closing the overlay leaves a stuck image

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5451,6 +5451,9 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 				if ( gameFocused && ( w == ctx->focus.overlayWindow || w == ctx->focus.notificationWindow ) )
 				{
 					hasRepaintNonBasePlane = true;
+					if (newOpacity == 0) {
+						hasRepaint = true;
+					}
 				}
 				if ( w == ctx->focus.externalOverlayWindow )
 				{


### PR DESCRIPTION
when the base plane game isn't repainting (like 2d app)