### PR TITLE
steamcompmgr: consider windows with 0-position hints valid dropdowns

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4286,7 +4286,7 @@ get_size_hints(xwayland_ctx_t *ctx, steamcompmgr_win_t *w)
 
 	const bool bHasPositionAndGravityHints = ( hintsSpecified & ( PPosition | PWinGravity ) ) == ( PPosition | PWinGravity );
 	if ( bHasPositionAndGravityHints &&
-		 hints.x && hints.y && hints.win_gravity == StaticGravity )
+		 hints.x >= 0 && hints.y >= 0 && hints.win_gravity == StaticGravity )
 	{
 		w->maybe_a_dropdown = true;
 	}


### PR DESCRIPTION
The previous condition (strictly ≠ 0) didn't allow for dropdowns with one of their position hints == 0 to be considered as such.

An instance of this problem could be observed with the account creation screen of Rockstar games where the 'month' dropdown would be displayed correctly (as all 13 entries fitted vertically), but the 'day' and 'year' dropdowns wouldn't be visible because they were taller, and their position ended up with a Y coordinate == 0 (on a screen with a 1280×800 resolution).