### PR TITLE
steamcompmgr, openvr: Support forwarding commits to a given VR Overlay

### DIFF
--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -892,6 +892,23 @@ namespace gamescope
                 }
             }
         }
+        
+        bool SupportsVROverlayForwarding() override
+        {
+            return true;
+        }
+        
+        void ForwardFramebuffer( IBackendFb *pFramebuffer, const void *pData ) override
+        {
+            COpenVRFb *pVRFB = static_cast<COpenVRFb *>( pFramebuffer );
+
+            vr::VROverlayHandle_t hOverlay = static_cast<vr::VROverlayHandle_t>( *reinterpret_cast<const uint64_t*>( pData ) );
+            vr::SharedTextureHandle_t ulHandle = pVRFB->GetSharedTextureHandle();
+
+            openvr_log.debugf( "Forwarding for overlay: %lx", (unsigned long)hOverlay );
+            vr::Texture_t texture = { (void *)&ulHandle, vr::TextureType_SharedTextureHandle, vr::ColorSpace_Gamma };
+            vr::VROverlay()->SetOverlayTexture( hOverlay, &texture );
+        }
 
         vr::IVRIPCResourceManagerClient *GetIPCResourceManager()
         {

--- a/src/backend.h
+++ b/src/backend.h
@@ -353,6 +353,9 @@ namespace gamescope
 
         virtual void NotifyPhysicalInput( InputType eInputType ) = 0;
 
+        virtual bool SupportsVROverlayForwarding() = 0;
+        virtual void ForwardFramebuffer( IBackendFb *pFramebuffer, const void *pData ) = 0;
+
         static IBackend *Get();
         template <typename T>
         static bool Set();
@@ -382,6 +385,9 @@ namespace gamescope
         virtual std::shared_ptr<IBackendConnector> CreateVirtualConnector( uint64_t ulVirtualConnectorKey ) override;
 
         virtual void NotifyPhysicalInput( InputType eInputType ) override {}
+
+        virtual bool SupportsVROverlayForwarding() override { return false; }
+        virtual void ForwardFramebuffer( IBackendFb *pFramebuffer, const void *pData ) override {}
     };
 
     // This is a blob of data that may be associated with

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -156,6 +156,8 @@ struct steamcompmgr_win_t {
 
 	steamcompmgr_win_type_t		type;
 
+	std::optional<uint64_t> oulTargetVROverlay;
+
 	steamcompmgr_xwayland_win_t& xwayland() { return std::get<steamcompmgr_xwayland_win_t>(_window_types); }
 	const steamcompmgr_xwayland_win_t& xwayland() const { return std::get<steamcompmgr_xwayland_win_t>(_window_types); }
 

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -135,6 +135,9 @@ struct xwayland_ctx_t final : public gamescope::IWaitable
 		Atom netSystemTrayOpcodeAtom;
 		Atom steamStreamingClientAtom;
 		Atom steamStreamingClientVideoAtom;
+		Atom steamGamescopeVROverlayTarget;
+		Atom gamescopePid;
+		Atom gamescopeVROverlayForwarding;
 		Atom gamescopeFocusableAppsAtom;
 		Atom gamescopeFocusableWindowsAtom;
 		Atom gamescopeFocusedWindowAtom;


### PR DESCRIPTION
Implement a system where a window can be tagged with a given VROverlayHandle_t where commit textures will be forwarded to.

These windows are ignored for focus and input is handled out-of-band.

GAMESCOPE_PID is exposed so SetOverlayRenderingPid can be used by the process setting this up to allow Gamescope to set the active texture on the overlay on its behalf.