### PR TITLE
wlserver: Send relative pointer motion alongside absolute in mousewarp

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2703,6 +2703,9 @@ void wlserver_mousewarp( double x, double y, uint32_t time, bool bSynthetic )
 {
 	assert( wlserver_is_lock_held() );
 
+	double dx = x - wlserver.mouse_surface_cursorx;
+	double dy = y - wlserver.mouse_surface_cursory;
+
 	wlserver.mouse_surface_cursorx = x;
 	wlserver.mouse_surface_cursory = y;
 
@@ -2714,6 +2717,7 @@ void wlserver_mousewarp( double x, double y, uint32_t time, bool bSynthetic )
 
 	wlserver_oncursorevent();
 
+	wlserver_perform_rel_pointer_motion( dx, dy );
 	wlr_seat_pointer_notify_motion( wlserver.wlr.seat, time, wlserver.mouse_surface_cursorx, wlserver.mouse_surface_cursory );
 	wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
 }


### PR DESCRIPTION
# Summary

I encountered a bug where the camera would snap to the floor when entering mouselook (holding right-click), then everything would work fine afterwards. Further testing showed that the bug completely disappears when running with `--force-grab-cursor`.

I investigated why `--force-grab-cursor` made a difference and found that it comes down to which input path is used. With `--force-grab-cursor`, all mouse movement goes through `wlserver_mousemotion`, which sends both `zwp_relative_pointer_v1.relative_motion` and `wl_pointer.motion` to XWayland. Without it, normal cursor movement goes through `wlserver_mousewarp`, which only sends `wl_pointer.motion` and no relative motion at all.

This means XWayland's relative_pointer device never gets position updates during normal gameplay. When a game enters mouselook (LOCKED pointer constraint) and gamescope switches to sending relative-only events, the relative_pointer device has a stale position, which produces a large spurious delta on the first frame and causes the camera snap.

# Fix

Add `wlserver_perform_rel_pointer_motion` to `wlserver_mousewarp` so that relative motion data is always sent alongside absolute, keeping XWayland's relative pointer device in sync. This matches the existing behavior of `wlserver_mousemotion` and the `--force-grab-cursor` code path.
