### PR TITLE
Content-driven HDR output and Legion Go 2 display script

### DIFF
--- a/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
+++ b/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
@@ -1,0 +1,69 @@
+local legiongo2_oled_refresh_rates = {
+    48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+    58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+    68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+    78, 79, 80, 81, 82, 83, 84, 85, 86, 87,
+    88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+    98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+    108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+    118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
+    128, 129, 130, 131, 132, 133, 134, 135, 136, 137,
+    138, 139, 140, 141, 142, 143, 144
+}
+
+gamescope.config.known_displays.lenovo_legiongo2_oled = {
+    pretty_name = "Lenovo Legion Go 2 OLED",
+    hdr = {
+        supported = true,
+        force_enabled = false,
+        eotf = gamescope.eotf.pq,
+        content_driven = true,
+    },
+    dynamic_refresh_rates = legiongo2_oled_refresh_rates,
+    dynamic_modegen = function(base_mode, refresh)
+        debug("Generating mode "..refresh.."Hz for Lenovo Legion Go 2 OLED with fixed pixel clock")
+        local vfps = {
+            2696, 2615, 2538, 2463, 2391,
+            2322, 2256, 2192, 2130, 2071,
+            2013, 1958, 1904, 1852, 1802,
+            1753, 1706, 1660, 1616, 1572,
+            1531, 1491, 1451, 1413, 1376,
+            1340, 1305, 1270, 1237, 1205,
+            1173, 1142, 1112, 1083, 1054,
+            1026, 999,  972,  946,  921,
+            896,  872,  848,  825,  802,
+            780,  758,  737,  716,  696,
+            676,  656,  637,  618,  600,
+            581,  564,  546,  529,  512,
+            496,  480,  464,  448,  433,
+            418,  403,  389,  375,  361,
+            347,  333,  320,  307,  294,
+            281,  269,  257,  245,  233,
+            221,  209,  198,  187,  176,
+            165,  155,  144,  134,  123,
+            113,  103,  94,   84,   75,
+            65,   56
+        }
+        local vfp = vfps[zero_index(refresh - 48)]
+        if vfp == nil then
+            warn("Couldn't do refresh "..refresh.." on Lenovo Legion Go 2 OLED")
+            return base_mode
+        end
+
+        local mode = base_mode
+
+        gamescope.modegen.adjust_front_porch(mode, vfp)
+        mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)
+
+        return mode
+    end,
+    matches = function(display)
+        if display.vendor == "SDC" and display.product == 17153 then
+            debug("[lenovo_legiongo2_oled] Matched vendor: "..display.vendor.." product: "..display.product)
+            return 5000
+        end
+        return -1
+    end,
+}
+debug("Registered Lenovo Legion Go 2 OLED as a known display")
+--debug(inspect(gamescope.config.known_displays.lenovo_legiongo2_oled))

--- a/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
+++ b/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
@@ -1,0 +1,70 @@
+local legiongo2_oled_refresh_rates = {
+    48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+    58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+    68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+    78, 79, 80, 81, 82, 83, 84, 85, 86, 87,
+    88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+    98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+    108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+    118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
+    128, 129, 130, 131, 132, 133, 134, 135, 136, 137,
+    138, 139, 140, 141, 142, 143, 144
+}
+
+gamescope.config.known_displays.lenovo_legiongo2_oled = {
+    pretty_name = "Lenovo Legion Go 2 OLED",
+    hdr = {
+        supported = true,
+        force_enabled = false,
+        eotf = gamescope.eotf.pq,
+        content_driven = true,
+        -- Luminance and colorimetry come from the panel's EDID.
+    },
+    dynamic_refresh_rates = legiongo2_oled_refresh_rates,
+    dynamic_modegen = function(base_mode, refresh)
+        debug("Generating mode "..refresh.."Hz for Lenovo Legion Go 2 OLED with fixed pixel clock")
+        local vfps = {
+            2696, 2615, 2538, 2463, 2391,
+            2322, 2256, 2192, 2130, 2071,
+            2013, 1958, 1904, 1852, 1802,
+            1753, 1706, 1660, 1616, 1572,
+            1531, 1491, 1451, 1413, 1376,
+            1340, 1305, 1270, 1237, 1205,
+            1173, 1142, 1112, 1083, 1054,
+            1026, 999,  972,  946,  921,
+            896,  872,  848,  825,  802,
+            780,  758,  737,  716,  696,
+            676,  656,  637,  618,  600,
+            581,  564,  546,  529,  512,
+            496,  480,  464,  448,  433,
+            418,  403,  389,  375,  361,
+            347,  333,  320,  307,  294,
+            281,  269,  257,  245,  233,
+            221,  209,  198,  187,  176,
+            165,  155,  144,  134,  123,
+            113,  103,  94,   84,   75,
+            65,   56
+        }
+        local vfp = vfps[zero_index(refresh - 48)]
+        if vfp == nil then
+            warn("Couldn't do refresh "..refresh.." on Lenovo Legion Go 2 OLED")
+            return base_mode
+        end
+
+        local mode = base_mode
+
+        gamescope.modegen.adjust_front_porch(mode, vfp)
+        mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)
+
+        return mode
+    end,
+    matches = function(display)
+        if display.vendor == "SDC" and display.product == 0x4301 then
+            debug("[lenovo_legiongo2_oled] Matched vendor: "..display.vendor.." product: "..display.product)
+            return 5000
+        end
+        return -1
+    end,
+}
+debug("Registered Lenovo Legion Go 2 OLED as a known display")
+--debug(inspect(gamescope.config.known_displays.lenovo_legiongo2_oled))

--- a/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
+++ b/scripts/00-gamescope/displays/lenovo.legiongo2.oled.lua
@@ -18,6 +18,8 @@ gamescope.config.known_displays.lenovo_legiongo2_oled = {
         force_enabled = false,
         eotf = gamescope.eotf.pq,
         content_driven = true,
+        -- The panel ignores hardware backlight control while in PQ mode.
+        software_backlight = true,
         -- Luminance and colorimetry come from the panel's EDID.
     },
     dynamic_refresh_rates = legiongo2_oled_refresh_rates,

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2297,6 +2297,9 @@ namespace gamescope
 
 		bool bHasKnownColorimetry = false;
 		bool bHasKnownHDRInfo = false;
+		bool bHasKnownMaxCLL = false;
+		bool bHasKnownMaxFALL = false;
+		bool bHasKnownMinCLL = false;
 
 		m_Mutable.ValidDynamicRefreshRates.clear();
 		m_Mutable.fnDynamicModeGenerator = nullptr;
@@ -2393,9 +2396,22 @@ namespace gamescope
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
 					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
-					m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( otHDRInfo->get_or( "max_content_light_level", 400.0f ) );
-					m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( otHDRInfo->get_or( "max_frame_average_luminance", 400.0f ) );
-					m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( otHDRInfo->get_or( "min_content_light_level", 0.1f ) );
+
+					if ( sol::optional<float> ofMaxCLL = (*otHDRInfo)["max_content_light_level"] )
+					{
+						m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( *ofMaxCLL );
+						bHasKnownMaxCLL = true;
+					}
+					if ( sol::optional<float> ofMaxFALL = (*otHDRInfo)["max_frame_average_luminance"] )
+					{
+						m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( *ofMaxFALL );
+						bHasKnownMaxFALL = true;
+					}
+					if ( sol::optional<float> ofMinCLL = (*otHDRInfo)["min_content_light_level"] )
+					{
+						m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( *ofMinCLL );
+						bHasKnownMinCLL = true;
+					}
 
 					bHasKnownHDRInfo = true;
 				}
@@ -2461,7 +2477,10 @@ namespace gamescope
 		/////////////////////
 		// Parse HDR stuff.
 		/////////////////////
-		if ( !bHasKnownHDRInfo )
+		if ( !bHasKnownHDRInfo
+			|| !bHasKnownMaxCLL
+			|| !bHasKnownMaxFALL
+			|| !bHasKnownMinCLL )
 		{
 			const di_cta_hdr_static_metadata_block *pHDRStaticMetadata = nullptr;
 			const di_cta_colorimetry_block *pColorimetry = nullptr;
@@ -2496,22 +2515,28 @@ namespace gamescope
 			if ( pColorimetry && pColorimetry->bt2020_rgb &&
 				 pHDRStaticMetadata && pHDRStaticMetadata->eotfs && pHDRStaticMetadata->eotfs->pq )
 			{
-				m_Mutable.HDR.bExposeHDRSupport = true;
-				m_Mutable.HDR.eOutputEncodingEOTF = EOTF_PQ;
-				m_Mutable.HDR.uMaxContentLightLevel =
-					pHDRStaticMetadata->desired_content_max_luminance
-					? nits_to_u16( pHDRStaticMetadata->desired_content_max_luminance )
-					: nits_to_u16( 1499.0f );
-				m_Mutable.HDR.uMaxFrameAverageLuminance =
-					pHDRStaticMetadata->desired_content_max_frame_avg_luminance
-					? nits_to_u16( pHDRStaticMetadata->desired_content_max_frame_avg_luminance )
-					: nits_to_u16( std::min( 799.f, nits_from_u16( m_Mutable.HDR.uMaxContentLightLevel ) ) );
-				m_Mutable.HDR.uMinContentLightLevel =
-					pHDRStaticMetadata->desired_content_min_luminance
-					? nits_to_u16_dark( pHDRStaticMetadata->desired_content_min_luminance )
-					: nits_to_u16_dark( 0.0f );
+				if ( !bHasKnownHDRInfo )
+				{
+					m_Mutable.HDR.bExposeHDRSupport = true;
+					m_Mutable.HDR.eOutputEncodingEOTF = EOTF_PQ;
+				}
+				if ( !bHasKnownMaxCLL )
+					m_Mutable.HDR.uMaxContentLightLevel =
+						pHDRStaticMetadata->desired_content_max_luminance
+						? nits_to_u16( pHDRStaticMetadata->desired_content_max_luminance )
+						: nits_to_u16( 1499.0f );
+				if ( !bHasKnownMaxFALL )
+					m_Mutable.HDR.uMaxFrameAverageLuminance =
+						pHDRStaticMetadata->desired_content_max_frame_avg_luminance
+						? nits_to_u16( pHDRStaticMetadata->desired_content_max_frame_avg_luminance )
+						: nits_to_u16( std::min( 799.f, nits_from_u16( m_Mutable.HDR.uMaxContentLightLevel ) ) );
+				if ( !bHasKnownMinCLL )
+					m_Mutable.HDR.uMinContentLightLevel =
+						pHDRStaticMetadata->desired_content_min_luminance
+						? nits_to_u16_dark( pHDRStaticMetadata->desired_content_min_luminance )
+						: nits_to_u16_dark( 0.0f );
 			}
-			else
+			else if ( !bHasKnownHDRInfo )
 			{
 				m_Mutable.HDR.bExposeHDRSupport = false;
 			}

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2392,6 +2392,7 @@ namespace gamescope
 				{
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
+					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
 					m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( otHDRInfo->get_or( "max_content_light_level", 400.0f ) );
 					m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( otHDRInfo->get_or( "max_frame_average_luminance", 400.0f ) );
 					m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( otHDRInfo->get_or( "min_content_light_level", 0.1f ) );

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2450,6 +2450,7 @@ namespace gamescope
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
 					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
+					m_Mutable.HDR.bSoftwareBacklight = otHDRInfo->get_or( "software_backlight", false );
 
 					ofScriptMaxCLL = (*otHDRInfo)["max_content_light_level"].get<sol::optional<float>>();
 					ofScriptMaxFALL = (*otHDRInfo)["max_frame_average_luminance"].get<sol::optional<float>>();
@@ -3679,7 +3680,11 @@ namespace gamescope
 			{
 				bNeedsFullComposite |= g_bHDRItmEnable;
 				if ( !SupportsColorManagement() )
+				{
 					bNeedsFullComposite |= ( pFrameInfo->layers.count() > 1 || pFrameInfo->layers.get( 0 ).colorspace != GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ );
+					// Scanout can't apply the LUT-baked backlight dim here.
+					bNeedsFullComposite |= g_ColorMgmt.current.flBacklightLutGain != 1.0f;
+				}
 			}
 			else
 			{

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2448,6 +2448,7 @@ namespace gamescope
 				{
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
+					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
 					m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( otHDRInfo->get_or( "max_content_light_level", 400.0f ) );
 					m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( otHDRInfo->get_or( "max_frame_average_luminance", 400.0f ) );
 					m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( otHDRInfo->get_or( "min_content_light_level", 0.1f ) );

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2353,6 +2353,7 @@ namespace gamescope
 
 		bool bHasKnownColorimetry = false;
 		bool bHasKnownHDRInfo = false;
+		sol::optional<float> ofScriptMaxCLL, ofScriptMaxFALL, ofScriptMinCLL;
 
 		m_Mutable.ValidDynamicRefreshRates.clear();
 		m_Mutable.fnDynamicModeGenerator = nullptr;
@@ -2449,9 +2450,10 @@ namespace gamescope
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
 					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
-					m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( otHDRInfo->get_or( "max_content_light_level", 400.0f ) );
-					m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( otHDRInfo->get_or( "max_frame_average_luminance", 400.0f ) );
-					m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( otHDRInfo->get_or( "min_content_light_level", 0.1f ) );
+
+					ofScriptMaxCLL = (*otHDRInfo)["max_content_light_level"].get<sol::optional<float>>();
+					ofScriptMaxFALL = (*otHDRInfo)["max_frame_average_luminance"].get<sol::optional<float>>();
+					ofScriptMinCLL = (*otHDRInfo)["min_content_light_level"].get<sol::optional<float>>();
 
 					bHasKnownHDRInfo = true;
 				}
@@ -2517,7 +2519,7 @@ namespace gamescope
 		/////////////////////
 		// Parse HDR stuff.
 		/////////////////////
-		if ( !bHasKnownHDRInfo )
+		if ( !bHasKnownHDRInfo || !ofScriptMaxCLL || !ofScriptMaxFALL || !ofScriptMinCLL )
 		{
 			const di_cta_hdr_static_metadata_block *pHDRStaticMetadata = nullptr;
 			const di_cta_colorimetry_block *pColorimetry = nullptr;
@@ -2552,8 +2554,11 @@ namespace gamescope
 			if ( pColorimetry && pColorimetry->bt2020_rgb &&
 				 pHDRStaticMetadata && pHDRStaticMetadata->eotfs && pHDRStaticMetadata->eotfs->pq )
 			{
-				m_Mutable.HDR.bExposeHDRSupport = true;
-				m_Mutable.HDR.eOutputEncodingEOTF = EOTF_PQ;
+				if ( !bHasKnownHDRInfo )
+				{
+					m_Mutable.HDR.bExposeHDRSupport = true;
+					m_Mutable.HDR.eOutputEncodingEOTF = EOTF_PQ;
+				}
 				m_Mutable.HDR.uMaxContentLightLevel =
 					pHDRStaticMetadata->desired_content_max_luminance
 					? nits_to_u16( pHDRStaticMetadata->desired_content_max_luminance )
@@ -2567,11 +2572,19 @@ namespace gamescope
 					? nits_to_u16_dark( pHDRStaticMetadata->desired_content_min_luminance )
 					: nits_to_u16_dark( 0.0f );
 			}
-			else
+			else if ( !bHasKnownHDRInfo )
 			{
 				m_Mutable.HDR.bExposeHDRSupport = false;
 			}
 		}
+
+		// Script values win over the EDID field by field.
+		if ( ofScriptMaxCLL )
+			m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( *ofScriptMaxCLL );
+		if ( ofScriptMaxFALL )
+			m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( *ofScriptMaxFALL );
+		if ( ofScriptMinCLL )
+			m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( *ofScriptMinCLL );
 
 		// Generate a default HDR10 infoframe.
 		if ( m_Mutable.HDR.IsHDR10() )

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2350,6 +2350,9 @@ namespace gamescope
 
 		bool bHasKnownColorimetry = false;
 		bool bHasKnownHDRInfo = false;
+		bool bHasKnownMaxCLL = false;
+		bool bHasKnownMaxFALL = false;
+		bool bHasKnownMinCLL = false;
 
 		m_Mutable.ValidDynamicRefreshRates.clear();
 		m_Mutable.fnDynamicModeGenerator = nullptr;
@@ -2446,9 +2449,22 @@ namespace gamescope
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
 					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
-					m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( otHDRInfo->get_or( "max_content_light_level", 400.0f ) );
-					m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( otHDRInfo->get_or( "max_frame_average_luminance", 400.0f ) );
-					m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( otHDRInfo->get_or( "min_content_light_level", 0.1f ) );
+
+					if ( sol::optional<float> ofMaxCLL = (*otHDRInfo)["max_content_light_level"] )
+					{
+						m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( *ofMaxCLL );
+						bHasKnownMaxCLL = true;
+					}
+					if ( sol::optional<float> ofMaxFALL = (*otHDRInfo)["max_frame_average_luminance"] )
+					{
+						m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( *ofMaxFALL );
+						bHasKnownMaxFALL = true;
+					}
+					if ( sol::optional<float> ofMinCLL = (*otHDRInfo)["min_content_light_level"] )
+					{
+						m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( *ofMinCLL );
+						bHasKnownMinCLL = true;
+					}
 
 					bHasKnownHDRInfo = true;
 				}
@@ -2514,7 +2530,10 @@ namespace gamescope
 		/////////////////////
 		// Parse HDR stuff.
 		/////////////////////
-		if ( !bHasKnownHDRInfo )
+		if ( !bHasKnownHDRInfo
+			|| !bHasKnownMaxCLL
+			|| !bHasKnownMaxFALL
+			|| !bHasKnownMinCLL )
 		{
 			const di_cta_hdr_static_metadata_block *pHDRStaticMetadata = nullptr;
 			const di_cta_colorimetry_block *pColorimetry = nullptr;
@@ -2549,22 +2568,28 @@ namespace gamescope
 			if ( pColorimetry && pColorimetry->bt2020_rgb &&
 				 pHDRStaticMetadata && pHDRStaticMetadata->eotfs && pHDRStaticMetadata->eotfs->pq )
 			{
-				m_Mutable.HDR.bExposeHDRSupport = true;
-				m_Mutable.HDR.eOutputEncodingEOTF = EOTF_PQ;
-				m_Mutable.HDR.uMaxContentLightLevel =
-					pHDRStaticMetadata->desired_content_max_luminance
-					? nits_to_u16( pHDRStaticMetadata->desired_content_max_luminance )
-					: nits_to_u16( 1499.0f );
-				m_Mutable.HDR.uMaxFrameAverageLuminance =
-					pHDRStaticMetadata->desired_content_max_frame_avg_luminance
-					? nits_to_u16( pHDRStaticMetadata->desired_content_max_frame_avg_luminance )
-					: nits_to_u16( std::min( 799.f, nits_from_u16( m_Mutable.HDR.uMaxContentLightLevel ) ) );
-				m_Mutable.HDR.uMinContentLightLevel =
-					pHDRStaticMetadata->desired_content_min_luminance
-					? nits_to_u16_dark( pHDRStaticMetadata->desired_content_min_luminance )
-					: nits_to_u16_dark( 0.0f );
+				if ( !bHasKnownHDRInfo )
+				{
+					m_Mutable.HDR.bExposeHDRSupport = true;
+					m_Mutable.HDR.eOutputEncodingEOTF = EOTF_PQ;
+				}
+				if ( !bHasKnownMaxCLL )
+					m_Mutable.HDR.uMaxContentLightLevel =
+						pHDRStaticMetadata->desired_content_max_luminance
+						? nits_to_u16( pHDRStaticMetadata->desired_content_max_luminance )
+						: nits_to_u16( 1499.0f );
+				if ( !bHasKnownMaxFALL )
+					m_Mutable.HDR.uMaxFrameAverageLuminance =
+						pHDRStaticMetadata->desired_content_max_frame_avg_luminance
+						? nits_to_u16( pHDRStaticMetadata->desired_content_max_frame_avg_luminance )
+						: nits_to_u16( std::min( 799.f, nits_from_u16( m_Mutable.HDR.uMaxContentLightLevel ) ) );
+				if ( !bHasKnownMinCLL )
+					m_Mutable.HDR.uMinContentLightLevel =
+						pHDRStaticMetadata->desired_content_min_luminance
+						? nits_to_u16_dark( pHDRStaticMetadata->desired_content_min_luminance )
+						: nits_to_u16_dark( 0.0f );
 			}
-			else
+			else if ( !bHasKnownHDRInfo )
 			{
 				m_Mutable.HDR.bExposeHDRSupport = false;
 			}

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2445,6 +2445,7 @@ namespace gamescope
 				{
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
+					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
 					m_Mutable.HDR.uMaxContentLightLevel = nits_to_u16( otHDRInfo->get_or( "max_content_light_level", 400.0f ) );
 					m_Mutable.HDR.uMaxFrameAverageLuminance = nits_to_u16( otHDRInfo->get_or( "max_frame_average_luminance", 400.0f ) );
 					m_Mutable.HDR.uMinContentLightLevel = nits_to_u16_dark( otHDRInfo->get_or( "min_content_light_level", 0.1f ) );

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2449,6 +2449,7 @@ namespace gamescope
 					m_Mutable.HDR.bExposeHDRSupport = otHDRInfo->get_or( "supported", false );
 					m_Mutable.HDR.eOutputEncodingEOTF = otHDRInfo->get_or( "eotf", EOTF_Gamma22 );
 					m_Mutable.HDR.bContentDrivenHDR = otHDRInfo->get_or( "content_driven", false );
+					m_Mutable.HDR.bSoftwareBacklight = otHDRInfo->get_or( "software_backlight", false );
 
 					if ( sol::optional<float> ofMaxCLL = (*otHDRInfo)["max_content_light_level"] )
 					{
@@ -3639,7 +3640,11 @@ namespace gamescope
 			{
 				bNeedsFullComposite |= g_bHDRItmEnable;
 				if ( !SupportsColorManagement() )
+				{
 					bNeedsFullComposite |= ( pFrameInfo->layerCount > 1 || pFrameInfo->layers[0].colorspace != GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ );
+					// Scanout can't apply the LUT-baked backlight dim here.
+					bNeedsFullComposite |= g_ColorMgmt.current.flBacklightLutGain != 1.0f;
+				}
 			}
 			else
 			{

--- a/src/backend.h
+++ b/src/backend.h
@@ -123,6 +123,9 @@ namespace gamescope
         // For displays doing "traditional HDR" such as Steam Deck OLED, this is Gamma 2.2.
         EOTF eOutputEncodingEOTF = EOTF_Gamma22;
 
+        // Only drive a panel in HDR while an HDR app is running.
+        bool bContentDrivenHDR = false;
+
         uint16_t uMaxContentLightLevel = 500;     // Nits
         uint16_t uMaxFrameAverageLuminance = 500; // Nits
         uint16_t uMinContentLightLevel = 0;       // Nits / 10000

--- a/src/backend.h
+++ b/src/backend.h
@@ -121,6 +121,8 @@ namespace gamescope
         bool bAlwaysPatchEdid = false;
         // Only drive a panel in HDR while an HDR app is running.
         bool bContentDrivenHDR = false;
+        // Panel ignores hardware backlight control in PQ, follow it in software.
+        bool bSoftwareBacklight = false;
 
         // The output encoding to use for HDR output.
         // For typical HDR10 displays, this will be PQ.

--- a/src/backend.h
+++ b/src/backend.h
@@ -119,6 +119,8 @@ namespace gamescope
         // but don't want to expose HDR there as it is not good.
         bool bExposeHDRSupport = false;
         bool bAlwaysPatchEdid = false;
+        // Only drive a panel in HDR while an HDR app is running.
+        bool bContentDrivenHDR = false;
 
         // The output encoding to use for HDR output.
         // For typical HDR10 displays, this will be PQ.

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -499,6 +499,8 @@ struct gamescope_color_mgmt_t
 	float flSDROnHDRBrightness = 203.f;
 	float flHDRInputGain = 1.f;
 	float flSDRInputGain = 1.f;
+	// Software backlight dim baked into the LUTs, PQ outputs only.
+	float flBacklightLutGain = 1.f;
 
 	// HDR Display Metadata Override & Tonemapping
 	ETonemapOperator hdrTonemapOperator = ETonemapOperator_None;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -450,6 +450,8 @@ struct gamescope_color_mgmt_t
 	float flSDROnHDRBrightness = 203.f;
 	float flHDRInputGain = 1.f;
 	float flSDRInputGain = 1.f;
+	// Software backlight dim baked into the LUTs, PQ outputs only.
+	float flBacklightLutGain = 1.f;
 
 	// HDR Display Metadata Override & Tonemapping
 	ETonemapOperator hdrTonemapOperator = ETonemapOperator_None;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -455,6 +455,7 @@ bool g_bVRRInUse_CachedValue = false;
 bool g_bSupportsHDR_CachedValue = false;
 bool g_bForceHDR10OutputDebug = false;
 gamescope::ConVar<bool> cv_hdr_enabled{ "hdr_enabled", false, "Whether or not HDR is enabled if it is available." };
+gamescope::ConVar<bool> cv_hdr_content_driven{ "hdr_content_driven", false, "Only drive a panel in HDR while an HDR app is running." };
 bool g_bHDRItmEnable = false;
 int g_nCurrentRefreshRate_CachedValue = 0;
 
@@ -884,6 +885,7 @@ global_focus_t *GetCurrentFocus()
 uint32_t		currentOutputWidth, currentOutputHeight;
 int 			currentOutputRefresh;
 bool			currentHDROutput = false;
+bool			currentHDRCapable = false;
 bool			currentHDRForce = false;
 
 std::vector< uint32_t > vecFocuscontrolAppIDs;
@@ -8541,7 +8543,36 @@ steamcompmgr_main(int argc, char **argv)
 
 		g_uCompositeDebug = cv_composite_debug;
 
-		g_bOutputHDREnabled = (g_bSupportsHDR_CachedValue || g_bForceHDR10OutputDebug) && cv_hdr_enabled;
+		// Capability is advertised to clients regardless of the live "active"
+		// state below, so games can request HDR while the panel is idling in SDR.
+		const bool bOutputHDRCapable = (g_bSupportsHDR_CachedValue || g_bForceHDR10OutputDebug) && cv_hdr_enabled;
+
+		{
+			gamescope::IBackendConnector *pConn = GetBackend()->GetCurrentConnector();
+			const bool bDynamic = bOutputHDRCapable &&
+				( cv_hdr_content_driven ||
+				  ( pConn && pConn->GetHDRInfo().bContentDrivenHDR ) );
+
+			bool bActive = bOutputHDRCapable;
+			if ( bDynamic )
+			{
+				// Track any live window, not just the focused one, so switching
+				// to the Steam UI over a running HDR game keeps the panel in HDR.
+				bActive = false;
+				for ( steamcompmgr_win_t *pWin : GetGlobalPossibleFocusWindows() )
+				{
+					commit_t *pCommit = get_window_last_done_commit_peek( pWin );
+					if ( pCommit && ColorspaceIsHDR( pCommit->colorspace() ) )
+					{
+						bActive = true;
+						break;
+					}
+				}
+			}
+			if ( bActive != g_bOutputHDREnabled )
+				xwm_log.infof( "HDR output %s%s", bActive ? "enabled" : "disabled", bDynamic ? " (hdr_content_driven)" : "" );
+			g_bOutputHDREnabled = bActive;
+		}
 
 		// Pick our width/height for this potential frame, regardless of how it might change later
 		// At some point we might even add proper locking so we get real updates atomically instead
@@ -8550,6 +8581,7 @@ steamcompmgr_main(int argc, char **argv)
 			 currentOutputHeight != g_nOutputHeight ||
 			 currentOutputRefresh != g_nOutputRefresh ||
 			 currentHDROutput != g_bOutputHDREnabled ||
+			 currentHDRCapable != bOutputHDRCapable ||
 			 currentHDRForce != g_bForceHDRSupportDebug )
 		{
 			if ( g_nXWaylandCount > 1 )
@@ -8579,7 +8611,7 @@ steamcompmgr_main(int argc, char **argv)
 				gamescope_xwayland_server_t *server = NULL;
 				for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
 				{
-					uint32_t hdr_value = ( g_bOutputHDREnabled || g_bForceHDRSupportDebug ) ? 1 : 0;
+					uint32_t hdr_value = ( bOutputHDRCapable || g_bForceHDRSupportDebug ) ? 1 : 0;
 					XChangeProperty(server->ctx->dpy, server->ctx->root, server->ctx->atoms.gamescopeHDROutputFeedback, XA_CARDINAL, 32, PropModeReplace,
 						(unsigned char *)&hdr_value, 1 );
 
@@ -8600,6 +8632,7 @@ steamcompmgr_main(int argc, char **argv)
 			currentOutputHeight = g_nOutputHeight;
 			currentOutputRefresh = g_nOutputRefresh;
 			currentHDROutput = g_bOutputHDREnabled;
+			currentHDRCapable = bOutputHDRCapable;
 			currentHDRForce = g_bForceHDRSupportDebug;
 
 #if HAVE_PIPEWIRE

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -462,6 +462,7 @@ bool g_bVRRInUse_CachedValue = false;
 bool g_bSupportsHDR_CachedValue = false;
 bool g_bForceHDR10OutputDebug = false;
 gamescope::ConVar<bool> cv_hdr_enabled{ "hdr_enabled", false, "Whether or not HDR is enabled if it is available." };
+gamescope::ConVar<bool> cv_hdr_content_driven{ "hdr_content_driven", false, "Only drive a panel in HDR while an HDR app is running." };
 bool g_bHDRItmEnable = false;
 int g_nCurrentRefreshRate_CachedValue = 0;
 
@@ -966,6 +967,7 @@ uint32_t		currentOutputWidth, currentOutputHeight;
 int 			currentOutputRefresh;
 uint32_t		currentOutputRotation = 0;
 bool			currentHDROutput = false;
+bool			currentHDRCapable = false;
 bool			currentHDRForce = false;
 
 std::vector< uint32_t > vecFocuscontrolAppIDs;
@@ -9858,7 +9860,37 @@ steamcompmgr_main(int argc, char **argv)
 
 		g_uCompositeDebug = cv_composite_debug;
 
-		g_bOutputHDREnabled = (g_bSupportsHDR_CachedValue || g_bForceHDR10OutputDebug) && cv_hdr_enabled;
+		// Capability is advertised to clients regardless of the live "active"
+		// state below, so games can request HDR while the panel is idling in SDR.
+		const bool bOutputHDRCapable = (g_bSupportsHDR_CachedValue || g_bForceHDR10OutputDebug) && cv_hdr_enabled;
+
+		{
+			gamescope::IBackendConnector *pConn = GetBackend()->GetCurrentConnector();
+			const bool bContentDriven = bOutputHDRCapable && !g_bForceHDR10OutputDebug &&
+				( cv_hdr_content_driven ||
+				  ( pConn && pConn->GetHDRInfo().bContentDrivenHDR ) );
+
+			bool bOutputHDRActive = bOutputHDRCapable;
+			if ( bContentDriven )
+			{
+				// Track any live window, not just the focused one, so browsing the
+				// Steam UI over a running HDR game does not bounce the panel through
+				// a modeset on every focus change.
+				bOutputHDRActive = false;
+				for ( steamcompmgr_win_t *pWin : GetGlobalPossibleFocusWindows() )
+				{
+					commit_t *pCommit = get_window_last_done_commit_peek( pWin );
+					if ( pCommit && ColorspaceIsHDR( pCommit->colorspace() ) )
+					{
+						bOutputHDRActive = true;
+						break;
+					}
+				}
+			}
+			if ( bOutputHDRActive != g_bOutputHDREnabled )
+				xwm_log.infof( "HDR output %s%s", bOutputHDRActive ? "enabled" : "disabled", bContentDriven ? " (hdr_content_driven)" : "" );
+			g_bOutputHDREnabled = bOutputHDRActive;
+		}
 
 		// Pick our width/height for this potential frame, regardless of how it might change later
 		// At some point we might even add proper locking so we get real updates atomically instead
@@ -9868,6 +9900,7 @@ steamcompmgr_main(int argc, char **argv)
 			 currentOutputRefresh != g_nOutputRefresh ||
 			 currentOutputRotation != g_uOutputRotation ||
 			 currentHDROutput != g_bOutputHDREnabled ||
+			 currentHDRCapable != bOutputHDRCapable ||
 			 currentHDRForce != g_bForceHDRSupportDebug )
 		{
 			if ( g_nXWaylandCount > 1 )
@@ -9897,7 +9930,7 @@ steamcompmgr_main(int argc, char **argv)
 				gamescope_xwayland_server_t *server = NULL;
 				for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
 				{
-					uint32_t hdr_value = ( g_bOutputHDREnabled || g_bForceHDRSupportDebug ) ? 1 : 0;
+					uint32_t hdr_value = ( bOutputHDRCapable || g_bForceHDRSupportDebug ) ? 1 : 0;
 					XChangeProperty(server->ctx->dpy, server->ctx->root, server->ctx->atoms.gamescopeHDROutputFeedback, XA_CARDINAL, 32, PropModeReplace,
 						(unsigned char *)&hdr_value, 1 );
 
@@ -9919,6 +9952,7 @@ steamcompmgr_main(int argc, char **argv)
 			currentOutputRefresh = g_nOutputRefresh;
 			currentOutputRotation = g_uOutputRotation;
 			currentHDROutput = g_bOutputHDREnabled;
+			currentHDRCapable = bOutputHDRCapable;
 			currentHDRForce = g_bForceHDRSupportDebug;
 
 #if HAVE_PIPEWIRE

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -340,6 +340,7 @@ create_color_mgmt_luts(const gamescope_color_mgmt_t& newColorMgmt, gamescope_col
 		if (!outColorMgmtLuts[nInputEOTF].vk_lut3d)
 			outColorMgmtLuts[nInputEOTF].vk_lut3d = vulkan_create_3d_lut(s_nLutEdgeSize3d, s_nLutEdgeSize3d, s_nLutEdgeSize3d);
 
+		// FIXME: an override bypasses the backlight gain below, like night mode and looks.
 		if ( g_ColorMgmtLutsOverride[nInputEOTF].HasLuts() )
 		{
 			memcpy(g_ColorMgmtLuts[nInputEOTF].lut1d, g_ColorMgmtLutsOverride[nInputEOTF].lut1d, sizeof(g_ColorMgmtLutsOverride[nInputEOTF].lut1d));
@@ -425,6 +426,9 @@ create_color_mgmt_luts(const gamescope_color_mgmt_t& newColorMgmt, gamescope_col
 				buildPQColorimetry( &inputColorimetry, &colorMapping, displayColorimetry );
 			}
 
+			// Software backlight dim, only ever != 1 on PQ outputs.
+			flGain *= newColorMgmt.flBacklightLutGain;
+
 			calcColorTransform<s_nLutEdgeSize3d>( &g_tmpLut1d, s_nLutSize1d, &g_tmpLut3d, inputColorimetry, inputEOTF,
 				outputEncodingColorimetry, newColorMgmt.outputEncodingEOTF,
 				newColorMgmt.outputVirtualWhite, newColorMgmt.chromaticAdaptationMode,
@@ -466,6 +470,124 @@ gamescope::ConVar<bool> cv_hdr_content_driven{ "hdr_content_driven", false, "Onl
 bool g_bHDRItmEnable = false;
 int g_nCurrentRefreshRate_CachedValue = 0;
 
+// Follows the panel backlight over sysfs for panels that ignore it in PQ. steamcompmgr thread only.
+class CBacklightWatcher final : public gamescope::IWaitable
+{
+public:
+	~CBacklightWatcher()
+	{
+		if ( m_nFD >= 0 )
+			close( m_nFD );
+	}
+
+	bool Init()
+	{
+		// amdgpu registers the panel as amdgpu_bl*, prefer it over firmware shims, lowest name for a stable pick.
+		std::string sDevice;
+		std::error_code ec;
+		for ( const auto &entry : std::filesystem::directory_iterator( "/sys/class/backlight", ec ) )
+		{
+			std::string sName = entry.path().filename().string();
+			bool bPreferred = sName.starts_with( "amdgpu_bl" );
+			bool bHavePreferred = sDevice.starts_with( "amdgpu_bl" );
+			if ( sDevice.empty() || ( bPreferred && !bHavePreferred ) || ( bPreferred == bHavePreferred && sName < sDevice ) )
+				sDevice = sName;
+		}
+
+		if ( sDevice.empty() )
+			return false;
+
+		std::string sBase = "/sys/class/backlight/" + sDevice;
+		int nMaxFD = open( ( sBase + "/max_brightness" ).c_str(), O_RDONLY | O_CLOEXEC );
+		m_nMaxBrightness = ReadInt( nMaxFD );
+		if ( nMaxFD >= 0 )
+			close( nMaxFD );
+		if ( m_nMaxBrightness <= 0 )
+			return false;
+
+		m_nFD = open( ( sBase + "/actual_brightness" ).c_str(), O_RDONLY | O_CLOEXEC );
+		if ( m_nFD < 0 )
+			return false;
+
+		m_flFactor = ReadFactor();
+		// The first read may have failed and closed the fd.
+		if ( m_nFD < 0 )
+			return false;
+
+		xwm_log.debugf( "Software backlight: watching %s, max brightness %d", sDevice.c_str(), m_nMaxBrightness );
+		return true;
+	}
+
+	int GetFD() final { return m_nFD; }
+	void OnPollPri() final
+	{
+		float flFactor = ReadFactor();
+		if ( flFactor == m_flFactor )
+			return;
+
+		m_flFactor = flFactor;
+
+		gamescope::IBackendConnector *pConn = GetBackend()->GetCurrentConnector();
+		if ( pConn && pConn->GetHDRInfo().bSoftwareBacklight )
+			hasRepaint = true;
+	}
+
+	// Drop the fd instead of the base class abort.
+	void OnPollHangUp() final
+	{
+		Disable();
+	}
+
+	float GetFactor() const { return m_flFactor; }
+
+private:
+	// Closing also removes the fd from the epoll set, the repaint restores unity gain.
+	void Disable()
+	{
+		if ( m_nFD < 0 )
+			return;
+
+		close( m_nFD );
+		m_nFD = -1;
+		m_flFactor = 1.0f;
+		hasRepaint = true;
+	}
+
+	static long ReadInt( int nFD )
+	{
+		if ( nFD < 0 )
+			return -1;
+
+		char szBuf[32];
+		lseek( nFD, 0, SEEK_SET );
+		ssize_t nRead = read( nFD, szBuf, sizeof( szBuf ) - 1 );
+		if ( nRead <= 0 )
+			return -1;
+		szBuf[nRead] = '\0';
+		return strtol( szBuf, nullptr, 10 );
+	}
+
+	// Reads actual_brightness, which also consumes the pending poll event.
+	float ReadFactor()
+	{
+		long nValue = ReadInt( m_nFD );
+		if ( nValue < 0 )
+		{
+			// A dead node reports EPOLLERR forever, drop it before it spins us.
+			Disable();
+			return m_flFactor;
+		}
+
+		return std::clamp( (float)nValue / (float)m_nMaxBrightness, 0.0f, 1.0f );
+	}
+
+	int m_nFD = -1;
+	int m_nMaxBrightness = -1;
+	float m_flFactor = 1.0f;
+};
+
+static CBacklightWatcher g_BacklightWatcher;
+
 static void
 update_color_mgmt()
 {
@@ -479,6 +601,11 @@ update_color_mgmt()
 
 	g_ColorMgmt.pending.flInternalDisplayBrightness =
 		GetBackend()->GetCurrentConnector()->GetHDRInfo().uMaxContentLightLevel;
+
+	// Panels that ignore the hardware backlight in PQ get it baked into the LUTs instead, never fully to black.
+	g_ColorMgmt.pending.flBacklightLutGain =
+		( GetBackend()->GetCurrentConnector()->GetHDRInfo().bSoftwareBacklight && g_ColorMgmt.pending.enabled && g_ColorMgmt.pending.outputEncodingEOTF == EOTF_PQ )
+			? std::max( g_BacklightWatcher.GetFactor(), 0.01f ) : 1.0f;
 
 #ifdef COLOR_MGMT_MICROBENCH
 	struct timespec t0, t1;
@@ -9599,6 +9726,9 @@ steamcompmgr_main(int argc, char **argv)
 	g_SteamCompMgrWaiter.AddWaitable( &g_FPSLimitVRRTimer );
 	GetVBlankTimer().ArmNextVBlank( true );
 	WatchMangoappConfig();
+
+	if ( g_BacklightWatcher.Init() )
+		g_SteamCompMgrWaiter.AddWaitable( &g_BacklightWatcher, EPOLLPRI );
 
 	{
 		gamescope_xwayland_server_t *pServer = NULL;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -459,6 +459,7 @@ bool g_bVRRInUse_CachedValue = false;
 bool g_bSupportsHDR_CachedValue = false;
 bool g_bForceHDR10OutputDebug = false;
 gamescope::ConVar<bool> cv_hdr_enabled{ "hdr_enabled", false, "Whether or not HDR is enabled if it is available." };
+gamescope::ConVar<bool> cv_hdr_content_driven{ "hdr_content_driven", false, "Only drive a panel in HDR while an HDR app is running." };
 bool g_bHDRItmEnable = false;
 int g_nCurrentRefreshRate_CachedValue = 0;
 
@@ -893,6 +894,7 @@ global_focus_t *GetCurrentMouseFocus()
 uint32_t		currentOutputWidth, currentOutputHeight;
 int 			currentOutputRefresh;
 bool			currentHDROutput = false;
+bool			currentHDRCapable = false;
 bool			currentHDRForce = false;
 
 std::vector< uint32_t > vecFocuscontrolAppIDs;
@@ -8706,7 +8708,37 @@ steamcompmgr_main(int argc, char **argv)
 
 		g_uCompositeDebug = cv_composite_debug;
 
-		g_bOutputHDREnabled = (g_bSupportsHDR_CachedValue || g_bForceHDR10OutputDebug) && cv_hdr_enabled;
+		// Capability is advertised to clients regardless of the live "active"
+		// state below, so games can request HDR while the panel is idling in SDR.
+		const bool bOutputHDRCapable = (g_bSupportsHDR_CachedValue || g_bForceHDR10OutputDebug) && cv_hdr_enabled;
+
+		{
+			gamescope::IBackendConnector *pConn = GetBackend()->GetCurrentConnector();
+			const bool bContentDriven = bOutputHDRCapable && !g_bForceHDR10OutputDebug &&
+				( cv_hdr_content_driven ||
+				  ( pConn && pConn->GetHDRInfo().bContentDrivenHDR ) );
+
+			bool bActive = bOutputHDRCapable;
+			if ( bContentDriven )
+			{
+				// Track any live window, not just the focused one, so browsing the
+				// Steam UI over a running HDR game does not bounce the panel through
+				// a modeset on every focus change.
+				bActive = false;
+				for ( steamcompmgr_win_t *pWin : GetGlobalPossibleFocusWindows() )
+				{
+					commit_t *pCommit = get_window_last_done_commit_peek( pWin );
+					if ( pCommit && ColorspaceIsHDR( pCommit->colorspace() ) )
+					{
+						bActive = true;
+						break;
+					}
+				}
+			}
+			if ( bActive != g_bOutputHDREnabled )
+				xwm_log.infof( "HDR output %s%s", bActive ? "enabled" : "disabled", bContentDriven ? " (hdr_content_driven)" : "" );
+			g_bOutputHDREnabled = bActive;
+		}
 
 		// Pick our width/height for this potential frame, regardless of how it might change later
 		// At some point we might even add proper locking so we get real updates atomically instead
@@ -8715,6 +8747,7 @@ steamcompmgr_main(int argc, char **argv)
 			 currentOutputHeight != g_nOutputHeight ||
 			 currentOutputRefresh != g_nOutputRefresh ||
 			 currentHDROutput != g_bOutputHDREnabled ||
+			 currentHDRCapable != bOutputHDRCapable ||
 			 currentHDRForce != g_bForceHDRSupportDebug )
 		{
 			if ( g_nXWaylandCount > 1 )
@@ -8744,7 +8777,7 @@ steamcompmgr_main(int argc, char **argv)
 				gamescope_xwayland_server_t *server = NULL;
 				for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
 				{
-					uint32_t hdr_value = ( g_bOutputHDREnabled || g_bForceHDRSupportDebug ) ? 1 : 0;
+					uint32_t hdr_value = ( bOutputHDRCapable || g_bForceHDRSupportDebug ) ? 1 : 0;
 					XChangeProperty(server->ctx->dpy, server->ctx->root, server->ctx->atoms.gamescopeHDROutputFeedback, XA_CARDINAL, 32, PropModeReplace,
 						(unsigned char *)&hdr_value, 1 );
 
@@ -8765,6 +8798,7 @@ steamcompmgr_main(int argc, char **argv)
 			currentOutputHeight = g_nOutputHeight;
 			currentOutputRefresh = g_nOutputRefresh;
 			currentHDROutput = g_bOutputHDREnabled;
+			currentHDRCapable = bOutputHDRCapable;
 			currentHDRForce = g_bForceHDRSupportDebug;
 
 #if HAVE_PIPEWIRE

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -337,6 +337,10 @@ create_color_mgmt_luts(const gamescope_color_mgmt_t& newColorMgmt, gamescope_col
 		if (!outColorMgmtLuts[nInputEOTF].vk_lut3d)
 			outColorMgmtLuts[nInputEOTF].vk_lut3d = vulkan_create_3d_lut(s_nLutEdgeSize3d, s_nLutEdgeSize3d, s_nLutEdgeSize3d);
 
+		// FIXME: an override bypasses the backlight LUT gain below, so with a
+		// calibration LUT loaded, SDR content stays at full brightness while
+		// HDR content dims. Night mode and looks are already bypassed the
+		// same way.
 		if ( g_ColorMgmtLutsOverride[nInputEOTF].HasLuts() )
 		{
 			memcpy(g_ColorMgmtLuts[nInputEOTF].lut1d, g_ColorMgmtLutsOverride[nInputEOTF].lut1d, sizeof(g_ColorMgmtLutsOverride[nInputEOTF].lut1d));
@@ -422,6 +426,9 @@ create_color_mgmt_luts(const gamescope_color_mgmt_t& newColorMgmt, gamescope_col
 				buildPQColorimetry( &inputColorimetry, &colorMapping, displayColorimetry );
 			}
 
+			// Software backlight dim, only ever != 1 on PQ outputs.
+			flGain *= newColorMgmt.flBacklightLutGain;
+
 			calcColorTransform<s_nLutEdgeSize3d>( &g_tmpLut1d, s_nLutSize1d, &g_tmpLut3d, inputColorimetry, inputEOTF,
 				outputEncodingColorimetry, newColorMgmt.outputEncodingEOTF,
 				newColorMgmt.outputVirtualWhite, newColorMgmt.chromaticAdaptationMode,
@@ -463,9 +470,163 @@ gamescope::ConVar<bool> cv_hdr_content_driven{ "hdr_content_driven", false, "Onl
 bool g_bHDRItmEnable = false;
 int g_nCurrentRefreshRate_CachedValue = 0;
 
+gamescope::ConVar<bool> cv_hdr_software_backlight{ "hdr_software_backlight", false, "Follow the panel backlight in software while the output is in PQ, regardless of the display script." };
+
+static bool BacklightDimEnabled()
+{
+	gamescope::IBackendConnector *pConn = GetBackend()->GetCurrentConnector();
+	return cv_hdr_software_backlight || ( pConn && pConn->GetHDRInfo().bSoftwareBacklight );
+}
+
+// Watches the panel backlight over sysfs. The kernel raises EPOLLPRI on
+// actual_brightness for every change, so Steam's slider is followed without
+// polling. steamcompmgr thread only.
+class CBacklightWatcher final : public gamescope::IWaitable
+{
+public:
+	~CBacklightWatcher()
+	{
+		if ( m_nFD >= 0 )
+			close( m_nFD );
+	}
+
+	bool Init()
+	{
+		// Prefer the internal panel's device if there are several, and pick
+		// the lowest name so the choice is stable across boots.
+		std::string sDevice;
+		std::error_code ec;
+		for ( const auto &entry : std::filesystem::directory_iterator( "/sys/class/backlight", ec ) )
+		{
+			std::string sName = entry.path().filename().string();
+			bool bPreferred = sName.starts_with( "amdgpu_bl" );
+			bool bHavePreferred = sDevice.starts_with( "amdgpu_bl" );
+			if ( sDevice.empty() || ( bPreferred && !bHavePreferred ) || ( bPreferred == bHavePreferred && sName < sDevice ) )
+				sDevice = sName;
+		}
+
+		if ( sDevice.empty() )
+			return false;
+
+		std::string sBase = "/sys/class/backlight/" + sDevice;
+		m_nMaxBrightness = ReadSysfsInt( ( sBase + "/max_brightness" ).c_str() );
+		if ( m_nMaxBrightness <= 0 )
+			return false;
+
+		m_nFD = open( ( sBase + "/actual_brightness" ).c_str(), O_RDONLY | O_CLOEXEC );
+		if ( m_nFD < 0 )
+			return false;
+
+		m_flFactor = ReadFactor();
+		// The first read may have failed and closed the fd.
+		if ( !IsValid() )
+			return false;
+
+		xwm_log.debugf( "Software backlight: watching %s, max brightness %d", sDevice.c_str(), m_nMaxBrightness );
+		return true;
+	}
+
+	int GetFD() final { return m_nFD; }
+	void OnPollPri() final
+	{
+		float flFactor = ReadFactor();
+		if ( flFactor == m_flFactor )
+			return;
+
+		m_flFactor = flFactor;
+
+		if ( BacklightDimEnabled() )
+			hasRepaint = true;
+	}
+
+	// kernfs never raises EPOLLHUP today, but if it ever does, drop the fd
+	// rather than aborting or spinning on the level-triggered event.
+	void OnPollHangUp() final
+	{
+		Disable();
+	}
+
+	bool IsValid() const { return m_nFD >= 0; }
+	float GetFactor() const { return m_flFactor; }
+
+private:
+	// Closing also removes the fd from the epoll set. Repaint so a dim
+	// currently on screen gets restored to unity gain.
+	void Disable()
+	{
+		if ( m_nFD < 0 )
+			return;
+
+		close( m_nFD );
+		m_nFD = -1;
+		hasRepaint = true;
+	}
+
+	static int ReadSysfsInt( const char *pszPath )
+	{
+		FILE *pFile = fopen( pszPath, "r" );
+		if ( !pFile )
+			return -1;
+
+		int nValue = -1;
+		if ( fscanf( pFile, "%d", &nValue ) != 1 )
+			nValue = -1;
+		fclose( pFile );
+		return nValue;
+	}
+
+	// Reads actual_brightness, which also consumes the pending poll event.
+	float ReadFactor()
+	{
+		char szBuf[32];
+		lseek( m_nFD, 0, SEEK_SET );
+		ssize_t nRead = read( m_nFD, szBuf, sizeof( szBuf ) - 1 );
+		if ( nRead <= 0 )
+		{
+			if ( nRead < 0 && errno == EINTR )
+				return m_flFactor;
+
+			// A dead node reports EPOLLERR forever, drop it before it spins us.
+			Disable();
+			return m_flFactor;
+		}
+		szBuf[nRead] = '\0';
+
+		return std::clamp( (float)strtol( szBuf, nullptr, 10 ) / (float)m_nMaxBrightness, 0.0f, 1.0f );
+	}
+
+	int m_nFD = -1;
+	int m_nMaxBrightness = -1;
+	float m_flFactor = 1.0f;
+};
+
+static CBacklightWatcher g_BacklightWatcher;
+
+static void UpdateBacklightDim()
+{
+	float flGain = 1.0f;
+
+	// Gate on the HDR state for the frame being built, not the possibly
+	// stale pending output EOTF, so HDR transitions never mis-dim a frame.
+	gamescope::IBackendConnector *pConn = GetBackend()->GetCurrentConnector();
+	if ( BacklightDimEnabled() &&
+	     g_ColorMgmt.pending.enabled &&
+	     g_bOutputHDREnabled &&
+	     pConn && pConn->GetHDRInfo().IsHDR10() &&
+	     g_BacklightWatcher.IsValid() )
+	{
+		// Never dim fully to black.
+		flGain = std::clamp( g_BacklightWatcher.GetFactor(), 0.01f, 1.0f );
+	}
+
+	g_ColorMgmt.pending.flBacklightLutGain = flGain;
+}
+
 static void
 update_color_mgmt()
 {
+	UpdateBacklightDim();
+
 	if ( !GetBackend()->GetCurrentConnector() )
 		return;
 
@@ -8450,6 +8611,9 @@ steamcompmgr_main(int argc, char **argv)
 	g_SteamCompMgrWaiter.AddWaitable( &GetVBlankTimer() );
 	g_SteamCompMgrWaiter.AddWaitable( &g_FPSLimitVRRTimer );
 	GetVBlankTimer().ArmNextVBlank( true );
+
+	if ( g_BacklightWatcher.Init() )
+		g_SteamCompMgrWaiter.AddWaitable( &g_BacklightWatcher, EPOLLPRI );
 
 	{
 		gamescope_xwayland_server_t *pServer = NULL;

--- a/src/waitable.h
+++ b/src/waitable.h
@@ -27,6 +27,7 @@ namespace gamescope
 
         virtual void OnPollIn() {}
         virtual void OnPollOut() {}
+        virtual void OnPollPri() {}
         virtual void OnPollHangUp()
         {
             g_WaitableLog.errorf( "IWaitable hung up. Aborting." );
@@ -39,6 +40,8 @@ namespace gamescope
                 this->OnPollIn();
             if ( nEvents & EPOLLOUT )
                 this->OnPollOut();
+            if ( nEvents & EPOLLPRI )
+                this->OnPollPri();
             if ( nEvents & EPOLLHUP )
                 this->OnPollHangUp();
         }


### PR DESCRIPTION
Some HDR panels (e.g. Legion Go 2) bypass sysfs backlight control while running in PQ mode, leaving the Steam brightness slider non-functional for SDR content and non-linear for HDR content. As a workaround, add an opt-in content-driven HDR mode that switches the panel to HDR only while an app is actively submitting HDR content.

This doesn't fix the underlying issue so the slider will still be non-linear for HDR content, but it makes the device more usable for SDR content and the Steam UI until there's proper brightness-control support for internal HDR panels that cannot blend hardware and gamma brightness control together.