### PR TITLE
Use keymap from session unless env set.

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -11,6 +11,7 @@
 #include "waitable.h"
 #include "Utils/TempFiles.h"
 
+#include <condition_variable>
 #include <cstring>
 #include <unordered_map>
 #include <unordered_set>
@@ -521,6 +522,8 @@ namespace gamescope
 
         void SetRelativePointer( bool bRelative );
 
+        ::xkb_keymap *Wayland_GetParentKeymap() const;
+
     private:
 
         void HandleKey( uint32_t uKey, bool bPressed );
@@ -547,8 +550,8 @@ namespace gamescope
 
         uint32_t m_uFakeTimestamp = 0;
 
-        xkb_context *m_pXkbContext = nullptr;
-        xkb_keymap *m_pXkbKeymap = nullptr;
+        xkb_context *m_pXkbContext        = nullptr;
+        ::xkb_keymap *m_pXkbKeymap = nullptr;
 
         uint32_t m_uKeyModifiers = 0;
         uint32_t m_uModMask[ GAMESCOPE_WAYLAND_MOD_COUNT ];
@@ -626,6 +629,7 @@ namespace gamescope
         .modifiers     = WAYLAND_USERDATA_TO_THIS( CWaylandInputThread, Wayland_Keyboard_Modifiers ),
         .repeat_info   = WAYLAND_USERDATA_TO_THIS( CWaylandInputThread, Wayland_Keyboard_RepeatInfo ),
     };
+
     const zwp_relative_pointer_v1_listener CWaylandInputThread::s_RelativePointerListener =
     {
         .relative_motion = WAYLAND_USERDATA_TO_THIS( CWaylandInputThread, Wayland_RelativePointer_RelativeMotion ),
@@ -676,6 +680,8 @@ namespace gamescope
 
         virtual bool UsesVirtualConnectors() override;
         virtual std::shared_ptr<IBackendConnector> CreateVirtualConnector( uint64_t ulVirtualConnectorKey ) override;
+    	
+    	::xkb_keymap *GetParentKeymap() const override;
     protected:
         virtual void OnBackendBlobDestroyed( BackendBlob *pBlob ) override;
 
@@ -2349,6 +2355,11 @@ namespace gamescope
         return pConnector;
     }
 
+    ::xkb_keymap *CWaylandBackend::GetParentKeymap() const
+    {
+        return m_InputThread.Wayland_GetParentKeymap();
+    }
+
     ///////////////////
     // INestedHints
     ///////////////////
@@ -2891,6 +2902,10 @@ namespace gamescope
         }
     }
 
+    ::xkb_keymap *CWaylandInputThread::Wayland_GetParentKeymap() const{
+		return m_pXkbKeymap;
+	}
+
     void CWaylandInputThread::HandleKey( uint32_t uKey, bool bPressed )
     {
         if ( m_uKeyModifiers & m_uModMask[ GAMESCOPE_WAYLAND_MOD_META ] )
@@ -3163,7 +3178,12 @@ namespace gamescope
         }
         defer( munmap( pMap, uSize ) );
 
-        xkb_keymap *pKeymap = xkb_keymap_new_from_string( m_pXkbContext, pMap, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS );
+        ::xkb_keymap *pKeymap = xkb_keymap_new_from_string(
+	        m_pXkbContext,
+	        pMap,
+	        XKB_KEYMAP_FORMAT_TEXT_V1,
+	        XKB_KEYMAP_COMPILE_NO_FLAGS
+        );
         if ( !pKeymap )
         {
             xdg_log.errorf( "Failed to create xkb_keymap" );

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -550,7 +550,7 @@ namespace gamescope
 
         uint32_t m_uFakeTimestamp = 0;
 
-        xkb_context *m_pXkbContext        = nullptr;
+        xkb_context *m_pXkbContext = nullptr;
         ::xkb_keymap *m_pXkbKeymap = nullptr;
 
         uint32_t m_uKeyModifiers = 0;

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -3163,9 +3163,6 @@ namespace gamescope
 
     void CWaylandInputThread::Wayland_Keyboard_Keymap( wl_keyboard *pKeyboard, uint32_t uFormat, int32_t nFd, uint32_t uSize )
     {
-        // We are not doing much with the keymap, we pass keycodes thru.
-        // Ideally we'd use this to influence our keymap to clients, eg. x server.
-
         defer( close( nFd ) );
         if ( uFormat != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1 )
 		return;

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -559,7 +559,7 @@ namespace gamescope
 
         uint32_t m_uFakeTimestamp = 0;
 
-        xkb_context *m_pXkbContext        = nullptr;
+        xkb_context *m_pXkbContext = nullptr;
         ::xkb_keymap *m_pXkbKeymap = nullptr;
 
         uint32_t m_uKeyModifiers = 0;

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -11,6 +11,7 @@
 #include "waitable.h"
 #include "Utils/TempFiles.h"
 
+#include <condition_variable>
 #include <cstring>
 #include <unordered_map>
 #include <unordered_set>
@@ -530,6 +531,8 @@ namespace gamescope
 
         void SetRelativePointer( bool bRelative );
 
+        ::xkb_keymap *Wayland_GetParentKeymap() const;
+
     private:
 
         void HandleKey( uint32_t uKey, bool bPressed );
@@ -556,8 +559,8 @@ namespace gamescope
 
         uint32_t m_uFakeTimestamp = 0;
 
-        xkb_context *m_pXkbContext = nullptr;
-        xkb_keymap *m_pXkbKeymap = nullptr;
+        xkb_context *m_pXkbContext        = nullptr;
+        ::xkb_keymap *m_pXkbKeymap = nullptr;
 
         uint32_t m_uKeyModifiers = 0;
         uint32_t m_uModMask[ GAMESCOPE_WAYLAND_MOD_COUNT ];
@@ -635,6 +638,7 @@ namespace gamescope
         .modifiers     = WAYLAND_USERDATA_TO_THIS( CWaylandInputThread, Wayland_Keyboard_Modifiers ),
         .repeat_info   = WAYLAND_USERDATA_TO_THIS( CWaylandInputThread, Wayland_Keyboard_RepeatInfo ),
     };
+
     const zwp_relative_pointer_v1_listener CWaylandInputThread::s_RelativePointerListener =
     {
         .relative_motion = WAYLAND_USERDATA_TO_THIS( CWaylandInputThread, Wayland_RelativePointer_RelativeMotion ),
@@ -685,6 +689,8 @@ namespace gamescope
 
         virtual bool UsesVirtualConnectors() override;
         virtual std::shared_ptr<IBackendConnector> CreateVirtualConnector( uint64_t ulVirtualConnectorKey ) override;
+    	
+    	::xkb_keymap *GetParentKeymap() const override;
     protected:
         virtual void OnBackendBlobDestroyed( BackendBlob *pBlob ) override;
 
@@ -2359,6 +2365,11 @@ namespace gamescope
         return pConnector;
     }
 
+    ::xkb_keymap *CWaylandBackend::GetParentKeymap() const
+    {
+        return m_InputThread.Wayland_GetParentKeymap();
+    }
+
     ///////////////////
     // INestedHints
     ///////////////////
@@ -2927,6 +2938,10 @@ namespace gamescope
         }
     }
 
+    ::xkb_keymap *CWaylandInputThread::Wayland_GetParentKeymap() const{
+		return m_pXkbKeymap;
+	}
+
     void CWaylandInputThread::HandleKey( uint32_t uKey, bool bPressed )
     {
         if ( m_uKeyModifiers & m_uModMask[ GAMESCOPE_WAYLAND_MOD_META ] )
@@ -3219,7 +3234,12 @@ namespace gamescope
         }
         defer( munmap( pMap, uSize ) );
 
-        xkb_keymap *pKeymap = xkb_keymap_new_from_string( m_pXkbContext, pMap, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS );
+        ::xkb_keymap *pKeymap = xkb_keymap_new_from_string(
+	        m_pXkbContext,
+	        pMap,
+	        XKB_KEYMAP_FORMAT_TEXT_V1,
+	        XKB_KEYMAP_COMPILE_NO_FLAGS
+        );
         if ( !pKeymap )
         {
             xdg_log.errorf( "Failed to create xkb_keymap" );

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -3219,9 +3219,6 @@ namespace gamescope
 
     void CWaylandInputThread::Wayland_Keyboard_Keymap( wl_keyboard *pKeyboard, uint32_t uFormat, int32_t nFd, uint32_t uSize )
     {
-        // We are not doing much with the keymap, we pass keycodes thru.
-        // Ideally we'd use this to influence our keymap to clients, eg. x server.
-
         defer( close( nFd ) );
         if ( uFormat != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1 )
 		return;

--- a/src/backend.h
+++ b/src/backend.h
@@ -18,6 +18,8 @@
 #include <variant>
 #include <any>
 
+#include <xkbcommon/xkbcommon.h>
+
 struct wlr_buffer;
 struct wlr_dmabuf_attributes;
 
@@ -395,6 +397,8 @@ namespace gamescope
         virtual bool ShouldFitWindows() = 0;
 
         virtual void OnEndFrame() = 0;
+
+    	virtual ::xkb_keymap *GetParentKeymap() const { return nullptr; }
 
         static IBackend *Get();
         template <typename T>

--- a/src/backend.h
+++ b/src/backend.h
@@ -18,6 +18,8 @@
 #include <variant>
 #include <any>
 
+#include <xkbcommon/xkbcommon.h>
+
 struct wlr_buffer;
 struct wlr_dmabuf_attributes;
 
@@ -405,6 +407,8 @@ namespace gamescope
         virtual bool NewlyInitted() = 0;
 
         virtual void OnEndFrame() = 0;
+
+    	virtual ::xkb_keymap *GetParentKeymap() const { return nullptr; }
 
         static IBackend *Get();
         template <typename T>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -997,12 +997,11 @@ int main(int argc, char **argv)
 	if ( g_nNestedWidth == 0 )
 		g_nNestedWidth = g_nNestedHeight * 16 / 9;
 
-	::xkb_keymap *parent_keymap = nullptr;
-	parent_keymap = GetBackend()->GetParentKeymap();
+	::xkb_keymap *parent_keymap = GetBackend()->GetParentKeymap();
 
 	if (!wlserver_init(parent_keymap))
 	{
-		fprintf( stderr, "Failed to initialize wlserver\n" );
+		fprintf(stderr, "Failed to initialize wlserver\n");
 		return 1;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -997,7 +997,10 @@ int main(int argc, char **argv)
 	if ( g_nNestedWidth == 0 )
 		g_nNestedWidth = g_nNestedHeight * 16 / 9;
 
-	if ( !wlserver_init() )
+	::xkb_keymap *parent_keymap = nullptr;
+	parent_keymap = GetBackend()->GetParentKeymap();
+
+	if (!wlserver_init(parent_keymap))
 	{
 		fprintf( stderr, "Failed to initialize wlserver\n" );
 		return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1069,12 +1069,11 @@ int main(int argc, char **argv)
 	if ( g_nNestedWidth == 0 )
 		g_nNestedWidth = g_nNestedHeight * 16 / 9;
 
-	::xkb_keymap *parent_keymap = nullptr;
-	parent_keymap = GetBackend()->GetParentKeymap();
+	::xkb_keymap *parent_keymap = GetBackend()->GetParentKeymap();
 
 	if (!wlserver_init(parent_keymap))
 	{
-		fprintf( stderr, "Failed to initialize wlserver\n" );
+		fprintf(stderr, "Failed to initialize wlserver\n");
 		return 1;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1069,7 +1069,10 @@ int main(int argc, char **argv)
 	if ( g_nNestedWidth == 0 )
 		g_nNestedWidth = g_nNestedHeight * 16 / 9;
 
-	if ( !wlserver_init() )
+	::xkb_keymap *parent_keymap = nullptr;
+	parent_keymap = GetBackend()->GetParentKeymap();
+
+	if (!wlserver_init(parent_keymap))
 	{
 		fprintf( stderr, "Failed to initialize wlserver\n" );
 		return 1;

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdint.h>
 
 #include "wlr_begin.hpp"

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -101,11 +101,6 @@ struct wlserver_content_override {
 std::mutex g_wlserver_xdg_shell_windows_lock;
 
 static struct wl_list pending_surfaces = {0};
-struct gamescope_input_ctx {
-	struct wl_listener destroy;
-	struct wlr_input_device *device;
-};
-static struct wlr_keyboard *parent_keyboard = NULL;
 static std::atomic<bool> g_bShutdownWLServer{ false };
 
 static void wlserver_x11_surface_info_set_wlr( struct wlserver_x11_surface_info *surf, struct wlr_surface *wlr_surf, bool override );
@@ -479,17 +474,6 @@ static void wlserver_handle_touch_motion(struct wl_listener *listener, void *dat
 	wlserver_touchmotion( event->x, event->y, event->touch_id, event->time_msec, false, touch->connector );
 }
 
-static void wlserver_destroy_input(struct wl_listener *listener, void *data)
-{
-	struct gamescope_input_ctx *ctx = wl_container_of(listener, ctx, destroy);
-	
-	if (parent_keyboard && &parent_keyboard->base == ctx->device) {
-		wl_log.infof("Parent keyboard destroyed");
-		parent_keyboard = NULL;
-	}
-	delete(ctx);
-}
-
 static void wlserver_new_input(struct wl_listener *listener, void *data)
 {
 	struct wlr_input_device *device = (struct wlr_input_device *) data;
@@ -499,18 +483,6 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 		case WLR_INPUT_DEVICE_KEYBOARD:
 		{
 			struct wlr_keyboard *keyboard = wlr_keyboard_from_input_device(device);
-			struct gamescope_input_ctx *ctx = new gamescope_input_ctx {
-				.destroy = { .notify = wlserver_destroy_input },
-				.device = device
-			};
-			wl_signal_add(&device->events.destroy, &ctx->destroy);
-
-			if (!parent_keyboard) {
-				parent_keyboard = keyboard;
-				wl_log.infof("Captured parent keyboard from %s", device->name);
-			}
-
-			wlr_keyboard_set_keymap(keyboard, wlserver.keyboard_group->keyboard.keymap);
 
 			if (!wlr_keyboard_group_add_keyboard(wlserver.keyboard_group, keyboard)) {
 				wl_log.errorf("failed to add physical keyboard %s", device->name);
@@ -1963,7 +1935,7 @@ static gamescope::CAsyncWaiter g_LibEisWaiter( "gamescope-eis" );
 static std::unique_ptr<gamescope::GamescopeInputServer> g_InputServer;
 #endif
 
-bool wlserver_init( void ) {
+bool wlserver_init( ::xkb_keymap *p_keymap ) {
 	assert( wlserver.display != nullptr );
 
 	wl_list_init(&pending_surfaces);
@@ -2108,9 +2080,9 @@ bool wlserver_init( void ) {
 
 	// Backend initialized, input_devices populated. Now we can extract keymap
 	// from parent, then override with any set env vars
-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-	struct xkb_rule_names rules = { 0 };
-	struct xkb_keymap *keymap = NULL;
+	::xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	::xkb_rule_names rules = { 0 };
+	::xkb_keymap *keymap = nullptr;
 
 	// Fetch xkb env vars from session
 	const char *env_rules = getenv("XKB_DEFAULT_RULES");
@@ -2119,22 +2091,31 @@ bool wlserver_init( void ) {
 	const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
 	const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
 
-	// priority: env > parent > default
+	// priority: env overrides parent keymap overrides default
 	if (env_rules || env_model || env_layout || env_variant || env_options) {
+		// Compile from env vars
 		rules.rules = env_rules ?: "evdev";
 		rules.model = env_model ?: "pc105";
 		rules.layout = env_layout ?: "us";
-		rules.variant = env_variant; // NULL
+		rules.variant = (env_layout && env_variant) ? env_variant : NULL; // NULL
 		rules.options = env_options; // NULL
-
 		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
-	} else if (parent_keyboard && parent_keyboard->keymap) {
-		keymap = xkb_keymap_ref(parent_keyboard->keymap);
-	} else {
+		wl_log.infof("Using XKB keymap from environment variables");
+	}
+	else {
+		if (p_keymap) {
+			keymap = xkb_keymap_ref(p_keymap);
+			wl_log.infof("Using parent session keymap");
+		}
+	}
+
+	// Fallback if nothing worked
+	if (!keymap) {
 		rules.rules = "evdev";
 		rules.model = "pc105";
 		rules.layout = "us";
 		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+		wl_log.infof("Using default XKB keymap");
 	}
 
 	wlr_keyboard_set_keymap(kbd, keymap);

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -101,7 +101,11 @@ struct wlserver_content_override {
 std::mutex g_wlserver_xdg_shell_windows_lock;
 
 static struct wl_list pending_surfaces = {0};
-
+struct gamescope_input_ctx {
+	struct wl_listener destroy;
+	struct wlr_input_device *device;
+};
+static struct wlr_keyboard *parent_keyboard = NULL;
 static std::atomic<bool> g_bShutdownWLServer{ false };
 
 static void wlserver_x11_surface_info_set_wlr( struct wlserver_x11_surface_info *surf, struct wlr_surface *wlr_surf, bool override );
@@ -475,6 +479,17 @@ static void wlserver_handle_touch_motion(struct wl_listener *listener, void *dat
 	wlserver_touchmotion( event->x, event->y, event->touch_id, event->time_msec, false, touch->connector );
 }
 
+static void wlserver_destroy_input(struct wl_listener *listener, void *data)
+{
+	struct gamescope_input_ctx *ctx = wl_container_of(listener, ctx, destroy);
+	
+	if (parent_keyboard && &parent_keyboard->base == ctx->device) {
+		wl_log.infof("Parent keyboard destroyed");
+		parent_keyboard = NULL;
+	}
+	delete(ctx);
+}
+
 static void wlserver_new_input(struct wl_listener *listener, void *data)
 {
 	struct wlr_input_device *device = (struct wlr_input_device *) data;
@@ -484,7 +499,19 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 		case WLR_INPUT_DEVICE_KEYBOARD:
 		{
 			struct wlr_keyboard *keyboard = wlr_keyboard_from_input_device(device);
+			struct gamescope_input_ctx *ctx = new gamescope_input_ctx {
+				.destroy = { .notify = wlserver_destroy_input },
+				.device = device
+			};
+			wl_signal_add(&device->events.destroy, &ctx->destroy);
+
+			if (!parent_keyboard) {
+				parent_keyboard = keyboard;
+				wl_log.infof("Captured parent keyboard from %s", device->name);
+			}
+
 			wlr_keyboard_set_keymap(keyboard, wlserver.keyboard_group->keyboard.keymap);
+
 			if (!wlr_keyboard_group_add_keyboard(wlserver.keyboard_group, keyboard)) {
 				wl_log.errorf("failed to add physical keyboard %s", device->name);
 				break;
@@ -1967,19 +1994,10 @@ bool wlserver_init( void ) {
 	wlserver.wlr.virtual_keyboard_device = kbd;
 
 	// Create a keyboard group to keep all externally connected keyboards
-	// in sync (one single layout and a shared state)
-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-	struct xkb_rule_names rules = { 0 };
-	rules.rules = getenv("XKB_DEFAULT_RULES");
-	rules.model = getenv("XKB_DEFAULT_MODEL");
-	rules.layout = getenv("XKB_DEFAULT_LAYOUT");
-	rules.variant = getenv("XKB_DEFAULT_VARIANT");
-	rules.options = getenv("XKB_DEFAULT_OPTIONS");
-	struct xkb_keymap *keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	// in sync (one single layout and a shared state) - defer keymap to later
 	wlserver.keyboard_group = wlr_keyboard_group_create();
 	struct wlr_keyboard *keyboard = &wlserver.keyboard_group->keyboard;
 	wlr_keyboard_set_repeat_info(keyboard, 25, 600);
-	wlr_keyboard_set_keymap(keyboard, keymap);
 	wlserver.keyboard_group_modifiers.notify = wlserver_handle_modifiers;
 	wl_signal_add(&keyboard->events.modifiers, &wlserver.keyboard_group_modifiers);
 	wlserver.keyboard_group_key.notify = wlserver_handle_key;
@@ -2087,6 +2105,39 @@ bool wlserver_init( void ) {
 		wl_display_destroy(wlserver.display);
 		return false;
 	}
+
+	// Backend initialized, input_devices populated. Now we can extract keymap
+	// from parent, then override with any set env vars
+	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	struct xkb_rule_names rules = { 0 };
+	struct xkb_keymap *keymap = NULL;
+
+	// Fetch xkb env vars from session
+	const char *env_rules = getenv("XKB_DEFAULT_RULES");
+	const char *env_model = getenv("XKB_DEFAULT_MODEL");
+	const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
+	const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
+	const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
+
+	// priority: env > parent > default
+	if (env_rules || env_model || env_layout || env_variant || env_options) {
+		rules.rules = env_rules ?: "evdev";
+		rules.model = env_model ?: "pc105";
+		rules.layout = env_layout ?: "us";
+		rules.variant = env_variant; // NULL
+		rules.options = env_options; // NULL
+
+		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	} else if (parent_keyboard && parent_keyboard->keymap) {
+		keymap = xkb_keymap_ref(parent_keyboard->keymap);
+	} else {
+		rules.rules = "evdev";
+		rules.model = "pc105";
+		rules.layout = "us";
+		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	}
+
+	wlr_keyboard_set_keymap(kbd, keymap);
 
 	wl_signal_emit( &wlserver.wlr.multi_backend->events.new_input, kbd );
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1967,11 +1967,14 @@ bool wlserver_init( ::xkb_keymap *p_keymap ) {
 
 	// Create a keyboard group to keep all externally connected keyboards
 	// in sync (one single layout and a shared state) - defer keymap to later
-	wlserver.keyboard_group = wlr_keyboard_group_create();
+	wlserver.keyboard_group       = wlr_keyboard_group_create();
 	struct wlr_keyboard *keyboard = &wlserver.keyboard_group->keyboard;
 	wlr_keyboard_set_repeat_info(keyboard, 25, 600);
 	wlserver.keyboard_group_modifiers.notify = wlserver_handle_modifiers;
-	wl_signal_add(&keyboard->events.modifiers, &wlserver.keyboard_group_modifiers);
+	wl_signal_add(
+		&keyboard->events.modifiers,
+		&wlserver.keyboard_group_modifiers
+	);
 	wlserver.keyboard_group_key.notify = wlserver_handle_key;
 	wl_signal_add(&keyboard->events.key, &wlserver.keyboard_group_key);
 
@@ -2082,40 +2085,72 @@ bool wlserver_init( ::xkb_keymap *p_keymap ) {
 	// from parent, then override with any set env vars
 	::xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	::xkb_rule_names rules = { 0 };
-	::xkb_keymap *keymap = nullptr;
+	::xkb_keymap *keymap   = nullptr;
 
 	// Fetch xkb env vars from session
-	const char *env_rules = getenv("XKB_DEFAULT_RULES");
-	const char *env_model = getenv("XKB_DEFAULT_MODEL");
-	const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
+	const char *env_rules   = getenv("XKB_DEFAULT_RULES");
+	const char *env_model   = getenv("XKB_DEFAULT_MODEL");
+	const char *env_layout  = getenv("XKB_DEFAULT_LAYOUT");
 	const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
 	const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
 
 	// priority: env overrides parent keymap overrides default
-	if (env_rules || env_model || env_layout || env_variant || env_options) {
-		// Compile from env vars
-		rules.rules = env_rules ?: "evdev";
-		rules.model = env_model ?: "pc105";
-		rules.layout = env_layout ?: "us";
-		rules.variant = (env_layout && env_variant) ? env_variant : NULL; // NULL
-		rules.options = env_options; // NULL
-		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
-		wl_log.infof("Using XKB keymap from environment variables");
-	}
-	else {
-		if (p_keymap) {
-			keymap = xkb_keymap_ref(p_keymap);
-			wl_log.infof("Using parent session keymap");
-		}
+	if (
+		env_rules
+		|| env_model
+		|| env_layout
+		|| env_options
+	)
+	{
+		// Build keymap from env
+		rules.rules   = env_rules ? : "evdev";
+		rules.model   = env_model ? : "pc105";
+		rules.layout  = env_layout ? : "us";
+		rules.variant = (env_layout && env_variant) ? env_variant : NULL;
+		rules.options = env_options;
+		keymap        = xkb_keymap_new_from_names(
+			context,
+			&rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS
+		);
 	}
 
-	// Fallback if nothing worked
-	if (!keymap) {
-		rules.rules = "evdev";
-		rules.model = "pc105";
-		rules.layout = "us";
-		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
-		wl_log.infof("Using default XKB keymap");
+	// Note: xkb_keymap_new_from_names can fail and leave keymap UB. This is
+	// why we check.
+	if (keymap)
+	{
+		wl_log.infof("Using xkb_keymap from environment variables");
+	}
+	else if (p_keymap)
+	{
+		// Ref parent session's keymap
+		keymap = xkb_keymap_ref(p_keymap);
+		wl_log.infof("Using parent session xkb_keymap");
+	}
+
+	// Build default keymap as fallback
+	if (!keymap)
+	{
+		rules.rules   = "evdev";
+		rules.model   = "pc105";
+		rules.layout  = "us";
+		rules.variant = NULL;
+		rules.options = NULL;
+		keymap        = xkb_keymap_new_from_names(
+			context,
+			&rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS
+		);
+
+		if (keymap)
+		{
+			wl_log.infof("Using default xkb_keymap.");
+		}
+		else
+		{
+			wl_log.errorf("Failed to create any xkb_keymap.");
+			return false;
+		}
 	}
 
 	wlr_keyboard_set_keymap(kbd, keymap);

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2052,11 +2052,14 @@ bool wlserver_init( ::xkb_keymap *p_keymap ) {
 
 	// Create a keyboard group to keep all externally connected keyboards
 	// in sync (one single layout and a shared state) - defer keymap to later
-	wlserver.keyboard_group = wlr_keyboard_group_create();
+	wlserver.keyboard_group       = wlr_keyboard_group_create();
 	struct wlr_keyboard *keyboard = &wlserver.keyboard_group->keyboard;
 	wlr_keyboard_set_repeat_info(keyboard, 25, 600);
 	wlserver.keyboard_group_modifiers.notify = wlserver_handle_modifiers;
-	wl_signal_add(&keyboard->events.modifiers, &wlserver.keyboard_group_modifiers);
+	wl_signal_add(
+		&keyboard->events.modifiers,
+		&wlserver.keyboard_group_modifiers
+	);
 	wlserver.keyboard_group_key.notify = wlserver_handle_key;
 	wl_signal_add(&keyboard->events.key, &wlserver.keyboard_group_key);
 
@@ -2175,40 +2178,72 @@ bool wlserver_init( ::xkb_keymap *p_keymap ) {
 	// from parent, then override with any set env vars
 	::xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	::xkb_rule_names rules = { 0 };
-	::xkb_keymap *keymap = nullptr;
+	::xkb_keymap *keymap   = nullptr;
 
 	// Fetch xkb env vars from session
-	const char *env_rules = getenv("XKB_DEFAULT_RULES");
-	const char *env_model = getenv("XKB_DEFAULT_MODEL");
-	const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
+	const char *env_rules   = getenv("XKB_DEFAULT_RULES");
+	const char *env_model   = getenv("XKB_DEFAULT_MODEL");
+	const char *env_layout  = getenv("XKB_DEFAULT_LAYOUT");
 	const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
 	const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
 
 	// priority: env overrides parent keymap overrides default
-	if (env_rules || env_model || env_layout || env_variant || env_options) {
-		// Compile from env vars
-		rules.rules = env_rules ?: "evdev";
-		rules.model = env_model ?: "pc105";
-		rules.layout = env_layout ?: "us";
-		rules.variant = (env_layout && env_variant) ? env_variant : NULL; // NULL
-		rules.options = env_options; // NULL
-		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
-		wl_log.infof("Using XKB keymap from environment variables");
-	}
-	else {
-		if (p_keymap) {
-			keymap = xkb_keymap_ref(p_keymap);
-			wl_log.infof("Using parent session keymap");
-		}
+	if (
+		env_rules
+		|| env_model
+		|| env_layout
+		|| env_options
+	)
+	{
+		// Build keymap from env
+		rules.rules   = env_rules ? : "evdev";
+		rules.model   = env_model ? : "pc105";
+		rules.layout  = env_layout ? : "us";
+		rules.variant = (env_layout && env_variant) ? env_variant : NULL;
+		rules.options = env_options;
+		keymap        = xkb_keymap_new_from_names(
+			context,
+			&rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS
+		);
 	}
 
-	// Fallback if nothing worked
-	if (!keymap) {
-		rules.rules = "evdev";
-		rules.model = "pc105";
-		rules.layout = "us";
-		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
-		wl_log.infof("Using default XKB keymap");
+	// Note: xkb_keymap_new_from_names can fail and leave keymap UB. This is
+	// why we check.
+	if (keymap)
+	{
+		wl_log.infof("Using xkb_keymap from environment variables");
+	}
+	else if (p_keymap)
+	{
+		// Ref parent session's keymap
+		keymap = xkb_keymap_ref(p_keymap);
+		wl_log.infof("Using parent session xkb_keymap");
+	}
+
+	// Build default keymap as fallback
+	if (!keymap)
+	{
+		rules.rules   = "evdev";
+		rules.model   = "pc105";
+		rules.layout  = "us";
+		rules.variant = NULL;
+		rules.options = NULL;
+		keymap        = xkb_keymap_new_from_names(
+			context,
+			&rules,
+			XKB_KEYMAP_COMPILE_NO_FLAGS
+		);
+
+		if (keymap)
+		{
+			wl_log.infof("Using default xkb_keymap.");
+		}
+		else
+		{
+			wl_log.errorf("Failed to create any xkb_keymap.");
+			return false;
+		}
 	}
 
 	wlr_keyboard_set_keymap(kbd, keymap);

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -103,7 +103,11 @@ struct wlserver_content_override {
 std::mutex g_wlserver_xdg_shell_windows_lock;
 
 static struct wl_list pending_surfaces = {0};
-
+struct gamescope_input_ctx {
+	struct wl_listener destroy;
+	struct wlr_input_device *device;
+};
+static struct wlr_keyboard *parent_keyboard = NULL;
 static std::atomic<bool> g_bShutdownWLServer{ false };
 
 static void wlserver_x11_surface_info_set_wlr( struct wlserver_x11_surface_info *surf, struct wlr_surface *wlr_surf, bool override );
@@ -472,6 +476,17 @@ static void wlserver_handle_touch_motion(struct wl_listener *listener, void *dat
 	wlserver_touchmotion( event->x, event->y, event->touch_id, event->time_msec, false, touch->connector );
 }
 
+static void wlserver_destroy_input(struct wl_listener *listener, void *data)
+{
+	struct gamescope_input_ctx *ctx = wl_container_of(listener, ctx, destroy);
+	
+	if (parent_keyboard && &parent_keyboard->base == ctx->device) {
+		wl_log.infof("Parent keyboard destroyed");
+		parent_keyboard = NULL;
+	}
+	delete(ctx);
+}
+
 static void wlserver_handle_pointer_destroy(struct wl_listener *listener, void *data)
 {
 	struct wlserver_pointer *pointer = wl_container_of( listener, pointer, destroy );
@@ -504,7 +519,19 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 		case WLR_INPUT_DEVICE_KEYBOARD:
 		{
 			struct wlr_keyboard *keyboard = wlr_keyboard_from_input_device(device);
+			struct gamescope_input_ctx *ctx = new gamescope_input_ctx {
+				.destroy = { .notify = wlserver_destroy_input },
+				.device = device
+			};
+			wl_signal_add(&device->events.destroy, &ctx->destroy);
+
+			if (!parent_keyboard) {
+				parent_keyboard = keyboard;
+				wl_log.infof("Captured parent keyboard from %s", device->name);
+			}
+
 			wlr_keyboard_set_keymap(keyboard, wlserver.keyboard_group->keyboard.keymap);
+
 			if (!wlr_keyboard_group_add_keyboard(wlserver.keyboard_group, keyboard)) {
 				wl_log.errorf("failed to add physical keyboard %s", device->name);
 				break;
@@ -2075,19 +2102,10 @@ bool wlserver_init( void ) {
 	wlserver.wlr.virtual_keyboard_device = kbd;
 
 	// Create a keyboard group to keep all externally connected keyboards
-	// in sync (one single layout and a shared state)
-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-	struct xkb_rule_names rules = { 0 };
-	rules.rules = getenv("XKB_DEFAULT_RULES");
-	rules.model = getenv("XKB_DEFAULT_MODEL");
-	rules.layout = getenv("XKB_DEFAULT_LAYOUT");
-	rules.variant = getenv("XKB_DEFAULT_VARIANT");
-	rules.options = getenv("XKB_DEFAULT_OPTIONS");
-	struct xkb_keymap *keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	// in sync (one single layout and a shared state) - defer keymap to later
 	wlserver.keyboard_group = wlr_keyboard_group_create();
 	struct wlr_keyboard *keyboard = &wlserver.keyboard_group->keyboard;
 	wlr_keyboard_set_repeat_info(keyboard, 25, 600);
-	wlr_keyboard_set_keymap(keyboard, keymap);
 	wlserver.keyboard_group_modifiers.notify = wlserver_handle_modifiers;
 	wl_signal_add(&keyboard->events.modifiers, &wlserver.keyboard_group_modifiers);
 	wlserver.keyboard_group_key.notify = wlserver_handle_key;
@@ -2203,6 +2221,39 @@ bool wlserver_init( void ) {
 		wl_display_destroy(wlserver.display);
 		return false;
 	}
+
+	// Backend initialized, input_devices populated. Now we can extract keymap
+	// from parent, then override with any set env vars
+	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	struct xkb_rule_names rules = { 0 };
+	struct xkb_keymap *keymap = NULL;
+
+	// Fetch xkb env vars from session
+	const char *env_rules = getenv("XKB_DEFAULT_RULES");
+	const char *env_model = getenv("XKB_DEFAULT_MODEL");
+	const char *env_layout = getenv("XKB_DEFAULT_LAYOUT");
+	const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
+	const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
+
+	// priority: env > parent > default
+	if (env_rules || env_model || env_layout || env_variant || env_options) {
+		rules.rules = env_rules ?: "evdev";
+		rules.model = env_model ?: "pc105";
+		rules.layout = env_layout ?: "us";
+		rules.variant = env_variant; // NULL
+		rules.options = env_options; // NULL
+
+		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	} else if (parent_keyboard && parent_keyboard->keymap) {
+		keymap = xkb_keymap_ref(parent_keyboard->keymap);
+	} else {
+		rules.rules = "evdev";
+		rules.model = "pc105";
+		rules.layout = "us";
+		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	}
+
+	wlr_keyboard_set_keymap(kbd, keymap);
 
 	wl_signal_emit( &wlserver.wlr.multi_backend->events.new_input, kbd );
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -103,11 +103,6 @@ struct wlserver_content_override {
 std::mutex g_wlserver_xdg_shell_windows_lock;
 
 static struct wl_list pending_surfaces = {0};
-struct gamescope_input_ctx {
-	struct wl_listener destroy;
-	struct wlr_input_device *device;
-};
-static struct wlr_keyboard *parent_keyboard = NULL;
 static std::atomic<bool> g_bShutdownWLServer{ false };
 
 static void wlserver_x11_surface_info_set_wlr( struct wlserver_x11_surface_info *surf, struct wlr_surface *wlr_surf, bool override );
@@ -476,40 +471,6 @@ static void wlserver_handle_touch_motion(struct wl_listener *listener, void *dat
 	wlserver_touchmotion( event->x, event->y, event->touch_id, event->time_msec, false, touch->connector );
 }
 
-static void wlserver_destroy_input(struct wl_listener *listener, void *data)
-{
-	struct gamescope_input_ctx *ctx = wl_container_of(listener, ctx, destroy);
-	
-	if (parent_keyboard && &parent_keyboard->base == ctx->device) {
-		wl_log.infof("Parent keyboard destroyed");
-		parent_keyboard = NULL;
-	}
-	delete(ctx);
-}
-
-static void wlserver_handle_pointer_destroy(struct wl_listener *listener, void *data)
-{
-	struct wlserver_pointer *pointer = wl_container_of( listener, pointer, destroy );
-
-	wl_list_remove( &pointer->motion.link );
-	wl_list_remove( &pointer->button.link );
-	wl_list_remove( &pointer->axis.link );
-	wl_list_remove( &pointer->frame.link );
-	wl_list_remove( &pointer->destroy.link );
-	free( pointer );
-}
-
-static void wlserver_handle_touch_destroy(struct wl_listener *listener, void *data)
-{
-	struct wlserver_touch *touch = wl_container_of( listener, touch, destroy );
-
-	wl_list_remove( &touch->down.link );
-	wl_list_remove( &touch->up.link );
-	wl_list_remove( &touch->motion.link );
-	wl_list_remove( &touch->destroy.link );
-	free( touch );
-}
-
 static void wlserver_new_input(struct wl_listener *listener, void *data)
 {
 	struct wlr_input_device *device = (struct wlr_input_device *) data;
@@ -519,18 +480,6 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 		case WLR_INPUT_DEVICE_KEYBOARD:
 		{
 			struct wlr_keyboard *keyboard = wlr_keyboard_from_input_device(device);
-			struct gamescope_input_ctx *ctx = new gamescope_input_ctx {
-				.destroy = { .notify = wlserver_destroy_input },
-				.device = device
-			};
-			wl_signal_add(&device->events.destroy, &ctx->destroy);
-
-			if (!parent_keyboard) {
-				parent_keyboard = keyboard;
-				wl_log.infof("Captured parent keyboard from %s", device->name);
-			}
-
-			wlr_keyboard_set_keymap(keyboard, wlserver.keyboard_group->keyboard.keymap);
 
 			if (!wlr_keyboard_group_add_keyboard(wlserver.keyboard_group, keyboard)) {
 				wl_log.errorf("failed to add physical keyboard %s", device->name);
@@ -2071,7 +2020,7 @@ static gamescope::CAsyncWaiter g_LibEisWaiter( "gamescope-eis" );
 static std::unique_ptr<gamescope::GamescopeInputServer> g_InputServer;
 #endif
 
-bool wlserver_init( void ) {
+bool wlserver_init( ::xkb_keymap *p_keymap ) {
 	assert( wlserver.display != nullptr );
 
 	wl_list_init(&pending_surfaces);
@@ -2224,9 +2173,9 @@ bool wlserver_init( void ) {
 
 	// Backend initialized, input_devices populated. Now we can extract keymap
 	// from parent, then override with any set env vars
-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-	struct xkb_rule_names rules = { 0 };
-	struct xkb_keymap *keymap = NULL;
+	::xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	::xkb_rule_names rules = { 0 };
+	::xkb_keymap *keymap = nullptr;
 
 	// Fetch xkb env vars from session
 	const char *env_rules = getenv("XKB_DEFAULT_RULES");
@@ -2235,22 +2184,31 @@ bool wlserver_init( void ) {
 	const char *env_variant = getenv("XKB_DEFAULT_VARIANT");
 	const char *env_options = getenv("XKB_DEFAULT_OPTIONS");
 
-	// priority: env > parent > default
+	// priority: env overrides parent keymap overrides default
 	if (env_rules || env_model || env_layout || env_variant || env_options) {
+		// Compile from env vars
 		rules.rules = env_rules ?: "evdev";
 		rules.model = env_model ?: "pc105";
 		rules.layout = env_layout ?: "us";
-		rules.variant = env_variant; // NULL
+		rules.variant = (env_layout && env_variant) ? env_variant : NULL; // NULL
 		rules.options = env_options; // NULL
-
 		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
-	} else if (parent_keyboard && parent_keyboard->keymap) {
-		keymap = xkb_keymap_ref(parent_keyboard->keymap);
-	} else {
+		wl_log.infof("Using XKB keymap from environment variables");
+	}
+	else {
+		if (p_keymap) {
+			keymap = xkb_keymap_ref(p_keymap);
+			wl_log.infof("Using parent session keymap");
+		}
+	}
+
+	// Fallback if nothing worked
+	if (!keymap) {
 		rules.rules = "evdev";
 		rules.model = "pc105";
 		rules.layout = "us";
 		keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+		wl_log.infof("Using default XKB keymap");
 	}
 
 	wlr_keyboard_set_keymap(kbd, keymap);

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -228,7 +228,7 @@ bool wlsession_init( void );
 int wlsession_open_kms( const char *device_name );
 void wlsession_close_kms();
 
-bool wlserver_init( void );
+bool wlserver_init(::xkb_keymap *p_keymap = nullptr);
 
 void wlserver_run(void);
 

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -253,7 +253,7 @@ bool wlsession_init( void );
 int wlsession_open_kms( const char *device_name );
 void wlsession_close_kms();
 
-bool wlserver_init( void );
+bool wlserver_init(::xkb_keymap *p_keymap = nullptr);
 
 void wlserver_run(void);
 


### PR DESCRIPTION
Fixes #203.

Unfortunately I cannot fetch the rules from the keymap once it's compiled, and since the session's keymap fetched is pre-compiled by the session, it is not something I can fetch. Thus, if an env is set, we will rebuild the entire keymap w.r.t the env vars, or sensible defaults. Do let me know if it IS possible to fix this though!

I welcome testing and reviews on this, mighta cocked something up!! (though I hope not xD)