### PR TITLE
layer: Force bypass when requested format is unsupported on fallback

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -500,6 +500,7 @@ namespace GamescopeWSILayer {
     VkSurfaceKHR surface; // Always the Gamescope Surface surface -- so the Wayland one.
     bool isWayland;
     bool isBypassingXWayland;
+    bool forcedBypass;
     bool forceFifo;
     VkPresentModeKHR presentMode;
     VkExtent2D extent;
@@ -1111,19 +1112,9 @@ namespace GamescopeWSILayer {
         return pDispatch->CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
       }
 
-      const bool canBypass = gamescopeSurface->canBypassXWayland();
+      bool canBypass = gamescopeSurface->canBypassXWayland();
 
       VkSwapchainCreateInfoKHR swapchainInfo = *pCreateInfo;
-
-      if (pCreateInfo->oldSwapchain) {
-        if (auto gamescopeSwapchain = GamescopeSwapchain::get(pCreateInfo->oldSwapchain)) {
-          gamescopeSwapchain->retired = true;
-          // If we are going to/from being able to bypass XWayland, make sure
-          // we NULL out oldSwapchain, as they'll be for different surfaces and swapchain types.
-          if (gamescopeSwapchain->isBypassingXWayland != canBypass)
-            swapchainInfo.oldSwapchain = VK_NULL_HANDLE;
-        }
-      }
 
       if (gamescopeSurface->flags & GamescopeLayerClient::Flag::ForceSwapchainExtent) {
         if (!gamescopeSurface->isWayland()) {
@@ -1132,6 +1123,42 @@ namespace GamescopeWSILayer {
             return VK_ERROR_SURFACE_LOST_KHR;
 
           swapchainInfo.imageExtent = rect->extent;
+        }
+      }
+
+      auto isFormatSupportedOnSurface = [&](VkSurfaceKHR vkSurface, VkFormat format) {
+        std::vector<VkSurfaceFormatKHR> formats;
+        vkroots::helpers::enumerate(
+          pDispatch->pPhysicalDeviceDispatch->pInstanceDispatch->GetPhysicalDeviceSurfaceFormatsKHR,
+          formats,
+          pDispatch->PhysicalDevice,
+          vkSurface);
+        return std::ranges::any_of(
+          formats,
+          std::bind_front(std::equal_to{}, format),
+          &VkSurfaceFormatKHR::format);
+      };
+
+      // If bypass supports the format but the XCB fallback doesn't, force bypass.
+      // Refusing here would leave the app with no recovery path.
+      bool forcedBypass = false;
+      if (!canBypass
+          && !isFormatSupportedOnSurface(gamescopeSurface->fallbackSurface, pCreateInfo->imageFormat)
+          && isFormatSupportedOnSurface(pCreateInfo->surface, pCreateInfo->imageFormat)) {
+        fprintf(stderr, "[Gamescope WSI] Forcing bypass (format unsupported on fallback) for xid: 0x%0x - format: %s\n",
+          gamescopeSurface->window,
+          vkroots::helpers::enumString(pCreateInfo->imageFormat));
+        canBypass = true;
+        forcedBypass = true;
+      }
+
+      if (pCreateInfo->oldSwapchain) {
+        if (auto gamescopeSwapchain = GamescopeSwapchain::get(pCreateInfo->oldSwapchain)) {
+          gamescopeSwapchain->retired = true;
+          // If we are going to/from being able to bypass XWayland, make sure
+          // we NULL out oldSwapchain, as they'll be for different surfaces and swapchain types.
+          if (gamescopeSwapchain->isBypassingXWayland != canBypass)
+            swapchainInfo.oldSwapchain = VK_NULL_HANDLE;
         }
       }
 
@@ -1175,28 +1202,14 @@ namespace GamescopeWSILayer {
 
       // Check for VkFormat support and return VK_ERROR_INITIALIZATION_FAILED
       // if that VkFormat is unsupported for the underlying surface.
-      {
-        std::vector<VkSurfaceFormatKHR> supportedSurfaceFormats;
-        vkroots::helpers::enumerate(
-          pDispatch->pPhysicalDeviceDispatch->pInstanceDispatch->GetPhysicalDeviceSurfaceFormatsKHR,
-          supportedSurfaceFormats,
-          pDispatch->PhysicalDevice,
-          swapchainInfo.surface);
+      if (!isFormatSupportedOnSurface(swapchainInfo.surface, swapchainInfo.imageFormat)) {
+        fprintf(stderr, "[Gamescope WSI] Refusing to make swapchain (unsupported VkFormat) for xid: 0x%0x - format: %s - colorspace: %s - flip: %s\n",
+          gamescopeSurface->window,
+          vkroots::helpers::enumString(pCreateInfo->imageFormat),
+          vkroots::helpers::enumString(pCreateInfo->imageColorSpace),
+          canBypass ? "true" : "false");
 
-        bool supportedSwapchainFormat = std::ranges::any_of(
-          supportedSurfaceFormats,
-          std::bind_front(std::equal_to{}, swapchainInfo.imageFormat),
-          &VkSurfaceFormatKHR::format)  ;
-
-        if (!supportedSwapchainFormat) {
-          fprintf(stderr, "[Gamescope WSI] Refusing to make swapchain (unsupported VkFormat) for xid: 0x%0x - format: %s - colorspace: %s - flip: %s\n",
-            gamescopeSurface->window,
-            vkroots::helpers::enumString(pCreateInfo->imageFormat),
-            vkroots::helpers::enumString(pCreateInfo->imageColorSpace),
-            canBypass ? "true" : "false");
-
-          return VK_ERROR_INITIALIZATION_FAILED;
-        }
+        return VK_ERROR_INITIALIZATION_FAILED;
       }
 
       uint32_t serverId = ~0u;
@@ -1232,6 +1245,7 @@ namespace GamescopeWSILayer {
           .surface             = pCreateInfo->surface, // Always the Wayland side surface.
           .isWayland           = gamescopeSurface->isWayland(),
           .isBypassingXWayland = canBypass,
+          .forcedBypass        = forcedBypass,
           .forceFifo           = gamescopeIsForcingFifo(), // Were we forcing fifo when this swapchain was made?
           .presentMode         = pCreateInfo->presentMode, // The new present mode.
           .extent              = pCreateInfo->imageExtent,
@@ -1431,8 +1445,10 @@ namespace GamescopeWSILayer {
             if (canBypass) {
               if (!(gamescopeSurface->flags & GamescopeLayerClient::Flag::NoSuboptimal))
                 UpdateSwapchainResult(VK_SUBOPTIMAL_KHR);
-            } else {
-              UpdateSwapchainResult(VK_ERROR_OUT_OF_DATE_KHR);  
+            } else if (!gamescopeSwapchain->forcedBypass) {
+              // A forced-bypass swapchain has no fallback path; recreating
+              // would re-force bypass and loop.
+              UpdateSwapchainResult(VK_ERROR_OUT_OF_DATE_KHR);
             }
           }
 

--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -451,6 +451,8 @@ namespace GamescopeWSILayer {
 
     // Cached for comparison.
     std::optional<VkRect2D> cachedWindowRect;
+    // Set by canBypassXWayland when the Wine offscreen gate refused.
+    bool cachedWineOffscreen = false;
 
     bool isWayland() const {
       // Is native Wayland?
@@ -477,6 +479,7 @@ namespace GamescopeWSILayer {
       }
 
       cachedWindowRect = *rect;
+      cachedWineOffscreen = false;
 
       // Never bypass windows Wine presents offscreen to GDI-blit onto the
       // real toplevel: marked with _WINE_ALLOW_FLIP=0 or parented under
@@ -491,6 +494,7 @@ namespace GamescopeWSILayer {
 #if GAMESCOPE_WSI_BYPASS_DEBUG
             fprintf(stderr, "[Gamescope WSI] Not bypassing: _WINE_ALLOW_FLIP is 0 for window 0x%x.\n", window);
 #endif
+            cachedWineOffscreen = true;
             return false;
           }
         } else if (auto parent = xcb::getParentWindow(connection, window)) {
@@ -501,6 +505,7 @@ namespace GamescopeWSILayer {
 #if GAMESCOPE_WSI_BYPASS_DEBUG
             fprintf(stderr, "[Gamescope WSI] Not bypassing: window 0x%x is parked under Wine dummy parent 0x%x.\n", window, *parent);
 #endif
+            cachedWineOffscreen = true;
             return false;
           }
         }
@@ -575,6 +580,7 @@ namespace GamescopeWSILayer {
     VkSurfaceKHR surface; // Always the Gamescope Surface surface -- so the Wayland one.
     bool isWayland;
     bool isBypassingXWayland;
+    bool forcedBypass;
     bool forceFifo;
     VkPresentModeKHR presentMode;
     VkExtent2D extent;
@@ -1197,7 +1203,34 @@ namespace GamescopeWSILayer {
       // HDR. Other non-sRGB colorspaces are still SDR content Wine can blit.
       const bool hdrColorspace = pCreateInfo->imageColorSpace == VK_COLOR_SPACE_HDR10_ST2084_EXT ||
                                   pCreateInfo->imageColorSpace == VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT;
-      const bool canBypass = gamescopeSurface->canBypassXWayland(hdrColorspace);
+      bool canBypass = gamescopeSurface->canBypassXWayland(hdrColorspace);
+
+      auto isFormatSupportedOnSurface = [&](VkSurfaceKHR vkSurface, VkFormat format) {
+        std::vector<VkSurfaceFormatKHR> formats;
+        vkroots::helpers::enumerate(
+          pDispatch->pPhysicalDeviceDispatch->pInstanceDispatch->GetPhysicalDeviceSurfaceFormatsKHR,
+          formats,
+          pDispatch->PhysicalDevice,
+          vkSurface);
+        return std::ranges::any_of(
+          formats,
+          std::bind_front(std::equal_to{}, format),
+          &VkSurfaceFormatKHR::format);
+      };
+
+      // Prefer bypass over refusing when only the XCB fallback lacks the format.
+      // The Wine offscreen gate still wins, that content is wrong to flip.
+      bool formatSupported = isFormatSupportedOnSurface(canBypass ? pCreateInfo->surface : gamescopeSurface->fallbackSurface, pCreateInfo->imageFormat);
+      bool forcedBypass = false;
+      if (!canBypass && !formatSupported && !gamescopeSurface->cachedWineOffscreen &&
+          isFormatSupportedOnSurface(pCreateInfo->surface, pCreateInfo->imageFormat)) {
+        fprintf(stderr, "[Gamescope WSI] Forcing bypass (format unsupported on fallback) for xid: 0x%0x - format: %s\n",
+          gamescopeSurface->window,
+          vkroots::helpers::enumString(pCreateInfo->imageFormat));
+        canBypass = true;
+        formatSupported = true;
+        forcedBypass = true;
+      }
 
       VkSwapchainCreateInfoKHR swapchainInfo = *pCreateInfo;
 
@@ -1261,28 +1294,14 @@ namespace GamescopeWSILayer {
 
       // Check for VkFormat support and return VK_ERROR_INITIALIZATION_FAILED
       // if that VkFormat is unsupported for the underlying surface.
-      {
-        std::vector<VkSurfaceFormatKHR> supportedSurfaceFormats;
-        vkroots::helpers::enumerate(
-          pDispatch->pPhysicalDeviceDispatch->pInstanceDispatch->GetPhysicalDeviceSurfaceFormatsKHR,
-          supportedSurfaceFormats,
-          pDispatch->PhysicalDevice,
-          swapchainInfo.surface);
+      if (!formatSupported) {
+        fprintf(stderr, "[Gamescope WSI] Refusing to make swapchain (unsupported VkFormat) for xid: 0x%0x - format: %s - colorspace: %s - flip: %s\n",
+          gamescopeSurface->window,
+          vkroots::helpers::enumString(pCreateInfo->imageFormat),
+          vkroots::helpers::enumString(pCreateInfo->imageColorSpace),
+          canBypass ? "true" : "false");
 
-        bool supportedSwapchainFormat = std::ranges::any_of(
-          supportedSurfaceFormats,
-          std::bind_front(std::equal_to{}, swapchainInfo.imageFormat),
-          &VkSurfaceFormatKHR::format)  ;
-
-        if (!supportedSwapchainFormat) {
-          fprintf(stderr, "[Gamescope WSI] Refusing to make swapchain (unsupported VkFormat) for xid: 0x%0x - format: %s - colorspace: %s - flip: %s\n",
-            gamescopeSurface->window,
-            vkroots::helpers::enumString(pCreateInfo->imageFormat),
-            vkroots::helpers::enumString(pCreateInfo->imageColorSpace),
-            canBypass ? "true" : "false");
-
-          return VK_ERROR_INITIALIZATION_FAILED;
-        }
+        return VK_ERROR_INITIALIZATION_FAILED;
       }
 
       uint32_t serverId = ~0u;
@@ -1318,6 +1337,7 @@ namespace GamescopeWSILayer {
           .surface             = pCreateInfo->surface, // Always the Wayland side surface.
           .isWayland           = gamescopeSurface->isWayland(),
           .isBypassingXWayland = canBypass,
+          .forcedBypass        = forcedBypass,
           .forceFifo           = gamescopeIsForcingFifo(gamescopeSurface->waylandObjects), // Were we forcing fifo when this swapchain was made?
           .presentMode         = pCreateInfo->presentMode, // The new present mode.
           .extent              = pCreateInfo->imageExtent,
@@ -1574,8 +1594,9 @@ namespace GamescopeWSILayer {
             if (canBypass) {
               if (!(gamescopeSurface->flags & GamescopeLayerClient::Flag::NoSuboptimal))
                 UpdateSwapchainResult(VK_SUBOPTIMAL_KHR);
-            } else {
-              UpdateSwapchainResult(VK_ERROR_OUT_OF_DATE_KHR);  
+            } else if (!gamescopeSwapchain->forcedBypass || gamescopeSurface->cachedWineOffscreen) {
+              // Recreating would only force bypass again, unless Wine now keeps the window offscreen.
+              UpdateSwapchainResult(VK_ERROR_OUT_OF_DATE_KHR);
             }
           }
 


### PR DESCRIPTION
When canBypassXWayland returns false at swapchain creation and the requested format isn't on the fallback surface, refusing the swapchain leaves the app with no recovery path. Instead, prefer bypass over INITIALIZATION_FAILED.

Star Citizen reproduces this during the game's launch process: it recreates its swapchain exactly when its X11 toplevel and inner window are mid-resize, so canBypass returns false (geometry mismatch) and the create lands on the XCB fallback surface. The XCB fallback only advertises B8G8R8A8 family formats, which means the recreate is refused for any other format. Without HDR exposed SC asks for VK_FORMAT_R8G8B8A8_UNORM, and with HDR exposed it instead tries to use VK_FORMAT_R16G16B16A16_SFLOAT. Either way, the game stalls on an infinite black screen after gamescope refuses the swapchain recreate.

Track the bypass override on the swapchain so QueuePresentKHR doesn't ask the app to recreate when the live canBypass disagrees.