### PR TITLE
process: derive AppID from /proc/$pid/cgroup where possible, instead of walking the process tree

### DIFF
--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -20,6 +20,7 @@
 #include "edid.h"
 #include "Ratio.h"
 #include "LibInputHandler.h"
+#include "Utils/Process.h"
 
 #include <signal.h>
 #include <string.h>
@@ -123,8 +124,6 @@ namespace vr
 //
 
 extern std::atomic<uint32_t> g_unCurrentVRSceneAppId;
-
-uint32_t get_appid_from_pid( pid_t pid );
 
 ///////////////////////////////////////////////
 // Josh:
@@ -1168,7 +1167,7 @@ namespace gamescope
                     if (m_uCurrentScenePid != vrEvent.data.process.pid)
                     {
                         m_uCurrentScenePid = vrEvent.data.process.pid;
-                        m_uCurrentSceneAppId = get_appid_from_pid(m_uCurrentScenePid);
+                        m_uCurrentSceneAppId = gamescope::Process::GetAppIdFromPid(m_uCurrentScenePid);
                         g_unCurrentVRSceneAppId = m_uCurrentSceneAppId;
 
                         openvr_log.debugf("SceneApplicationChanged -> pid: %u appid: %u", m_uCurrentScenePid, m_uCurrentSceneAppId);

--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -1,12 +1,17 @@
 #include "Process.h"
+#include "Algorithm.h"
 #include "../log.hpp"
-#include "../Utils/Algorithm.h"
 #include "../Utils/Defer.h"
 #include "../Utils/Parsers.h"
 #include "../Utils/String.h"
 
-#include <algorithm>
 #include <array>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <istream>
+#include <string>
+#include <vector>
 
 #include <errno.h>
 #include <pthread.h>
@@ -616,4 +621,143 @@ namespace gamescope::Process
         return __progname;
     }
 
+    uint32_t GetAppIdFromCgroup( std::istream &stream )
+    {
+        std::string line;
+        while ( std::getline( stream, line ) )
+        {
+            // cgroup line format: hierarchy-ID:controller-list:cgroup-path
+            size_t first_colon = line.find( ':' );
+            if ( first_colon == std::string::npos )
+                continue;
+            size_t second_colon = line.find( ':', first_colon + 1 );
+            if ( second_colon == std::string::npos )
+                continue;
+
+            const char *path = line.c_str() + second_colon + 1;
+            const char *last_slash = strrchr( path, '/' );
+            const char *scope = last_slash ? last_slash + 1 : path;
+
+            pid_t reaperpid = 0;
+            uint32_t appid = 0;
+            if ( sscanf( scope, "app-steam-app%u-%d.scope", &appid, &reaperpid ) == 2 && appid != 0 )
+                return appid;
+        }
+        return 0;
+    }
+
+    uint32_t GetAppIdFromReaper( pid_t pid )
+    {
+        uint32_t unFoundAppId = 0;
+
+        char filename[256];
+        pid_t next_pid = pid;
+
+        while ( 1 )
+        {
+            snprintf( filename, sizeof( filename ), "/proc/%i/stat", next_pid );
+            std::ifstream proc_stat_file( filename );
+
+            if (!proc_stat_file.is_open() || proc_stat_file.bad())
+                break;
+
+            std::string proc_stat;
+
+            std::getline( proc_stat_file, proc_stat );
+
+            char *procName = nullptr;
+            char *lastParens = nullptr;
+
+            for ( uint32_t i = 0; i < proc_stat.length(); i++ )
+            {
+                if ( procName == nullptr && proc_stat[ i ] == '(' )
+                {
+                    procName = &proc_stat[ i + 1 ];
+                }
+
+                if ( proc_stat[ i ] == ')' )
+                {
+                    lastParens = &proc_stat[ i ];
+                }
+            }
+
+            if (!lastParens)
+                break;
+
+            *lastParens = '\0';
+            char state;
+            int parent_pid = -1;
+
+            sscanf( lastParens + 1, " %c %d", &state, &parent_pid );
+
+            if ( strcmp( "reaper", procName ) == 0 )
+            {
+                snprintf( filename, sizeof( filename ), "/proc/%i/cmdline", next_pid );
+                std::ifstream proc_cmdline_file( filename );
+                std::string proc_cmdline;
+
+                bool bSteamLaunch = false;
+                uint32_t unAppId = 0;
+
+                std::getline( proc_cmdline_file, proc_cmdline );
+
+                for ( uint32_t j = 0; j < proc_cmdline.length(); j++ )
+                {
+                    if ( proc_cmdline[ j ] == '\0' && j + 1 < proc_cmdline.length() )
+                    {
+                        if ( strcmp( "SteamLaunch", &proc_cmdline[ j + 1 ] ) == 0 )
+                        {
+                            bSteamLaunch = true;
+                        }
+                        else if ( sscanf( &proc_cmdline[ j + 1 ], "AppId=%u", &unAppId ) == 1 && unAppId != 0 )
+                        {
+                            if ( bSteamLaunch == true )
+                            {
+                                unFoundAppId = unAppId;
+                            }
+                        }
+                        else if ( strcmp( "--", &proc_cmdline[ j + 1 ] ) == 0 )
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if ( parent_pid == -1 || parent_pid == 0 )
+            {
+                break;
+            }
+            else
+            {
+                next_pid = parent_pid;
+            }
+        }
+
+        return unFoundAppId;
+    }
+
+    uint32_t GetAppIdFromPid( pid_t pid )
+    {
+        uint32_t appid = 0;
+
+        char filename[256];
+        snprintf( filename, sizeof( filename ), "/proc/%i/cgroup", pid );
+        std::ifstream cgroup_file( filename );
+        if ( cgroup_file.is_open() && !cgroup_file.bad() )
+        {
+            appid = GetAppIdFromCgroup( cgroup_file );
+            if ( appid != 0 )
+                s_ProcessLog.debugf( "AppID %u derived from cgroup for pid %d", appid, pid );
+        }
+
+        if ( appid == 0 )
+        {
+            appid = GetAppIdFromReaper( pid );
+            if ( appid != 0 )
+                s_ProcessLog.debugf( "AppID %u derived from process hierarchy for pid %d", appid, pid );
+        }
+
+        return appid;
+    }
 }

--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -1,11 +1,15 @@
 #include "Process.h"
-#include "../Utils/Algorithm.h"
+#include "Algorithm.h"
 #include "../convar.h"
 #include "../log.hpp"
 #include "../Utils/Defer.h"
 
-#include <algorithm>
 #include <array>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <istream>
+#include <string>
 
 #include <errno.h>
 #include <pthread.h>
@@ -615,4 +619,143 @@ namespace gamescope::Process
         return __progname;
     }
 
+    uint32_t GetAppIdFromCgroup( std::istream &stream )
+    {
+        std::string line;
+        while ( std::getline( stream, line ) )
+        {
+            // cgroup line format: hierarchy-ID:controller-list:cgroup-path
+            size_t first_colon = line.find( ':' );
+            if ( first_colon == std::string::npos )
+                continue;
+            size_t second_colon = line.find( ':', first_colon + 1 );
+            if ( second_colon == std::string::npos )
+                continue;
+
+            const char *path = line.c_str() + second_colon + 1;
+            const char *last_slash = strrchr( path, '/' );
+            const char *scope = last_slash ? last_slash + 1 : path;
+
+            pid_t reaperpid = 0;
+            uint32_t appid = 0;
+            if ( sscanf( scope, "app-steam-app%u-%d.scope", &appid, &reaperpid ) == 2 && appid != 0 )
+                return appid;
+        }
+        return 0;
+    }
+
+    uint32_t GetAppIdFromReaper( pid_t pid )
+    {
+        uint32_t unFoundAppId = 0;
+
+        char filename[256];
+        pid_t next_pid = pid;
+
+        while ( 1 )
+        {
+            snprintf( filename, sizeof( filename ), "/proc/%i/stat", next_pid );
+            std::ifstream proc_stat_file( filename );
+
+            if (!proc_stat_file.is_open() || proc_stat_file.bad())
+                break;
+
+            std::string proc_stat;
+
+            std::getline( proc_stat_file, proc_stat );
+
+            char *procName = nullptr;
+            char *lastParens = nullptr;
+
+            for ( uint32_t i = 0; i < proc_stat.length(); i++ )
+            {
+                if ( procName == nullptr && proc_stat[ i ] == '(' )
+                {
+                    procName = &proc_stat[ i + 1 ];
+                }
+
+                if ( proc_stat[ i ] == ')' )
+                {
+                    lastParens = &proc_stat[ i ];
+                }
+            }
+
+            if (!lastParens)
+                break;
+
+            *lastParens = '\0';
+            char state;
+            int parent_pid = -1;
+
+            sscanf( lastParens + 1, " %c %d", &state, &parent_pid );
+
+            if ( strcmp( "reaper", procName ) == 0 )
+            {
+                snprintf( filename, sizeof( filename ), "/proc/%i/cmdline", next_pid );
+                std::ifstream proc_cmdline_file( filename );
+                std::string proc_cmdline;
+
+                bool bSteamLaunch = false;
+                uint32_t unAppId = 0;
+
+                std::getline( proc_cmdline_file, proc_cmdline );
+
+                for ( uint32_t j = 0; j < proc_cmdline.length(); j++ )
+                {
+                    if ( proc_cmdline[ j ] == '\0' && j + 1 < proc_cmdline.length() )
+                    {
+                        if ( strcmp( "SteamLaunch", &proc_cmdline[ j + 1 ] ) == 0 )
+                        {
+                            bSteamLaunch = true;
+                        }
+                        else if ( sscanf( &proc_cmdline[ j + 1 ], "AppId=%u", &unAppId ) == 1 && unAppId != 0 )
+                        {
+                            if ( bSteamLaunch == true )
+                            {
+                                unFoundAppId = unAppId;
+                            }
+                        }
+                        else if ( strcmp( "--", &proc_cmdline[ j + 1 ] ) == 0 )
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if ( parent_pid == -1 || parent_pid == 0 )
+            {
+                break;
+            }
+            else
+            {
+                next_pid = parent_pid;
+            }
+        }
+
+        return unFoundAppId;
+    }
+
+    uint32_t GetAppIdFromPid( pid_t pid )
+    {
+        uint32_t appid = 0;
+
+        char filename[256];
+        snprintf( filename, sizeof( filename ), "/proc/%i/cgroup", pid );
+        std::ifstream cgroup_file( filename );
+        if ( cgroup_file.is_open() && !cgroup_file.bad() )
+        {
+            appid = GetAppIdFromCgroup( cgroup_file );
+            if ( appid != 0 )
+                s_ProcessLog.debugf( "AppID %u derived from cgroup for pid %d", appid, pid );
+        }
+
+        if ( appid == 0 )
+        {
+            appid = GetAppIdFromReaper( pid );
+             if ( appid != 0 )
+                 s_ProcessLog.debugf( "AppID %u derived from process hierarchy for pid %d", appid, pid );
+        }
+
+        return appid;
+    }
 }

--- a/src/Utils/Process.h
+++ b/src/Utils/Process.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <optional>
+#include <cstdint>
 #include <functional>
+#include <iosfwd>
+#include <optional>
 #include <span>
 
 #include <sys/types.h>
@@ -53,4 +55,7 @@ namespace gamescope::Process
 
     const char *GetProcessName();
 
+    uint32_t GetAppIdFromCgroup( std::istream &stream );
+    uint32_t GetAppIdFromReaper( pid_t pid );
+    uint32_t GetAppIdFromPid( pid_t pid );
 }

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -43,15 +43,11 @@
 #include <condition_variable>
 #include <mutex>
 #include <atomic>
-#include <vector>
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <fstream>
 #include <string>
-#include <queue>
 #include <filesystem>
-#include <variant>
 #include <unordered_set>
 
 #include <assert.h>
@@ -96,10 +92,7 @@
 #include "commit.h"
 #include "reshade_effect_manager.hpp"
 #include "BufferMemo.h"
-#include "Utils/Algorithm.h"
-#include "Utils/Parsers.h"
 #include "Utils/Process.h"
-#include "Utils/String.h"
 
 #include "wlr_begin.hpp"
 #include "wlr/types/wlr_pointer_constraints_v1.h"
@@ -5283,98 +5276,6 @@ get_name_from_pid( pid_t pid )
 	return procNameStr;
 }
 
-uint32_t
-get_appid_from_pid( pid_t pid )
-{
-	uint32_t unFoundAppId = 0;
-
-	char filename[256];
-	pid_t next_pid = pid;
-
-	while ( 1 )
-	{
-		snprintf( filename, sizeof( filename ), "/proc/%i/stat", next_pid );
-		std::ifstream proc_stat_file( filename );
-
-		if (!proc_stat_file.is_open() || proc_stat_file.bad())
-			break;
-
-		std::string proc_stat;
-
-		std::getline( proc_stat_file, proc_stat );
-
-		char *procName = nullptr;
-		char *lastParens = nullptr;
-
-		for ( uint32_t i = 0; i < proc_stat.length(); i++ )
-		{
-			if ( procName == nullptr && proc_stat[ i ] == '(' )
-			{
-				procName = &proc_stat[ i + 1 ];
-			}
-
-			if ( proc_stat[ i ] == ')' )
-			{
-				lastParens = &proc_stat[ i ];
-			}
-		}
-
-		if (!lastParens)
-			break;
-
-		*lastParens = '\0';
-		char state;
-		int parent_pid = -1;
-
-		sscanf( lastParens + 1, " %c %d", &state, &parent_pid );
-
-		if ( strcmp( "reaper", procName ) == 0 )
-		{
-			snprintf( filename, sizeof( filename ), "/proc/%i/cmdline", next_pid );
-			std::ifstream proc_cmdline_file( filename );
-			std::string proc_cmdline;
-
-			bool bSteamLaunch = false;
-			uint32_t unAppId = 0;
-
-			std::getline( proc_cmdline_file, proc_cmdline );
-
-			for ( uint32_t j = 0; j < proc_cmdline.length(); j++ )
-			{
-				if ( proc_cmdline[ j ] == '\0' && j + 1 < proc_cmdline.length() )
-				{
-					if ( strcmp( "SteamLaunch", &proc_cmdline[ j + 1 ] ) == 0 )
-					{
-						bSteamLaunch = true;
-					}
-					else if ( sscanf( &proc_cmdline[ j + 1 ], "AppId=%u", &unAppId ) == 1 && unAppId != 0 )
-					{
-						if ( bSteamLaunch == true )
-						{
-							unFoundAppId = unAppId;
-						}
-					}
-					else if ( strcmp( "--", &proc_cmdline[ j + 1 ] ) == 0 )
-					{
-						break;
-					}
-				}
-			}
-		}
-
-		if ( parent_pid == -1 || parent_pid == 0 )
-		{
-			break;
-		}
-		else
-		{
-			next_pid = parent_pid;
-		}
-	}
-
-	return unFoundAppId;
-}
-
 static pid_t
 get_win_pid(xwayland_ctx_t *ctx, Window id)
 {
@@ -5464,7 +5365,7 @@ add_win(xwayland_ctx_t *ctx, Window id, Window prev, unsigned long sequence)
 	{
 		if ( new_win->pid != -1 )
 		{
-			new_win->appID = get_appid_from_pid( new_win->pid );
+			new_win->appID = gamescope::Process::GetAppIdFromPid( new_win->pid );
 		}
 		else
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -43,15 +43,11 @@
 #include <condition_variable>
 #include <mutex>
 #include <atomic>
-#include <vector>
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <fstream>
 #include <string>
-#include <queue>
 #include <filesystem>
-#include <variant>
 #include <unordered_set>
 
 #include <assert.h>
@@ -97,7 +93,6 @@
 #include "reshade_effect_manager.hpp"
 #include "BufferMemo.h"
 #include "Utils/Process.h"
-#include "Utils/Algorithm.h"
 
 #include "wlr_begin.hpp"
 #include "wlr/types/wlr_pointer_constraints_v1.h"
@@ -4975,98 +4970,6 @@ get_name_from_pid( pid_t pid )
 	return procNameStr;
 }
 
-uint32_t
-get_appid_from_pid( pid_t pid )
-{
-	uint32_t unFoundAppId = 0;
-
-	char filename[256];
-	pid_t next_pid = pid;
-
-	while ( 1 )
-	{
-		snprintf( filename, sizeof( filename ), "/proc/%i/stat", next_pid );
-		std::ifstream proc_stat_file( filename );
-
-		if (!proc_stat_file.is_open() || proc_stat_file.bad())
-			break;
-
-		std::string proc_stat;
-
-		std::getline( proc_stat_file, proc_stat );
-
-		char *procName = nullptr;
-		char *lastParens = nullptr;
-
-		for ( uint32_t i = 0; i < proc_stat.length(); i++ )
-		{
-			if ( procName == nullptr && proc_stat[ i ] == '(' )
-			{
-				procName = &proc_stat[ i + 1 ];
-			}
-
-			if ( proc_stat[ i ] == ')' )
-			{
-				lastParens = &proc_stat[ i ];
-			}
-		}
-
-		if (!lastParens)
-			break;
-
-		*lastParens = '\0';
-		char state;
-		int parent_pid = -1;
-
-		sscanf( lastParens + 1, " %c %d", &state, &parent_pid );
-
-		if ( strcmp( "reaper", procName ) == 0 )
-		{
-			snprintf( filename, sizeof( filename ), "/proc/%i/cmdline", next_pid );
-			std::ifstream proc_cmdline_file( filename );
-			std::string proc_cmdline;
-
-			bool bSteamLaunch = false;
-			uint32_t unAppId = 0;
-
-			std::getline( proc_cmdline_file, proc_cmdline );
-
-			for ( uint32_t j = 0; j < proc_cmdline.length(); j++ )
-			{
-				if ( proc_cmdline[ j ] == '\0' && j + 1 < proc_cmdline.length() )
-				{
-					if ( strcmp( "SteamLaunch", &proc_cmdline[ j + 1 ] ) == 0 )
-					{
-						bSteamLaunch = true;
-					}
-					else if ( sscanf( &proc_cmdline[ j + 1 ], "AppId=%u", &unAppId ) == 1 && unAppId != 0 )
-					{
-						if ( bSteamLaunch == true )
-						{
-							unFoundAppId = unAppId;
-						}
-					}
-					else if ( strcmp( "--", &proc_cmdline[ j + 1 ] ) == 0 )
-					{
-						break;
-					}
-				}
-			}
-		}
-
-		if ( parent_pid == -1 || parent_pid == 0 )
-		{
-			break;
-		}
-		else
-		{
-			next_pid = parent_pid;
-		}
-	}
-
-	return unFoundAppId;
-}
-
 static pid_t
 get_win_pid(xwayland_ctx_t *ctx, Window id)
 {
@@ -5156,7 +5059,7 @@ add_win(xwayland_ctx_t *ctx, Window id, Window prev, unsigned long sequence)
 	{
 		if ( new_win->pid != -1 )
 		{
-			new_win->appID = get_appid_from_pid( new_win->pid );
+			new_win->appID = gamescope::Process::GetAppIdFromPid( new_win->pid );
 		}
 		else
 		{

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -67,7 +67,7 @@
 #include "InputEmulation.h"
 #include "commit.h"
 #include "Timeline.h"
-#include "Utils/NonCopyable.h"
+#include "Utils/Process.h"
 
 #if HAVE_PIPEWIRE
 #include "pipewire.hpp"
@@ -1925,8 +1925,6 @@ void xdg_toplevel_new(struct wl_listener *listener, void *data)
 {
 }
 
-uint32_t get_appid_from_pid( pid_t pid );
-
 wlserver_xdg_surface_info* waylandy_type_surface_new(struct wl_client *client, struct wlr_surface *surface)
 {
 	wlserver_wl_surface_info *wlserver_surface = get_wl_surface_info(surface);
@@ -1948,7 +1946,7 @@ wlserver_xdg_surface_info* waylandy_type_surface_new(struct wl_client *client, s
 	{
 		pid_t nPid = 0;
 		wl_client_get_credentials( client, &nPid, nullptr, nullptr );
-		window->appID = get_appid_from_pid( nPid );
+		window->appID = gamescope::Process::GetAppIdFromPid( nPid );
 	}
 	window->_window_types.emplace<steamcompmgr_xdg_win_t>();
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -67,7 +67,7 @@
 #include "InputEmulation.h"
 #include "commit.h"
 #include "Timeline.h"
-#include "Utils/NonCopyable.h"
+#include "Utils/Process.h"
 
 #if HAVE_PIPEWIRE
 #include "pipewire.hpp"
@@ -1907,8 +1907,6 @@ void xdg_toplevel_new(struct wl_listener *listener, void *data)
 {
 }
 
-uint32_t get_appid_from_pid( pid_t pid );
-
 wlserver_xdg_surface_info* waylandy_type_surface_new(struct wl_client *client, struct wlr_surface *surface)
 {
 	wlserver_wl_surface_info *wlserver_surface = get_wl_surface_info(surface);
@@ -1930,7 +1928,7 @@ wlserver_xdg_surface_info* waylandy_type_surface_new(struct wl_client *client, s
 	{
 		pid_t nPid = 0;
 		wl_client_get_credentials( client, &nPid, nullptr, nullptr );
-		window->appID = get_appid_from_pid( nPid );
+		window->appID = gamescope::Process::GetAppIdFromPid( nPid );
 	}
 	window->_window_types.emplace<steamcompmgr_xdg_win_t>();
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,7 +13,10 @@ gamescope_tests = executable(
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
 )
+
+reaper_test_helper = executable('reaper_test_helper', 'reaper_test_helper.cpp')
+
 test('convar', gamescope_tests, args: ['[convar]'])
 test('utils/parsers', gamescope_tests, args: ['[parsers]'])
-test('utils/process', gamescope_tests, args: ['[process]'])
+test('utils/process', gamescope_tests, args: ['[process]'], depends: [reaper_test_helper])
 test('utils/string', gamescope_tests, args: ['[string]'])

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,5 +13,8 @@ gamescope_tests = executable(
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
 )
+
+reaper_test_helper = executable('reaper_test_helper', 'reaper_test_helper.cpp')
+
 test('convar', gamescope_tests, args: ['[convar]'])
-test('process', gamescope_tests, args: ['[process]'])
+test('process', gamescope_tests, args: ['[process]'], depends: [reaper_test_helper])

--- a/tests/reaper_test_helper.cpp
+++ b/tests/reaper_test_helper.cpp
@@ -1,0 +1,27 @@
+#include <cstdio>
+#include <signal.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+
+// Mimic a reaper parent process for GetAppIdFromReaper unit tests.
+// Call as: reaper_test_helper [steam-launch args...]
+int main() {
+    prctl(PR_SET_NAME, "reaper", 0, 0, 0);
+
+    // Spawn a child process (game)
+    pid_t game_pid = fork();
+    if (game_pid == 0) {
+        prctl(PR_SET_NAME, "game", 0, 0, 0);
+        while (true) pause();
+        _exit(0);
+    }
+
+    // Prints its PID on stdout
+    printf("%d\n", static_cast<int>(game_pid));
+    fflush(stdout);
+
+    // Wait for both processes to be killed
+    while (true) pause();
+
+    return 0;
+}

--- a/tests/test_process.cpp
+++ b/tests/test_process.cpp
@@ -1,8 +1,12 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <filesystem>
+#include <limits.h>
+#include <signal.h>
 #include <stdlib.h>
-
 #include <string>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "Utils/Process.h"
 
@@ -65,4 +69,157 @@ TEST_CASE("RestoreSteamOverlayPreload", "[process]") {
 		REQUIRE( GetEnv( "LD_PRELOAD" ) == k_pszOverlay );
 		REQUIRE( getenv( k_pszStashedOverlayPreload ) == nullptr );
 	}
+}
+
+TEST_CASE("GetAppIdFromCgroup", "[process]") {
+    SECTION("steam app scope") {
+        std::istringstream stream("0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-steam-app12345-9876.scope\n");
+        REQUIRE(gamescope::Process::GetAppIdFromCgroup(stream) == 12345u);
+    }
+
+    SECTION("no matching scope") {
+        std::istringstream stream("0::/user.slice/user-1000.slice/session.scope\n");
+        REQUIRE(gamescope::Process::GetAppIdFromCgroup(stream) == 0u);
+    }
+
+    SECTION("multiple lines, one matching") {
+        std::istringstream stream(
+            "12:devices:/user.slice\n"
+            "11:memory:/user.slice/user-1000.slice/session-1.scope\n"
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-steam-app567-42.scope\n"
+        );
+        REQUIRE(gamescope::Process::GetAppIdFromCgroup(stream) == 567u);
+    }
+
+    SECTION("empty stream") {
+        std::istringstream stream("");
+        REQUIRE(gamescope::Process::GetAppIdFromCgroup(stream) == 0u);
+    }
+
+    SECTION("malformed lines") {
+        std::istringstream stream("not-a-valid-cgroup-line\n");
+        REQUIRE(gamescope::Process::GetAppIdFromCgroup(stream) == 0u);
+
+        stream = std::istringstream("not-a-valid:cgroup-line\n");
+        REQUIRE(gamescope::Process::GetAppIdFromCgroup(stream) == 0u);
+
+        stream = std::istringstream("not-a-valid:cgroup-line:\n");
+        REQUIRE(gamescope::Process::GetAppIdFromCgroup(stream) == 0u);
+    }
+}
+
+namespace {
+
+struct ScopedReaper {
+    pid_t reaper_pid = -1;
+    pid_t game_pid   = -1;
+
+    static std::string HelperPath() {
+        char buf[PATH_MAX];
+        ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+        if (len < 0) return "";
+        buf[len] = '\0';
+        return std::filesystem::path(buf).parent_path() / "reaper_test_helper";
+    }
+
+    // extra_args appear in /proc/reaper_pid/cmdline after the binary name
+    static ScopedReaper Spawn(std::vector<std::string> extra_args) {
+        ScopedReaper reaper;
+        int pipefd[2];
+        if (pipe(pipefd) != 0) return reaper;
+
+        pid_t pid = fork();
+        if (pid < 0)
+        {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return reaper;
+        }
+
+        if (pid == 0)
+        {
+            close(pipefd[0]);
+            dup2(pipefd[1], STDOUT_FILENO);
+            close(pipefd[1]);
+
+            std::string helper = HelperPath();
+            std::vector<char *> argv;
+            argv.push_back(const_cast<char *>(helper.c_str()));
+            for (auto &arg : extra_args)
+                argv.push_back(const_cast<char *>(arg.c_str()));
+            argv.push_back(nullptr);
+            execvp(argv[0], argv.data());
+            _exit(1);
+        }
+
+        close(pipefd[1]);
+        reaper.reaper_pid = pid;
+
+        char buf[32] = {};
+        read(pipefd[0], buf, sizeof(buf) - 1);
+        close(pipefd[0]);
+        reaper.game_pid = atoi(buf);
+        return reaper;
+    }
+
+    ~ScopedReaper() {
+        if (game_pid > 0)
+        {
+            kill(game_pid, SIGKILL);
+            waitpid(game_pid, nullptr, 0);
+        }
+        if (reaper_pid > 0)
+        {
+            kill(reaper_pid, SIGKILL);
+            waitpid(reaper_pid, nullptr, 0);
+        }
+    }
+};
+
+}
+
+TEST_CASE("GetAppIdFromReaper", "[process]") {
+    SECTION("well-formed reaper command line") {
+        auto reaper = ScopedReaper::Spawn({"SteamLaunch", "AppId=42", "--", "game"});
+        REQUIRE(reaper.game_pid > 0);
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(reaper.game_pid) == 42);
+    }
+
+    SECTION("AppId must come after SteamLaunch") {
+        auto reaper = ScopedReaper::Spawn({"AppId=42", "SteamLaunch", "--", "game"});
+        REQUIRE(reaper.game_pid > 0);
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(reaper.game_pid) == 0u);
+    }
+
+    SECTION("missing SteamLaunch token") {
+        auto reaper = ScopedReaper::Spawn({"AppId=42", "--", "game"});
+        REQUIRE(reaper.game_pid > 0);
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(reaper.game_pid) == 0u);
+    }
+
+    SECTION("-- stops parsing before AppId is seen") {
+        auto reaper = ScopedReaper::Spawn({"SteamLaunch", "--", "AppId=42", "game"});
+        REQUIRE(reaper.game_pid > 0);
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(reaper.game_pid) == 0u);
+    }
+
+    SECTION("AppId=0 is excluded") {
+        auto reaper = ScopedReaper::Spawn({"SteamLaunch", "AppId=0", "--", "game"});
+        REQUIRE(reaper.game_pid > 0);
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(reaper.game_pid) == 0u);
+    }
+
+    SECTION("malformed AppId is ignored") {
+        auto reaper = ScopedReaper::Spawn({"SteamLaunch", "AppId=foobar", "--", "game"});
+        REQUIRE(reaper.game_pid > 0);
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(reaper.game_pid) == 0u);
+    }
+
+    SECTION("no reaper in the process tree") {
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(getpid()) == 0u);
+    }
+
+    SECTION("non-existent pid") {
+        REQUIRE(gamescope::Process::GetAppIdFromReaper(std::numeric_limits<pid_t>::max()) == 0u);
+    }
 }


### PR DESCRIPTION
Replace the old get_appid_from_pid(), which walked up the process tree looking for a "reaper" process and parsing its command line, with a simpler and more robust approach that reads /proc/$pid/cgroup and extracts the AppID from the Steam systemd scope name (app-steam-app${appid}-${reaperpid}.scope).

The old implementation remains as a fallback mechanism, for cases where the Steam client doesn't put games it launches in a scope cgroup (currently the case on desktop).

Move the implementation to Utils/Process, and add unit tests for both the new method and the old one.