### PR TITLE
Forward Wayland modifier events to wlroots seat when nested

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -3239,6 +3239,10 @@ namespace gamescope
     void CWaylandInputThread::Wayland_Keyboard_Modifiers( wl_keyboard *pKeyboard, uint32_t uSerial, uint32_t uModsDepressed, uint32_t uModsLatched, uint32_t uModsLocked, uint32_t uGroup )
     {
         m_uKeyModifiers = uModsDepressed | uModsLatched | uModsLocked;
+
+        wlserver_lock();
+        wlserver_modifiers( uModsDepressed, uModsLatched, uModsLocked, uGroup );
+        wlserver_unlock();
     }
     void CWaylandInputThread::Wayland_Keyboard_RepeatInfo( wl_keyboard *pKeyboard, int32_t nRate, int32_t nDelay )
     {

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2418,11 +2418,28 @@ bool wlserver_process_hotkeys( wlr_keyboard *keyboard, uint32_t key, bool press 
 	return false;
 }
 
+void wlserver_modifiers( uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group )
+{
+	assert( wlserver_is_lock_held() );
+
+	if ( !wlserver.keyboard_group )
+		return;
+
+	struct wlr_keyboard *keyboard = &wlserver.keyboard_group->keyboard;
+	wlr_keyboard_notify_modifiers( keyboard, depressed, latched, locked, group );
+	wlr_seat_set_keyboard( wlserver.wlr.seat, keyboard );
+	wlr_seat_keyboard_notify_modifiers( wlserver.wlr.seat, &keyboard->modifiers );
+
+	bump_input_counter();
+}
+
 void wlserver_key( uint32_t key, bool press, uint32_t time )
 {
 	assert( wlserver_is_lock_held() );
 
-	wlr_keyboard *keyboard = wlserver.wlr.virtual_keyboard_device;
+	wlr_keyboard *keyboard = wlserver.keyboard_group
+		? &wlserver.keyboard_group->keyboard
+		: wlserver.wlr.virtual_keyboard_device;
 
 	if ( !wlserver_process_hotkeys( keyboard, key, press ) )
 	{

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -242,6 +242,7 @@ bool wlserver_is_lock_held(void);
 
 void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain = true );
 void wlserver_key( uint32_t key, bool press, uint32_t time );
+void wlserver_modifiers( uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group );
 
 void wlserver_mousefocus( struct wlr_surface *wlrsurface, int x = 0, int y = 0 );
 void wlserver_clear_dropdowns();


### PR DESCRIPTION
## Summary

When gamescope runs nested on a Wayland compositor, it receives `wl_keyboard.modifiers` from the host compositor but previously only stored them locally. Key events were injected via a stub virtual keyboard with no modifier state, so clients (especially Xwayland apps) received key presses with modifier state `0x0`.

This change forwards modifier events to the wlroots `keyboard_group` and injects keys through that keyboard, so the seat reports correct Shift/Ctrl/Alt state.

Fixes #1740
Fixes #2032

## Root cause

Discussed in #1740: older Xwayland versions ran their own XKB state machine and masked this bug. Xwayland 24.1.5+ correctly expects the compositor to forward modifier state ([xserver MR 1758](https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1758)), which exposed the issue in gamescope.

## Test plan

- [x] `gamescope -- konsole` — Shift+letters produce capitals
- [x] War Thunder via gamescope on KDE Plasma Wayland (Xwayland 24.1.13) — Shift works for typing and game binds
- [x] Modifier forwarding works regardless of Xwayland version (correct compositor behavior)

## Environment

- openSUSE Tumbleweed, KDE Plasma 6.7 Wayland
- Xwayland 24.1.13
- gamescope built from master (`976f7fc`) with this patch


Made with [Cursor](https://cursor.com)