### PR TITLE
steamcompmgr: don't abort on X11 I/O error while shutting down

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6781,6 +6781,17 @@ steamcompmgr_exit(void)
 [[noreturn]] static int
 handle_io_error(Display *dpy)
 {
+	// A group-wide interrupt reaches Xwayland at the same moment it reaches us, so give
+	// an in-flight shutdown up to 100ms to announce itself before calling this fatal.
+	for ( int i = 0; g_bRun && i < 20; i++ )
+		sleep_for_nanos( 5'000'000ul );
+
+	if ( !g_bRun )
+	{
+		xwm_log.infof("X11 I/O error while shutting down, exiting.");
+		_exit(0);
+	}
+
 	xwm_log.errorf("X11 I/O error! This is fatal. Aborting...");
 	abort();
 }


### PR DESCRIPTION
Interrupting gamescope signals our whole process group, so Xwayland can lose its connection before the thread handling our own signal has set g_bRun, and the next Xlib call then trips the I/O error handler. Ctrl-C dumped core roughly half the time as a result. Wait up to 100ms for an in-flight shutdown to announce itself, then exit with the normal status rather than aborting. An Xwayland crash mid-session still aborts, just 100ms later, so gamescope still goes down and takes the session with it the way 02f91de6 intended.