### PR TITLE
wlserver: Support wlr_subcompositor and wlr_viewporter

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -101,6 +101,9 @@
 
 #include "wlr_begin.hpp"
 #include "wlr/types/wlr_pointer_constraints_v1.h"
+#include "wlr/types/wlr_subcompositor.h"
+#include "wlr/types/wlr_viewporter.h"
+#include "wlr/types/wlr_xdg_shell.h"
 #include "wlr_end.hpp"
 
 #if HAVE_AVIF
@@ -125,6 +128,7 @@ static const int g_nBaseCursorScale = 36;
 LogScope xwm_log("xwm");
 LogScope focus_log("focus");
 LogScope g_WaitableLog("waitable");
+LogScope subsurfaces_log("subsurfaces");
 
 gamescope::ConVar<bool> cv_overlay_unmultiplied_alpha{ "overlay_unmultiplied_alpha", false };
 
@@ -2073,6 +2077,120 @@ wlserver_vk_swapchain_feedback* steamcompmgr_get_base_layer_swapchain_feedback()
 
 gamescope::ConVar<bool> cv_paint_debug_pause_base_plane( "paint_debug_pause_base_plane", false, "Pause updates to the base plane." );
 
+static gamescope::OwningRc<CVulkanTexture> GetSubsurfaceTexture( struct wlr_buffer *buf )
+{
+	if ( !buf )
+		return nullptr;
+	return s_BufferMemos.LookupVulkanTexture( buf );
+}
+
+static void compute_output_scale_and_offset(
+	float &outScaleX, float &outScaleY,
+	float &outOffsetX, float &outOffsetY,
+	int32_t sourceWidth, int32_t sourceHeight,
+	steamcompmgr_win_t *w, steamcompmgr_win_t *scaleW )
+{
+	float ratioX = 1.0f, ratioY = 1.0f;
+	int offsetX = 0, offsetY = 0;
+
+	bool needsScaling = sourceWidth  != (int32_t)currentOutputWidth
+	                 || sourceHeight != (int32_t)currentOutputHeight
+	                 || w->GetGeometry().nX
+	                 || w->GetGeometry().nY
+	                 || globalScaleRatio != 1.0f;
+
+	if ( needsScaling )
+	{
+		calc_scale_factor( ratioX, ratioY, sourceWidth, sourceHeight );
+		offsetX = ( (int)currentOutputWidth  - (int)sourceWidth  * ratioX ) / 2.0f;
+		offsetY = ( (int)currentOutputHeight - (int)sourceHeight * ratioY ) / 2.0f;
+
+		if ( w != scaleW )
+		{
+			offsetX += w->GetGeometry().nX * ratioX;
+			offsetY += w->GetGeometry().nY * ratioY;
+		}
+	}
+
+	outScaleX  = 1.0f / ratioX;
+	outScaleY  = 1.0f / ratioY;
+	outOffsetX = -offsetX;
+	outOffsetY = -offsetY;
+}
+
+static void paint_subsurface_tree( struct wlr_subsurface *sub,
+	int parentX, int parentY,
+	FrameInfo_t::Layer_t *parentLayer, uint32_t zPos,
+	struct FrameInfo_t *frameInfo )
+{
+	if ( !sub || !sub->surface->mapped )
+		return;
+	if ( frameInfo->layerCount >= k_nMaxLayers )
+		return;
+
+	int x = parentX + sub->current.x;
+	int y = parentY + sub->current.y;
+
+	struct wlr_subsurface *child, *tmp;
+
+	wl_list_for_each_safe( child, tmp, &sub->surface->current.subsurfaces_below, current.link )
+		paint_subsurface_tree( child, x, y, parentLayer, zPos, frameInfo );
+
+	VulkanWlrTexture_t *subtex = (VulkanWlrTexture_t *)wlr_surface_get_texture( sub->surface );
+	if ( subtex && subtex->buf )
+	{
+		gamescope::OwningRc<CVulkanTexture> pSubTex = GetSubsurfaceTexture( subtex->buf );
+		if ( pSubTex && frameInfo->layerCount < k_nMaxLayers )
+		{
+			int curLayer = frameInfo->layerCount++;
+			FrameInfo_t::Layer_t *sublayer = &frameInfo->layers[ curLayer ];
+
+			sublayer->tex = pSubTex;
+			sublayer->filter = parentLayer->filter;
+
+			if ( pSubTex->isYcbcr() )
+				sublayer->colorspace = GAMESCOPE_APP_TEXTURE_COLORSPACE_PASSTHRU;
+			else
+				sublayer->colorspace = VkColorSpaceToGamescopeAppTextureColorSpace(
+					pSubTex->format(), VK_COLOR_SPACE_SRGB_NONLINEAR_KHR );
+
+			if ( parentLayer->scale.x != 0.0f && parentLayer->scale.y != 0.0f )
+			{
+				sublayer->scale.x = parentLayer->scale.x;
+				sublayer->scale.y = parentLayer->scale.y;
+				sublayer->offset.x = parentLayer->offset.x - x / parentLayer->scale.x;
+				sublayer->offset.y = parentLayer->offset.y - y / parentLayer->scale.y;
+
+				const struct wlr_surface_state &st = sub->surface->current;
+				int buf_w = st.buffer_width, buf_h = st.buffer_height;
+				if ( st.viewport.has_src && buf_w > 0 && buf_h > 0 )
+				{
+					float sw = (float)st.viewport.src.width;
+					float sh = (float)st.viewport.src.height;
+					sublayer->scale.x  *= sw / (float)buf_w;
+					sublayer->scale.y  *= sh / (float)buf_h;
+					sublayer->offset.x  = (float)st.viewport.src.x + ( sublayer->offset.x * sw / (float)buf_w );
+					sublayer->offset.y  = (float)st.viewport.src.y + ( sublayer->offset.y * sh / (float)buf_h );
+				}
+			}
+
+			sublayer->opacity = 1.0f;
+			sublayer->zpos = zPos;
+			sublayer->blackBorder = false;
+			sublayer->applyColorMgmt = parentLayer->applyColorMgmt;
+			sublayer->ctm = nullptr;
+			sublayer->hdr_metadata_blob = nullptr;
+			sublayer->eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
+
+			if ( sublayer->colorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB )
+				sublayer->ctm = s_scRGB709To2020Matrix;
+		}
+	}
+
+	wl_list_for_each_safe( child, tmp, &sub->surface->current.subsurfaces_above, current.link )
+		paint_subsurface_tree( child, x, y, parentLayer, zPos, frameInfo );
+}
+
 static FrameInfo_t::Layer_t *
 paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win_t *w, steamcompmgr_win_t *scaleW, struct FrameInfo_t *frameInfo,
 			  MouseCursor *cursor, PaintWindowFlags flags = 0, float flOpacityScale = 1.0f, steamcompmgr_win_t *fit = nullptr )
@@ -2262,7 +2380,63 @@ paint_window(steamcompmgr_win_t *w, steamcompmgr_win_t *scaleW, struct FrameInfo
 		}
 	}
 
+	if ( ( flags & PaintWindowFlag::BasePlane ) && lastCommit )
+	{
+		struct wlr_surface *rootSurface = lastCommit->surf;
+		if ( rootSurface )
+		{
+			FrameInfo_t::Layer_t tempParentLayer = {};
+
+			int32_t sourceWidth, sourceHeight;
+			if ( flags & PaintWindowFlag::NoScale ) {
+				sourceWidth = currentOutputWidth;
+				sourceHeight = currentOutputHeight;
+			} else if ( w == scaleW ) {
+				GamescopeAppTextureColorspace dummyCs;
+				auto tex = lastCommit->GetTexture( GamescopeUpscaleFilter::LINEAR, g_upscaleScaler, dummyCs );
+				sourceWidth = tex->width();
+				sourceHeight = tex->height();
+			} else {
+				sourceWidth = scaleW->GetGeometry().nWidth;
+				sourceHeight = scaleW->GetGeometry().nHeight;
+			}
+			compute_output_scale_and_offset( tempParentLayer.scale.x, tempParentLayer.scale.y,
+				tempParentLayer.offset.x, tempParentLayer.offset.y,
+				sourceWidth, sourceHeight, w, scaleW );
+
+			tempParentLayer.zpos = g_zposBase;
+			tempParentLayer.filter = ( flags & PaintWindowFlag::NoFilter )
+				? GamescopeUpscaleFilter::LINEAR : g_upscaleFilter;
+			tempParentLayer.applyColorMgmt = g_ColorMgmt.pending.enabled;
+
+			wlserver_lock();
+			if ( w->type != steamcompmgr_win_type_t::XDG || rootSurface == w->main_surface() )
+			{
+				struct wlr_subsurface *sub, *tmp;
+				wl_list_for_each_safe( sub, tmp, &rootSurface->current.subsurfaces_below, current.link )
+					paint_subsurface_tree( sub, 0, 0, &tempParentLayer, tempParentLayer.zpos, frameInfo );
+			}
+			wlserver_unlock();
+		}
+	}
+
 	FrameInfo_t::Layer_t *layer = paint_window_commit( lastCommit, w, scaleW, frameInfo, cursor, flags, flOpacityScale, fit );
+
+	if ( layer && ( flags & PaintWindowFlag::BasePlane ) && lastCommit )
+	{
+		struct wlr_surface *rootSurface = lastCommit->surf;
+		if ( rootSurface )
+		{
+			wlserver_lock();
+			if ( w->type != steamcompmgr_win_type_t::XDG || rootSurface == w->main_surface() )
+			{
+				struct wlr_subsurface *sub, *tmp;
+				wl_list_for_each_safe( sub, tmp, &rootSurface->current.subsurfaces_above, current.link )
+					paint_subsurface_tree( sub, 0, 0, layer, g_zposBase + 1, frameInfo );
+			}
+			wlserver_unlock();
+		}
+	}
 
 	if ( layer && ( flags & PaintWindowFlag::BasePlane ) )
 	{
@@ -5758,7 +5932,20 @@ steamcompmgr_flush_frame_done( steamcompmgr_win_t *w )
 
 		if ( main_surface != nullptr )
 		{
-			wlserver_send_frame_done(main_surface, &now);
+			wlr_surface_for_each_surface( main_surface,
+				[](struct wlr_surface *surf, int, int, void *data) {
+					wlserver_send_frame_done(surf, static_cast<const struct timespec *>(data));
+				}, &now );
+
+			wlserver_wl_surface_info *wl_info = get_wl_surface_info( main_surface );
+			if ( wl_info && wl_info->xdg_surface && wl_info->xdg_surface->xdg_surface )
+			{
+				wlr_xdg_surface_for_each_popup_surface(
+					wl_info->xdg_surface->xdg_surface,
+					[](struct wlr_surface *surf, int, int, void *data) {
+						wlserver_send_frame_done(surf, static_cast<const struct timespec *>(data));
+					}, &now );
+			}
 		}
 
 		if ( current_surface != nullptr && main_surface != current_surface )
@@ -7419,6 +7606,92 @@ void check_new_xwayland_res(xwayland_ctx_t *ctx)
 	}
 }
 
+struct SubsurfaceCommit_t {
+	struct wlr_surface *root;
+	struct wlr_buffer *buf;
+	std::shared_ptr<gamescope::CReleaseTimelinePoint> pReleasePoint;
+	std::vector<struct wl_resource*> presentation_feedbacks;
+};
+
+static std::vector<SubsurfaceCommit_t> g_PendingSubsurfaceCommits;
+
+static void check_new_subsurface_res()
+{
+	struct SubsurfacePending_t {
+		ResListEntry_t entry;
+		struct wlr_surface *root;
+	};
+
+	std::vector<SubsurfacePending_t> pendings;
+	{
+		wlserver_lock();
+		std::vector<ResListEntry_t> tmpQueue = wlserver_subsurface_commit_queue();
+		pendings.reserve( tmpQueue.size() );
+		for ( auto& entry : tmpQueue )
+		{
+			struct wlr_surface *root = nullptr;
+			if ( entry.surf )
+				root = wlr_surface_get_root_surface( entry.surf );
+			pendings.push_back( SubsurfacePending_t{ std::move( entry ), root } );
+		}
+		wlserver_unlock();
+	}
+
+	if ( pendings.empty() )
+		return;
+
+	hasRepaint = true;
+
+	for ( auto& pending : pendings )
+	{
+		auto& entry = pending.entry;
+
+		if ( !entry.buf )
+		{
+			subsurfaces_log.errorf( "commit with no buffer" );
+			wlserver_presentation_feedbacks_destroy( entry.presentation_feedbacks );
+			continue;
+		}
+
+		if ( entry.pAcquirePoint && !entry.pAcquirePoint->Wait() )
+			subsurfaces_log.errorf( "acquire point wait failed" );
+
+		if ( !s_BufferMemos.LookupVulkanTexture( entry.buf ) )
+		{
+			struct wlr_dmabuf_attributes dmabuf = {};
+			gamescope::OwningRc<gamescope::IBackendFb> pBackendFb;
+			if ( wlr_buffer_get_dmabuf( entry.buf, &dmabuf ) )
+				pBackendFb = GetBackend()->ImportDmabufToBackend( &dmabuf );
+			if ( entry.pReleasePoint && pBackendFb )
+				pBackendFb->SetReleasePoint( entry.pReleasePoint );
+
+			gamescope::OwningRc<CVulkanTexture> pTex =
+				vulkan_create_texture_from_wlr_buffer( entry.buf, std::move( pBackendFb ) );
+			if ( pTex )
+				s_BufferMemos.MemoizeBuffer( entry.buf, std::move( pTex ) );
+		}
+
+		if ( pending.root )
+		{
+			for ( const auto& xdg_win : g_steamcompmgr_xdg_wins )
+			{
+				if ( xdg_win->xdg().surface.main_surface == pending.root )
+				{
+					xdg_win->receivedDoneCommit = true;
+					break;
+				}
+			}
+		}
+
+		g_PendingSubsurfaceCommits.push_back( SubsurfaceCommit_t{
+			.root = pending.root,
+			.buf = entry.buf,
+			.pReleasePoint = std::move( entry.pReleasePoint ),
+			.presentation_feedbacks = std::move( entry.presentation_feedbacks ),
+		} );
+	}
+}
+
 void check_new_xdg_res()
 {
 	std::vector<ResListEntry_t> tmp_queue = wlserver_xdg_commit_queue();
@@ -8104,6 +8377,8 @@ void steamcompmgr_check_xdg(bool vblank, uint64_t vblank_idx)
 		MakeFocusDirty();
 	}
 
+	check_new_subsurface_res();
+
 	handle_done_commits_xdg( vblank, vblank_idx );
 
 	// When we have observed both a complete commit and a VBlank, we should request a new frame.
@@ -8116,6 +8391,28 @@ void steamcompmgr_check_xdg(bool vblank, uint64_t vblank_idx)
 
 		wlserver_lock();
 		handle_presented_xdg();
+
+		uint64_t nextRefresh = g_SteamCompMgrVBlankTime.schedule.ulTargetVBlank;
+		uint64_t refreshCycle = g_SteamCompMgrAppRefreshCycle;
+		for ( auto& pending : g_PendingSubsurfaceCommits )
+		{
+			if ( !pending.presentation_feedbacks.empty() )
+			{
+				if ( pending.root )
+				{
+					wlserver_presentation_feedback_presented(
+						pending.root, pending.presentation_feedbacks,
+						nextRefresh, refreshCycle );
+				}
+				else
+				{
+					wlserver_presentation_feedbacks_destroy( pending.presentation_feedbacks );
+				}
+			}
+			wlr_buffer_unlock( pending.buf );
+		}
+		g_PendingSubsurfaceCommits.clear();
+
 		wlserver_unlock();
 	}
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -45,6 +45,8 @@
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_data_device.h>
+#include <wlr/types/wlr_subcompositor.h>
+#include <wlr/types/wlr_viewporter.h>
 #include <wlr/util/region.h>
 #include "wlr_end.hpp"
 
@@ -236,6 +238,13 @@ void xwayland_surface_commit(struct wlr_surface *wlr_surface) {
 		}
 	}
 
+	// Non-toplevel surfaces need the initial configure sent before they can map.
+	if ( struct wlr_xdg_surface *xdg_surface = wlr_xdg_surface_try_from_wlr_surface( wlr_surface ) )
+	{
+		if ( xdg_surface->initial_commit && xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL )
+			wlr_xdg_surface_schedule_configure( xdg_surface );
+	}
+
 	// Committing without buffer state is valid and commits the same buffer again.
 	// Mutter and Weston have forward progress on the frame callback in this situation,
 	// so let the commit go through. It will be duplication-eliminated later.
@@ -258,6 +267,24 @@ void xwayland_surface_commit(struct wlr_surface *wlr_surface) {
 	else if (wlserver_xdg_surface_info)
 	{
 		wlserver_xdg_commit(wlr_surface, buf);
+	}
+	else if ( wlr_subsurface_try_from_wlr_surface( wlr_surface ) )
+	{
+		std::optional<ResListEntry_t> oEntry = PrepareCommit( wlr_surface, buf );
+		if ( oEntry )
+		{
+			std::lock_guard<std::mutex> lock( wlserver.subsurface_commit_lock );
+			wlserver.subsurface_commit_queue.push_back( std::move( *oEntry ) );
+		}
+		else
+		{
+			wlr_buffer_unlock( buf );
+		}
+		nudge_steamcompmgr();
+	}
+	else if ( wlr_xdg_surface_try_from_wlr_surface( wlr_surface ) )
+	{
+		wlr_buffer_unlock( buf );
 	}
 	else
 	{
@@ -594,6 +621,19 @@ static void handle_wl_surface_destroy( struct wl_listener *l, void *data )
 		// wl_list_remove leaves stuff in a weird state, so we need to call
 		// this to re-init the list to avoid a crash.
 		wlserver_x11_surface_info_init(x11_surface, x11_surface->xwayland_server, x11_surface->x11_id);
+	}
+
+	{
+		std::lock_guard<std::mutex> lock( wlserver.subsurface_commit_lock );
+		std::erase_if( wlserver.subsurface_commit_queue,
+			[surf = surf->wlr]( auto &entry ) {
+				if ( entry.surf != surf )
+					return false;
+				wlserver_presentation_feedbacks_destroy( entry.presentation_feedbacks );
+				if ( entry.buf )
+					wlr_buffer_unlock( entry.buf );
+				return true;
+			} );
 	}
 
 	if ( surf->wlr == wlserver.mouse_focus_surface )
@@ -1553,6 +1593,16 @@ void wlserver_presentation_feedback_discard( struct wlr_surface *surface, std::v
 	presentation_feedbacks.clear();
 }
 
+void wlserver_presentation_feedbacks_destroy( std::vector<struct wl_resource*>& presentation_feedbacks )
+{
+	for ( auto *feedback : presentation_feedbacks )
+	{
+		wp_presentation_feedback_send_discarded( feedback );
+		wl_resource_destroy( feedback );
+	}
+	presentation_feedbacks.clear();
+}
+
 ///////////////////////
 
 
@@ -1895,8 +1945,21 @@ static void waylandy_surface_destroy(struct wl_listener *listener, void *data) {
 	wlserver_surface->xdg_surface = nullptr;
 }
 
+wlserver_xdg_surface_info* waylandy_type_surface_new(struct wl_client *client, struct wlr_surface *surface);
+
 void xdg_toplevel_new(struct wl_listener *listener, void *data)
 {
+	struct wlr_xdg_toplevel *toplevel = (struct wlr_xdg_toplevel *)data;
+	struct wlr_xdg_surface *xdg_surface = toplevel->base;
+
+	wlserver_xdg_surface_info *surface_info = waylandy_type_surface_new(xdg_surface->client->client, xdg_surface->surface);
+	if (!surface_info)
+		return;
+
+	surface_info->destroy.notify = waylandy_surface_destroy;
+	wl_signal_add(&xdg_surface->events.destroy, &surface_info->destroy);
+
+	surface_info->xdg_surface = xdg_surface;
 }
 
 uint32_t get_appid_from_pid( pid_t pid );
@@ -1958,18 +2021,6 @@ wlserver_xdg_surface_info* waylandy_type_surface_new(struct wl_client *client, s
 
 	return xdg_surface_info;
 }
-
-void xdg_surface_new(struct wl_listener *listener, void *data)
-{
-	struct wlr_xdg_surface *xdg_surface = (struct wlr_xdg_surface *)data;
-
-	wlserver_xdg_surface_info *surface_info = waylandy_type_surface_new(xdg_surface->client->client, xdg_surface->surface);
-	surface_info->destroy.notify = waylandy_surface_destroy;
-	wl_signal_add(&xdg_surface->events.destroy, &surface_info->destroy);
-
-	surface_info->xdg_surface = xdg_surface;
-}
-
 
 void layer_shell_surface_new(struct wl_listener *listener, void *data)
 {
@@ -2047,6 +2098,9 @@ bool wlserver_init( void ) {
 
 	wl_signal_add( &wlserver.wlr.compositor->events.new_surface, &new_surface_listener );
 
+	wlr_subcompositor_create(wlserver.display);
+	wlr_viewporter_create(wlserver.display);
+
 	create_ime_manager( &wlserver );
 
 	create_reshade();
@@ -2100,9 +2154,7 @@ bool wlserver_init( void ) {
 		wl_log.infof("Unable to create XDG shell interface");
 		return false;
 	}
-	wlserver.new_xdg_surface.notify = xdg_surface_new;
 	wlserver.new_xdg_toplevel.notify = xdg_toplevel_new;
-	wl_signal_add(&wlserver.xdg_shell->events.new_surface, &wlserver.new_xdg_surface);
 	wl_signal_add(&wlserver.xdg_shell->events.new_toplevel, &wlserver.new_xdg_toplevel);
 
 	wlserver.layer_shell_v1 = wlr_layer_shell_v1_create(wlserver.display, 4);
@@ -2307,7 +2359,6 @@ void wlserver_run(void)
 	wl_list_remove( &new_surface_listener.link );
 	wl_list_remove( &new_input_listener.link );
 	wl_list_remove( &wlserver.new_pointer_constraint.link );
-	wl_list_remove( &wlserver.new_xdg_surface.link );
 	wl_list_remove( &wlserver.new_xdg_toplevel.link );
 	wl_list_remove( &wlserver.new_layer_shell_surface.link );
 
@@ -3290,6 +3341,16 @@ std::vector<ResListEntry_t> wlserver_xdg_commit_queue()
 	{
 		std::lock_guard<std::mutex> lock( wlserver.xdg_commit_lock );
 		commits = std::move(wlserver.xdg_commit_queue);
+	}
+	return commits;
+}
+
+std::vector<ResListEntry_t> wlserver_subsurface_commit_queue()
+{
+	std::vector<ResListEntry_t> commits;
+	{
+		std::lock_guard<std::mutex> lock( wlserver.subsurface_commit_lock );
+		commits = std::move(wlserver.subsurface_commit_queue);
 	}
 	return commits;
 }

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -181,7 +181,6 @@ struct wlserver_t {
 	struct wlr_layer_shell_v1 *layer_shell_v1;
 	struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
 	struct wlr_pointer_constraints_v1 *constraints;
-	struct wl_listener new_xdg_surface;
 	struct wl_listener new_xdg_toplevel;
 	struct wl_listener new_layer_shell_surface;
 	struct wl_listener new_pointer_constraint;
@@ -189,6 +188,9 @@ struct wlserver_t {
 	std::atomic<bool> xdg_dirty;
 	std::mutex xdg_commit_lock;
 	std::vector<ResListEntry_t> xdg_commit_queue;
+
+	std::mutex subsurface_commit_lock;
+	std::vector<ResListEntry_t> subsurface_commit_queue;
 
 	std::vector<wl_resource*> gamescope_controls;
 	std::unordered_map< uint32_t, std::vector<wl_resource*> > app_perf_requests;
@@ -204,6 +206,7 @@ struct wlserver_t {
 extern struct wlserver_t wlserver;
 
 std::vector<ResListEntry_t> wlserver_xdg_commit_queue();
+std::vector<ResListEntry_t> wlserver_subsurface_commit_queue();
 
 struct wlserver_pointer {
 	struct wlr_pointer *wlr;
@@ -289,6 +292,7 @@ void wlserver_destroy_xwayland_server(gamescope_xwayland_server_t *server);
 
 void wlserver_presentation_feedback_presented( struct wlr_surface *surface, std::vector<struct wl_resource*>& presentation_feedbacks, uint64_t last_refresh_nsec, uint64_t refresh_cycle );
 void wlserver_presentation_feedback_discard( struct wlr_surface *surface, std::vector<struct wl_resource*>& presentation_feedbacks );
+void wlserver_presentation_feedbacks_destroy( std::vector<struct wl_resource*>& presentation_feedbacks );
 
 void wlserver_past_present_timing( struct wlr_surface *surface, uint32_t present_id, uint64_t desired_present_time, uint64_t actual_present_time, uint64_t earliest_present_time, uint64_t present_margin );
 void wlserver_refresh_cycle( struct wlr_surface *surface, uint64_t refresh_cycle );


### PR DESCRIPTION
Initial draft implementation. [`wlr_subcompositor`](https://wlroots.pages.freedesktop.org/wlroots/wlr/types/wlr_subcompositor.h.html) implements [`wl_subcompositor`](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_subcompositor), which adds sub-surface compositing capabilities. [`wlr_viewporter`](https://wlroots.pages.freedesktop.org/wlroots/wlr/types/wlr_viewporter.h.html) implements the viewporter protocol. Both of them are needed to support some applications running natively on wayland under gamescope.

The main use case is launching Firefox without xwayland, using wayland directly. This is now running and not crashing as before. However, there are still some known issues that will need fixing in follow up improvements.

|![](https://github.com/user-attachments/assets/75eed381-0a66-4f36-a7b1-d112709cb846)|![](https://github.com/user-attachments/assets/85943668-4696-4a19-ada5-48ed71433d45)|
|---|---|

It also seems to fix the use case described in #2194, but as with Firefox, it will probably need some testing and fixes to be fully usable.

**Known issues:**

- Input needs some work, both pointer (is slightly moved from where it should be) and keyboard (combination keys don't seem to work).
- Popups are not showing.

Fixes: #2194