### PR TITLE
Make native Wayland clients usable in the Steam session

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4100,6 +4100,13 @@ steamcompmgr_xdg_get_possible_focus_windows()
 			continue;
 		}
 
+		// Only mapped toplevels are focus candidates: popups and
+		// not-yet-mapped surfaces must not be reported to Steam.
+		if ( !win->xdg().surface.bIsToplevel || !win->xdg().surface.mapped )
+		{
+			continue;
+		}
+
 		windows.emplace_back( win.get() );
 	}
 	return windows;
@@ -4191,14 +4198,15 @@ determine_and_apply_focus( global_focus_t *pFocus )
 
 	for ( steamcompmgr_win_t *focusable_window : vecPossibleFocusWindows )
 	{
-		if ( focusable_window->type != steamcompmgr_win_type_t::XWAYLAND )
-			continue;
+		const bool bIsXWayland = focusable_window->type == steamcompmgr_win_type_t::XWAYLAND;
 
 		// Exclude windows that are useless (1x1), skip taskbar + pager or override redirect windows
-		// from the reported focusable windows to Steam.
-		if ( win_is_useless( focusable_window ) ||
-			win_skip_and_not_fullscreen( focusable_window ) ||
-			focusable_window->xwayland().a.override_redirect )
+		// from the reported focusable windows to Steam. These are all XWayland concepts, so XDG
+		// windows are reported as-is.
+		if ( bIsXWayland &&
+			( win_is_useless( focusable_window ) ||
+			  win_skip_and_not_fullscreen( focusable_window ) ||
+			  focusable_window->xwayland().a.override_redirect ) )
 			continue;
 
 		unsigned int unAppID = focusable_window->appID;
@@ -4219,7 +4227,7 @@ determine_and_apply_focus( global_focus_t *pFocus )
 		}
 
 		// list of [window, appid, pid] triplets
-		focusable_windows.push_back( focusable_window->xwayland().id );
+		focusable_windows.push_back( focusable_window->id() );
 		focusable_windows.push_back( focusable_window->appID );
 		focusable_windows.push_back( focusable_window->pid );
 	}

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -56,6 +56,8 @@ struct wlserver_xdg_surface_info
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
+	struct wl_listener request_fullscreen;
+	struct wl_listener request_maximize;
 };
 
 

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -47,6 +47,7 @@ struct wlserver_xdg_surface_info
 	struct wlr_layer_surface_v1 *layer_surface = nullptr;
 	steamcompmgr_win_t *win = nullptr;
 	bool bDoneConfigure = false;
+	std::atomic<bool> bIsToplevel = { false };
 
 	std::atomic<bool> mapped = { false };
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1905,6 +1905,13 @@ static void waylandy_surface_destroy(struct wl_listener *listener, void *data) {
 
 void xdg_toplevel_new(struct wl_listener *listener, void *data)
 {
+	struct wlr_xdg_toplevel *toplevel = (struct wlr_xdg_toplevel *)data;
+
+	wlserver_wl_surface_info *wlserver_surface = get_wl_surface_info(toplevel->base->surface);
+	if (!wlserver_surface || !wlserver_surface->xdg_surface)
+		return;
+
+	wlserver_surface->xdg_surface->bIsToplevel = true;
 }
 
 uint32_t get_appid_from_pid( pid_t pid );

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -227,7 +227,23 @@ void xwayland_surface_commit(struct wlr_surface *wlr_surface) {
 		if ( !wlserver_xdg_surface_info->bDoneConfigure )
 		{
 			if ( wlserver_xdg_surface_info->xdg_surface )
-				wlr_xdg_surface_schedule_configure( wlserver_xdg_surface_info->xdg_surface );
+			{
+				struct wlr_xdg_surface *xdg_surface = wlserver_xdg_surface_info->xdg_surface;
+				struct wlr_xdg_toplevel *toplevel = xdg_surface->toplevel;
+
+				if ( toplevel && !toplevel->parent )
+				{
+					// set_size/set_fullscreen schedule the configure themselves.
+					wlr_xdg_toplevel_set_size( toplevel, g_nNestedWidth, g_nNestedHeight );
+					wlr_xdg_toplevel_set_fullscreen( toplevel, true );
+				}
+				else
+				{
+					// Child toplevels (dialogs) and other roles keep their own
+					// size; they still need the initial configure.
+					wlr_xdg_surface_schedule_configure( xdg_surface );
+				}
+			}
 
 			if ( wlserver_xdg_surface_info->layer_surface )
 				wlr_layer_surface_v1_configure( wlserver_xdg_surface_info->layer_surface, g_nNestedWidth, g_nNestedHeight );
@@ -1899,8 +1915,33 @@ static void waylandy_surface_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&info->map.link);
 	wl_list_remove(&info->unmap.link);
 	wl_list_remove(&info->destroy.link);
+	if (info->bIsToplevel)
+	{
+		wl_list_remove(&info->request_fullscreen.link);
+		wl_list_remove(&info->request_maximize.link);
+	}
 
 	wlserver_surface->xdg_surface = nullptr;
+}
+
+static void xdg_toplevel_request_fullscreen(struct wl_listener *listener, void *data)
+{
+	struct wlserver_xdg_surface_info *info =
+		wl_container_of(listener, info, request_fullscreen);
+
+	// The compositor stays authoritative over the fullscreen state, but any
+	// request must still be answered with a configure.
+	if (info->xdg_surface)
+		wlr_xdg_surface_schedule_configure(info->xdg_surface);
+}
+
+static void xdg_toplevel_request_maximize(struct wl_listener *listener, void *data)
+{
+	struct wlserver_xdg_surface_info *info =
+		wl_container_of(listener, info, request_maximize);
+
+	if (info->xdg_surface)
+		wlr_xdg_surface_schedule_configure(info->xdg_surface);
 }
 
 void xdg_toplevel_new(struct wl_listener *listener, void *data)
@@ -1911,7 +1952,13 @@ void xdg_toplevel_new(struct wl_listener *listener, void *data)
 	if (!wlserver_surface || !wlserver_surface->xdg_surface)
 		return;
 
-	wlserver_surface->xdg_surface->bIsToplevel = true;
+	wlserver_xdg_surface_info *info = wlserver_surface->xdg_surface;
+	info->bIsToplevel = true;
+
+	info->request_fullscreen.notify = xdg_toplevel_request_fullscreen;
+	wl_signal_add(&toplevel->events.request_fullscreen, &info->request_fullscreen);
+	info->request_maximize.notify = xdg_toplevel_request_maximize;
+	wl_signal_add(&toplevel->events.request_maximize, &info->request_maximize);
 }
 
 uint32_t get_appid_from_pid( pid_t pid );
@@ -1938,6 +1985,8 @@ wlserver_xdg_surface_info* waylandy_type_surface_new(struct wl_client *client, s
 		pid_t nPid = 0;
 		wl_client_get_credentials( client, &nPid, nullptr, nullptr );
 		window->appID = get_appid_from_pid( nPid );
+		window->pid = nPid;
+
 	}
 	window->_window_types.emplace<steamcompmgr_xdg_win_t>();
 


### PR DESCRIPTION
Native Wayland clients under `--expose-wayland` don't really work in the embedded Steam session (`-e`): launching one from a Steam shortcut leaves the launch spinner up forever. 

Two small fixes: the window-management prerequisite for ValveSoftware/SteamOS#2166 (the HDR part is a follow-up). Tested on SteamOS holo (Fremont) with an Electron app and a Qt 6.10 app, launched from Steam shortcuts.

- **steamcompmgr: report XDG windows as focusable to Steam**
`GAMESCOPE_FOCUSABLE_APPS`/`_WINDOWS` were built from a loop that skipped every non-XWayland window. XDG windows are now included.

- **wlserver: make XDG toplevels fullscreen-sized and carry a pid**
Send `set_size` + `set_fullscreen` before the configure, so that the app does not choose its own size. Also fill `window->pid` so the focusable-windows triplet doesn't report -1.

