### PR TITLE
steamcompmgr: write back NET_WM_STATE on state changes

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3916,6 +3916,42 @@ carry_override_underlay( focus_t *pFocus, steamcompmgr_win_t *pPreviousOverride,
 static void
 handle_desktop_window(steamcompmgr_win_t *w);
 
+static void
+resize_window_to_desired_geometry( xwayland_ctx_t *ctx, steamcompmgr_win_t *w )
+{
+	if ( win_has_game_id( w ) )
+	{
+		if ( window_is_fullscreen( w ) || ctx->force_windows_fullscreen )
+		{
+			bool bIsSteam = window_is_steam( w );
+			int fs_width  = ctx->root_width;
+			int fs_height = ctx->root_height;
+			if ( bIsSteam && g_nSteamMaxHeight && ctx->root_height > g_nSteamMaxHeight )
+			{
+				float steam_height_scale = g_nSteamMaxHeight / (float)ctx->root_height;
+				fs_height = g_nSteamMaxHeight;
+				fs_width  = ctx->root_width * steam_height_scale;
+			}
+
+			if ( w->GetGeometry().nWidth != fs_width || w->GetGeometry().nHeight != fs_height || globalScaleRatio != 1.0f )
+				XResizeWindow( ctx->dpy, w->xwayland().id, fs_width, fs_height );
+		}
+		else
+		{
+			if ( w->sizeHintsSpecified &&
+				((unsigned)w->GetGeometry().nWidth != w->requestedWidth ||
+				 (unsigned)w->GetGeometry().nHeight != w->requestedHeight))
+			{
+				XResizeWindow( ctx->dpy, w->xwayland().id, w->requestedWidth, w->requestedHeight );
+			}
+		}
+	}
+	else
+	{
+		handle_desktop_window( w );
+	}
+}
+
 static bool
 pick_primary_focus_and_override(
 	focus_t *out,
@@ -4440,37 +4476,7 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 		w->placed = true;
 	}
 
-	if ( win_has_game_id( w ) )
-	{
-		if ( window_is_fullscreen( ctx->focus.focusWindow ) || ctx->force_windows_fullscreen )
-		{
-			bool bIsSteam = window_is_steam( ctx->focus.focusWindow );
-			int fs_width  = ctx->root_width;
-			int fs_height = ctx->root_height;
-			if ( bIsSteam && g_nSteamMaxHeight && ctx->root_height > g_nSteamMaxHeight )
-			{
-				float steam_height_scale = g_nSteamMaxHeight / (float)ctx->root_height;
-				fs_height = g_nSteamMaxHeight;
-				fs_width  = ctx->root_width * steam_height_scale;
-			}
-
-			if ( w->GetGeometry().nWidth != fs_width || w->GetGeometry().nHeight != fs_height || globalScaleRatio != 1.0f )
-				XResizeWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, fs_width, fs_height);
-		}
-		else
-		{
-			if (ctx->focus.focusWindow->sizeHintsSpecified &&
-				((unsigned)ctx->focus.focusWindow->GetGeometry().nWidth != ctx->focus.focusWindow->requestedWidth ||
-				(unsigned)ctx->focus.focusWindow->GetGeometry().nHeight != ctx->focus.focusWindow->requestedHeight))
-			{
-				XResizeWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, ctx->focus.focusWindow->requestedWidth, ctx->focus.focusWindow->requestedHeight);
-			}
-		}
-	}
-	else
-	{
-		handle_desktop_window( w );
-	}
+	resize_window_to_desired_geometry( ctx, w );
 
 	Window	    root_return = None, parent_return = None;
 	Window	    *children = NULL;
@@ -5993,6 +5999,9 @@ handle_net_wm_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessageEv
 			xwm_log.debugf("Unhandled NET_WM_STATE property change: %s", XGetAtomName(ctx->dpy, props[i]));
 		}
 	}
+
+	if (fullscreenChanged)
+		resize_window_to_desired_geometry( ctx, w );
 
 	if (!fullscreenChanged && !skipTaskbarChanged && !skipPagerChanged)
 		return;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5576,6 +5576,14 @@ handle_net_wm_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessageEv
 			xwm_log.debugf("Unhandled NET_WM_STATE property change: %s", XGetAtomName(ctx->dpy, props[i]));
 		}
 	}
+
+	Atom atoms[3];
+	int count = 0;
+	if (w->isFullscreen) atoms[count++] = ctx->atoms.netWMStateFullscreenAtom;
+	if (w->skipTaskbar) atoms[count++] = ctx->atoms.netWMStateSkipTaskbarAtom;
+	if (w->skipPager) atoms[count++] = ctx->atoms.netWMStateSkipPagerAtom;
+	XChangeProperty(ctx->dpy, w->xwayland().id, ctx->atoms.netWMStateAtom,
+			XA_ATOM, 32, PropModeReplace, (unsigned char*)atoms, count);
 }
 
 bool g_bLowLatency = false;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3533,6 +3533,42 @@ static bool is_good_override_candidate( steamcompmgr_win_t *override, steamcompm
 static void
 handle_desktop_window(steamcompmgr_win_t *w);
 
+static void
+resize_window_to_desired_geometry( xwayland_ctx_t *ctx, steamcompmgr_win_t *w )
+{
+	if ( win_has_game_id( w ) )
+	{
+		if ( window_is_fullscreen( w ) || ctx->force_windows_fullscreen )
+		{
+			bool bIsSteam = window_is_steam( w );
+			int fs_width  = ctx->root_width;
+			int fs_height = ctx->root_height;
+			if ( bIsSteam && g_nSteamMaxHeight && ctx->root_height > g_nSteamMaxHeight )
+			{
+				float steam_height_scale = g_nSteamMaxHeight / (float)ctx->root_height;
+				fs_height = g_nSteamMaxHeight;
+				fs_width  = ctx->root_width * steam_height_scale;
+			}
+
+			if ( w->GetGeometry().nWidth != fs_width || w->GetGeometry().nHeight != fs_height || globalScaleRatio != 1.0f )
+				XResizeWindow( ctx->dpy, w->xwayland().id, fs_width, fs_height );
+		}
+		else
+		{
+			if ( w->sizeHintsSpecified &&
+				((unsigned)w->GetGeometry().nWidth != w->requestedWidth ||
+				 (unsigned)w->GetGeometry().nHeight != w->requestedHeight))
+			{
+				XResizeWindow( ctx->dpy, w->xwayland().id, w->requestedWidth, w->requestedHeight );
+			}
+		}
+	}
+	else
+	{
+		handle_desktop_window( w );
+	}
+}
+
 static bool
 pick_primary_focus_and_override(
 	focus_t *out,
@@ -4044,37 +4080,7 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 		w->placed = true;
 	}
 
-	if ( win_has_game_id( w ) )
-	{
-		if ( window_is_fullscreen( ctx->focus.focusWindow ) || ctx->force_windows_fullscreen )
-		{
-			bool bIsSteam = window_is_steam( ctx->focus.focusWindow );
-			int fs_width  = ctx->root_width;
-			int fs_height = ctx->root_height;
-			if ( bIsSteam && g_nSteamMaxHeight && ctx->root_height > g_nSteamMaxHeight )
-			{
-				float steam_height_scale = g_nSteamMaxHeight / (float)ctx->root_height;
-				fs_height = g_nSteamMaxHeight;
-				fs_width  = ctx->root_width * steam_height_scale;
-			}
-
-			if ( w->GetGeometry().nWidth != fs_width || w->GetGeometry().nHeight != fs_height || globalScaleRatio != 1.0f )
-				XResizeWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, fs_width, fs_height);
-		}
-		else
-		{
-			if (ctx->focus.focusWindow->sizeHintsSpecified &&
-				((unsigned)ctx->focus.focusWindow->GetGeometry().nWidth != ctx->focus.focusWindow->requestedWidth ||
-				(unsigned)ctx->focus.focusWindow->GetGeometry().nHeight != ctx->focus.focusWindow->requestedHeight))
-			{
-				XResizeWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, ctx->focus.focusWindow->requestedWidth, ctx->focus.focusWindow->requestedHeight);
-			}
-		}
-	}
-	else
-	{
-		handle_desktop_window( w );
-	}
+	resize_window_to_desired_geometry( ctx, w );
 
 	Window	    root_return = None, parent_return = None;
 	Window	    *children = NULL;
@@ -5562,9 +5568,12 @@ handle_net_wm_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessageEv
 {
 	uint32_t action = (uint32_t)ev->data.l[0];
 	Atom *props = (Atom *)&ev->data.l[1];
+	bool fullscreenChanged = false;
 	for (size_t i = 0; i < 2; i++) {
 		if (props[i] == ctx->atoms.netWMStateFullscreenAtom) {
+			bool wasFullscreen = w->isFullscreen;
 			update_net_wm_state(action, &w->isFullscreen);
+			fullscreenChanged |= w->isFullscreen != wasFullscreen;
 			MakeFocusDirty();
 		} else if (props[i] == ctx->atoms.netWMStateSkipTaskbarAtom) {
 			update_net_wm_state(action, &w->skipTaskbar);
@@ -5576,6 +5585,9 @@ handle_net_wm_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessageEv
 			xwm_log.debugf("Unhandled NET_WM_STATE property change: %s", XGetAtomName(ctx->dpy, props[i]));
 		}
 	}
+
+	if (fullscreenChanged)
+		resize_window_to_desired_geometry( ctx, w );
 
 	Atom atoms[3];
 	int count = 0;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5970,19 +5970,62 @@ handle_net_wm_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessageEv
 {
 	uint32_t action = (uint32_t)ev->data.l[0];
 	Atom *props = (Atom *)&ev->data.l[1];
+	bool fullscreenChanged = false;
+	bool skipTaskbarChanged = false;
+	bool skipPagerChanged = false;
 	for (size_t i = 0; i < 2; i++) {
 		if (props[i] == ctx->atoms.netWMStateFullscreenAtom) {
+			bool wasFullscreen = w->isFullscreen;
 			update_net_wm_state(action, &w->isFullscreen);
+			fullscreenChanged |= w->isFullscreen != wasFullscreen;
 			MakeFocusDirty();
 		} else if (props[i] == ctx->atoms.netWMStateSkipTaskbarAtom) {
+			bool wasSkipTaskbar = w->skipTaskbar;
 			update_net_wm_state(action, &w->skipTaskbar);
+			skipTaskbarChanged |= w->skipTaskbar != wasSkipTaskbar;
 			MakeFocusDirty();
 		} else if (props[i] == ctx->atoms.netWMStateSkipPagerAtom) {
+			bool wasSkipPager = w->skipPager;
 			update_net_wm_state(action, &w->skipPager);
+			skipPagerChanged |= w->skipPager != wasSkipPager;
 			MakeFocusDirty();
 		} else if (props[i] != None) {
 			xwm_log.debugf("Unhandled NET_WM_STATE property change: %s", XGetAtomName(ctx->dpy, props[i]));
 		}
+	}
+
+	if (!fullscreenChanged && !skipTaskbarChanged && !skipPagerChanged)
+		return;
+
+	Atom type;
+	int format;
+	unsigned long nitems;
+	unsigned long bytesAfter;
+	unsigned char *data = nullptr;
+	std::vector<Atom> atoms;
+	if (XGetWindowProperty(ctx->dpy, w->xwayland().id, ctx->atoms.netWMStateAtom,
+			0, 2048, false, AnyPropertyType, &type, &format, &nitems, &bytesAfter,
+			&data) == Success && data) {
+		if (type == XA_ATOM)
+			atoms.assign((Atom *)data, (Atom *)data + nitems);
+		XFree(data);
+	}
+
+	std::erase_if(atoms, [&](Atom atom) {
+		return atom == ctx->atoms.netWMStateFullscreenAtom ||
+			   atom == ctx->atoms.netWMStateSkipTaskbarAtom ||
+			   atom == ctx->atoms.netWMStateSkipPagerAtom;
+	});
+
+	if (w->isFullscreen) atoms.push_back(ctx->atoms.netWMStateFullscreenAtom);
+	if (w->skipTaskbar) atoms.push_back(ctx->atoms.netWMStateSkipTaskbarAtom);
+	if (w->skipPager) atoms.push_back(ctx->atoms.netWMStateSkipPagerAtom);
+
+	if (atoms.empty()) {
+		XDeleteProperty(ctx->dpy, w->xwayland().id, ctx->atoms.netWMStateAtom);
+	} else {
+		XChangeProperty(ctx->dpy, w->xwayland().id, ctx->atoms.netWMStateAtom,
+				XA_ATOM, 32, PropModeReplace, (unsigned char*)atoms.data(), atoms.size());
 	}
 }
 


### PR DESCRIPTION
Gamescope honors `NET_WM_STATE` client messages by updating its internal window state, but never writes the property back onto the client window. Clients like Firefox only consider a state change acknowledged after receiving a `PropertyNotify` on that property, so fullscreen requests never completed (See Firefox bug [1867649](https://bugzilla.mozilla.org/show_bug.cgi?id=1867649)). This patch writes the state back to the window.

Tested using Firefox 153, and `gamescope -- firefox`, then navigating to YouTube and playing a video, and enabling and disabling fullscreen.

_Note: While I'm working on supporting running Firefox natively on Wayland in Gamescope, this is a fix for running it using XWayland._

@oSoMoN