### PR TITLE
subprojects: update libdisplay-info to 0.4.0

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -33,7 +33,7 @@ wlroots_dep = dependency(
 
 displayinfo_dep = dependency(
   'libdisplay-info',
-  version: ['>= 0.0.0', '< 0.4.0'],
+  version: ['>= 0.0.0', '< 0.5.0'],
   fallback: 'libdisplay-info',
   default_options: ['default_library=static'],
 )


### PR DESCRIPTION
Patching gamescope-3.16.25 it built fine:

```
$ ldd /usr/x86_64-pc-linux-gnu/bin/gamescope | grep libdisplay-info
        libdisplay-info.so.4 => /usr/x86_64-pc-linux-gnu/lib/libdisplay-info.so.4 (0x00007f528a898000)
```