### PR TITLE
VRR flicker mitigations

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -61,6 +61,7 @@ extern int g_nPreferredOutputWidth;
 extern int g_nPreferredOutputHeight;
 
 gamescope::ConVar<bool> cv_drm_single_plane_optimizations( "drm_single_plane_optimizations", true, "Whether or not to enable optimizations for single plane usage." );
+gamescope::ConVar<bool> cv_drm_reuse_last_composite( "drm_reuse_last_composite", true, "Present the last composited image again for repeated frames instead of compositing an identical one." );
 gamescope::ConVar<bool> cv_drm_cursor_plane( "drm_cursor_plane", false, "Scan out the cursor with the DRM cursor plane instead of forcing composition while a cursor is visible. Known driver issues on AMDGPU." );
 
 gamescope::ConVar<bool> cv_drm_debug_disable_shaper_and_3dlut( "drm_debug_disable_shaper_and_3dlut", false, "Shaper + 3DLUT chicken bit. (Force disable/DEFAULT, no logic change)" );
@@ -3750,40 +3751,49 @@ namespace gamescope
 			// in time so we don't lose layers.
 			bool bDefer = !bNeedsFullComposite && ( !m_bWasCompositing || m_bWasPartialCompositing );
 
-			// If doing a partial composition then remove the baseplane
-			// from our frameinfo to composite.
-			if ( !bNeedsFullComposite )
-			{
-				for ( int i = 1; i < compositeFrameInfo.layers.count(); i++ )
-					compositeFrameInfo.layers.get( i - 1 ) = compositeFrameInfo.layers.get( i );
-				compositeFrameInfo.layers.pop();
+			// Skipping the composite leaves the output ring in place, so the
+			// last composited image is still the one scanning out.
+			const bool bReuseLastComposite = cv_drm_reuse_last_composite &&
+				pFrameInfo->bRepeatFrame && bNeedsFullComposite &&
+				m_bWasCompositing && !m_bWasPartialCompositing;
 
-				// When doing partial composition, apply the shaper + 3D LUT stuff
-				// at scanout.
-				for ( uint32_t nEOTF = 0; nEOTF < EOTF_Count; nEOTF++ ) {
-					compositeFrameInfo.shaperLut[ nEOTF ] = nullptr;
-					compositeFrameInfo.lut3D[ nEOTF ] = nullptr;
+			if ( !bReuseLastComposite )
+			{
+				// If doing a partial composition then remove the baseplane
+				// from our frameinfo to composite.
+				if ( !bNeedsFullComposite )
+				{
+					for ( int i = 1; i < compositeFrameInfo.layers.count(); i++ )
+						compositeFrameInfo.layers.get( i - 1 ) = compositeFrameInfo.layers.get( i );
+					compositeFrameInfo.layers.pop();
+
+					// When doing partial composition, apply the shaper + 3D LUT stuff
+					// at scanout.
+					for ( uint32_t nEOTF = 0; nEOTF < EOTF_Count; nEOTF++ ) {
+						compositeFrameInfo.shaperLut[ nEOTF ] = nullptr;
+						compositeFrameInfo.lut3D[ nEOTF ] = nullptr;
+					}
 				}
+
+				// If using composite debug markers, make sure we mark them as partial
+				// so we know!
+				if ( bDefer && !!( g_uCompositeDebug & CompositeDebugFlag::Markers ) )
+					g_uCompositeDebug |= CompositeDebugFlag::Markers_Partial;
+
+				std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite );
+
+				m_bWasCompositing = true;
+
+				g_uCompositeDebug &= ~CompositeDebugFlag::Markers_Partial;
+
+				if ( !oCompositeResult )
+				{
+					xwm_log.errorf("vulkan_composite failed");
+					return -EINVAL;
+				}
+
+				vulkan_wait( *oCompositeResult, true );
 			}
-
-			// If using composite debug markers, make sure we mark them as partial
-			// so we know!
-			if ( bDefer && !!( g_uCompositeDebug & CompositeDebugFlag::Markers ) )
-				g_uCompositeDebug |= CompositeDebugFlag::Markers_Partial;
-
-			std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite );
-
-			m_bWasCompositing = true;
-
-			g_uCompositeDebug &= ~CompositeDebugFlag::Markers_Partial;
-
-			if ( !oCompositeResult )
-			{
-				xwm_log.errorf("vulkan_composite failed");
-				return -EINVAL;
-			}
-
-			vulkan_wait( *oCompositeResult, true );
 
 			FrameInfo_t presentCompFrameInfo = {};
 			presentCompFrameInfo.allowVRR = pFrameInfo->allowVRR;

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -59,6 +59,7 @@ extern int g_nPreferredOutputWidth;
 extern int g_nPreferredOutputHeight;
 
 gamescope::ConVar<bool> cv_drm_single_plane_optimizations( "drm_single_plane_optimizations", true, "Whether or not to enable optimizations for single plane usage." );
+gamescope::ConVar<bool> cv_drm_reuse_last_composite( "drm_reuse_last_composite", true, "Present the last composited image again for repeated frames instead of compositing an identical one." );
 gamescope::ConVar<bool> cv_drm_cursor_plane( "drm_cursor_plane", false, "Scan out the cursor with the DRM cursor plane instead of forcing composition while a cursor is visible. Known driver issues on AMDGPU." );
 
 gamescope::ConVar<bool> cv_drm_debug_disable_shaper_and_3dlut( "drm_debug_disable_shaper_and_3dlut", false, "Shaper + 3DLUT chicken bit. (Force disable/DEFAULT, no logic change)" );
@@ -3748,40 +3749,49 @@ namespace gamescope
 			// in time so we don't lose layers.
 			bool bDefer = !bNeedsFullComposite && ( !m_bWasCompositing || m_bWasPartialCompositing );
 
-			// If doing a partial composition then remove the baseplane
-			// from our frameinfo to composite.
-			if ( !bNeedsFullComposite )
-			{
-				for ( int i = 1; i < compositeFrameInfo.layerCount; i++ )
-					compositeFrameInfo.layers[i - 1] = compositeFrameInfo.layers[i];
-				compositeFrameInfo.layerCount -= 1;
+			// Skipping the composite leaves the output ring in place, so the
+			// last composited image is still the one scanning out.
+			const bool bReuseLastComposite = cv_drm_reuse_last_composite &&
+				pFrameInfo->bRepeatFrame && bNeedsFullComposite &&
+				m_bWasCompositing && !m_bWasPartialCompositing;
 
-				// When doing partial composition, apply the shaper + 3D LUT stuff
-				// at scanout.
-				for ( uint32_t nEOTF = 0; nEOTF < EOTF_Count; nEOTF++ ) {
-					compositeFrameInfo.shaperLut[ nEOTF ] = nullptr;
-					compositeFrameInfo.lut3D[ nEOTF ] = nullptr;
+			if ( !bReuseLastComposite )
+			{
+				// If doing a partial composition then remove the baseplane
+				// from our frameinfo to composite.
+				if ( !bNeedsFullComposite )
+				{
+					for ( int i = 1; i < compositeFrameInfo.layerCount; i++ )
+						compositeFrameInfo.layers[i - 1] = compositeFrameInfo.layers[i];
+					compositeFrameInfo.layerCount -= 1;
+
+					// When doing partial composition, apply the shaper + 3D LUT stuff
+					// at scanout.
+					for ( uint32_t nEOTF = 0; nEOTF < EOTF_Count; nEOTF++ ) {
+						compositeFrameInfo.shaperLut[ nEOTF ] = nullptr;
+						compositeFrameInfo.lut3D[ nEOTF ] = nullptr;
+					}
 				}
+
+				// If using composite debug markers, make sure we mark them as partial
+				// so we know!
+				if ( bDefer && !!( g_uCompositeDebug & CompositeDebugFlag::Markers ) )
+					g_uCompositeDebug |= CompositeDebugFlag::Markers_Partial;
+
+				std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite );
+
+				m_bWasCompositing = true;
+
+				g_uCompositeDebug &= ~CompositeDebugFlag::Markers_Partial;
+
+				if ( !oCompositeResult )
+				{
+					xwm_log.errorf("vulkan_composite failed");
+					return -EINVAL;
+				}
+
+				vulkan_wait( *oCompositeResult, true );
 			}
-
-			// If using composite debug markers, make sure we mark them as partial
-			// so we know!
-			if ( bDefer && !!( g_uCompositeDebug & CompositeDebugFlag::Markers ) )
-				g_uCompositeDebug |= CompositeDebugFlag::Markers_Partial;
-
-			std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite );
-
-			m_bWasCompositing = true;
-
-			g_uCompositeDebug &= ~CompositeDebugFlag::Markers_Partial;
-
-			if ( !oCompositeResult )
-			{
-				xwm_log.errorf("vulkan_composite failed");
-				return -EINVAL;
-			}
-
-			vulkan_wait( *oCompositeResult, true );
 
 			FrameInfo_t presentCompFrameInfo = {};
 			presentCompFrameInfo.allowVRR = pFrameInfo->allowVRR;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -290,6 +290,8 @@ struct FrameInfo_t
 	gamescope::Rc<CVulkanTexture> lut3D[EOTF_Count];
 
 	bool allowVRR;
+	// Content identical to the previous present, eg. an adaptive sync idle hold.
+	bool bRepeatFrame;
 	bool applyOutputColorMgmt; // drm only
 	EOTF outputEncodingEOTF;
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -293,6 +293,7 @@ gamescope::ConVar<bool> cv_adaptive_sync( "adaptive_sync", false, "Whether or no
 gamescope::ConVar<bool> cv_adaptive_sync_ignore_overlay( "adaptive_sync_ignore_overlay", false, "Whether or not to ignore overlay planes for pushing commits with adaptive sync." );
 gamescope::ConVar<int> cv_adaptive_sync_overlay_cycles( "adaptive_sync_overlay_cycles", 1, "Number of vblank cycles to ignore overlay repaints before forcing a commit with adaptive sync." );
 gamescope::ConVar<int> cv_adaptive_sync_cursor_min_fps( "adaptive_sync_cursor_min_fps", 30, "Content frame rate at or above which cursor repaints coalesce with content frames when adaptive sync is on. 0 = repaint the cursor immediately." );
+gamescope::ConVar<bool> cv_adaptive_sync_idle_hold( "adaptive_sync_idle_hold", true, "Hold the display at its refresh rate while the Steam UI is focused with adaptive sync." );
 
 gamescope::ConVar<bool> cv_upscale_preemptive( "upscale_preemptive", true, "Allow pre-emptive upscaling" );
 gamescope::ConVar<bool> cv_upscale_preemptive_debug_force_sync( "upscale_preemptive_debug_force_sync", false, "Force synchronize pre-emptive upscaling" );
@@ -9641,6 +9642,14 @@ steamcompmgr_main(int argc, char **argv)
 							{
 								bShouldPaint = true;
 							}
+						}
+
+						// Hold the panel at its refresh rate so it can't stretch toward
+						// the minimum and flicker. Games pace the display themselves.
+						if ( !bShouldPaint && bIsVBlankFromTimer && g_bSteamIsActiveWindow &&
+						     cv_adaptive_sync_idle_hold )
+						{
+							bShouldPaint = true;
 						}
 
 						if ( bIsVBlankFromTimer )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -292,6 +292,7 @@ update_runtime_info();
 gamescope::ConVar<bool> cv_adaptive_sync( "adaptive_sync", false, "Whether or not adaptive sync is enabled if available." );
 gamescope::ConVar<bool> cv_adaptive_sync_ignore_overlay( "adaptive_sync_ignore_overlay", false, "Whether or not to ignore overlay planes for pushing commits with adaptive sync." );
 gamescope::ConVar<int> cv_adaptive_sync_overlay_cycles( "adaptive_sync_overlay_cycles", 1, "Number of vblank cycles to ignore overlay repaints before forcing a commit with adaptive sync." );
+gamescope::ConVar<int> cv_adaptive_sync_cursor_min_fps( "adaptive_sync_cursor_min_fps", 30, "Content frame rate at or above which cursor repaints coalesce with content frames when adaptive sync is on. 0 = repaint the cursor immediately." );
 
 gamescope::ConVar<bool> cv_upscale_preemptive( "upscale_preemptive", true, "Allow pre-emptive upscaling" );
 gamescope::ConVar<bool> cv_upscale_preemptive_debug_force_sync( "upscale_preemptive_debug_force_sync", false, "Force synchronize pre-emptive upscaling" );
@@ -913,6 +914,7 @@ uint32_t		lastPublishedInputCounter;
 
 std::atomic<bool> hasRepaint = false;
 bool			hasRepaintNonBasePlane = false;
+std::atomic<bool> hasCursorRepaint = false;
 
 bool			g_bUpdateForwardedVROverlays = false;
 
@@ -1812,9 +1814,9 @@ void MouseCursor::checkSuspension()
 				}
 			}
 
-			// We're hiding the cursor, force redraw if we were showing it
+			// We're hiding the cursor, repaint if we were showing it
 			if (window && !m_imageEmpty ) {
-				hasRepaintNonBasePlane = true;
+				hasCursorRepaint = true;
 				nudge_steamcompmgr();
 			}
 		}
@@ -9519,6 +9521,7 @@ steamcompmgr_main(int argc, char **argv)
 		bool bPainted = false;
 
 		static int nIgnoredOverlayRepaints = 0;
+		static uint64_t s_ulLastContentPaintTime = 0;
 
 		if ( !hasRepaintNonBasePlane )
 			nIgnoredOverlayRepaints = 0;
@@ -9610,13 +9613,13 @@ steamcompmgr_main(int argc, char **argv)
 				{
 					case FlipType::Normal:
 					{
-						bShouldPaint = vblank && ( hasRepaint || hasRepaintNonBasePlane || bForceSyncFlip );
+						bShouldPaint = vblank && ( hasRepaint || hasRepaintNonBasePlane || hasCursorRepaint || bForceSyncFlip );
 						break;
 					}
 
 					case FlipType::Async:
 					{
-						bShouldPaint = hasRepaint;
+						bShouldPaint = hasRepaint || hasCursorRepaint;
 
 						if ( vblank && !bShouldPaint && hasRepaintNonBasePlane )
 							nIgnoredOverlayRepaints++;
@@ -9627,6 +9630,18 @@ steamcompmgr_main(int argc, char **argv)
 					case FlipType::VRR:
 					{
 						bShouldPaint = hasRepaint;
+
+						// A game presenting at or above adaptive_sync_cursor_min_fps paces
+						// the display alone, cursor damage rides along with its frames.
+						if ( !bShouldPaint && hasCursorRepaint )
+						{
+							const int nCursorMinFPS = cv_adaptive_sync_cursor_min_fps;
+							if ( nCursorMinFPS <= 0 ||
+							     get_time_in_nanos() - s_ulLastContentPaintTime >= 1'000'000'000ul / uint64_t( nCursorMinFPS ) )
+							{
+								bShouldPaint = true;
+							}
+						}
 
 						if ( bIsVBlankFromTimer )
 						{
@@ -9684,8 +9699,12 @@ steamcompmgr_main(int argc, char **argv)
 		{
 			GetBackend()->OnEndFrame();
 
+			if ( hasRepaint )
+				s_ulLastContentPaintTime = get_time_in_nanos();
+
 			hasRepaint = false;
 			hasRepaintNonBasePlane = false;
+			hasCursorRepaint = false;
 			nIgnoredOverlayRepaints = 0;
 
 			{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2742,7 +2742,7 @@ gamescope::ConVar<bool> cv_paint_cursor_plane{ "paint_cursor_plane", true };
 gamescope::ConVar<bool> cv_paint_mura_plane{ "paint_mura_plane", true };
 
 static void
-paint_all( global_focus_t *pFocus, bool async )
+paint_all( global_focus_t *pFocus, bool async, bool bRepeatFrame )
 {
 	if ( !pFocus )
 		return;
@@ -2802,6 +2802,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	frameInfo.applyOutputColorMgmt = g_ColorMgmt.pending.enabled;
 	frameInfo.outputEncodingEOTF = g_ColorMgmt.pending.outputEncodingEOTF;
 	frameInfo.allowVRR = cv_adaptive_sync;
+	frameInfo.bRepeatFrame = bRepeatFrame;
 	frameInfo.bFadingOut = fadingOut;
 
 	// If the window we'd paint as the base layer is the streaming client,
@@ -9533,6 +9534,7 @@ steamcompmgr_main(int argc, char **argv)
 		for ( auto &iter : g_VirtualConnectorFocuses )
 		{
 			global_focus_t *pPaintFocus = &iter.second;
+			bool bRepeatFrame = false;
 
 			if ( vblank )
 			{
@@ -9650,6 +9652,8 @@ steamcompmgr_main(int argc, char **argv)
 						     cv_adaptive_sync_idle_hold )
 						{
 							bShouldPaint = true;
+							// Cursor or overlay damage must really be drawn, only unchanged frames repeat.
+							bRepeatFrame = !hasRepaint && !hasCursorRepaint && !hasRepaintNonBasePlane;
 						}
 
 						if ( bIsVBlankFromTimer )
@@ -9689,7 +9693,7 @@ steamcompmgr_main(int argc, char **argv)
 
 			if ( bShouldPaint )
 			{
-				paint_all( pPaintFocus, eFlipType == FlipType::Async );
+				paint_all( pPaintFocus, eFlipType == FlipType::Async, bRepeatFrame );
 
 				bPainted = true;
 			}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2510,7 +2510,7 @@ gamescope::ConVar<bool> cv_paint_cursor_plane{ "paint_cursor_plane", true };
 gamescope::ConVar<bool> cv_paint_mura_plane{ "paint_mura_plane", true };
 
 static void
-paint_all( global_focus_t *pFocus, bool async )
+paint_all( global_focus_t *pFocus, bool async, bool bRepeatFrame )
 {
 	if ( !pFocus )
 		return;
@@ -2567,6 +2567,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	frameInfo.applyOutputColorMgmt = g_ColorMgmt.pending.enabled;
 	frameInfo.outputEncodingEOTF = g_ColorMgmt.pending.outputEncodingEOTF;
 	frameInfo.allowVRR = cv_adaptive_sync;
+	frameInfo.bRepeatFrame = bRepeatFrame;
 	frameInfo.bFadingOut = fadingOut;
 
 	// If the window we'd paint as the base layer is the streaming client,
@@ -9022,6 +9023,7 @@ steamcompmgr_main(int argc, char **argv)
 		for ( auto &iter : g_VirtualConnectorFocuses )
 		{
 			global_focus_t *pPaintFocus = &iter.second;
+			bool bRepeatFrame = false;
 
 			if ( vblank )
 			{
@@ -9139,6 +9141,8 @@ steamcompmgr_main(int argc, char **argv)
 						     cv_adaptive_sync_idle_hold )
 						{
 							bShouldPaint = true;
+							// Cursor or overlay damage must really be drawn, only unchanged frames repeat.
+							bRepeatFrame = !hasRepaint && !hasCursorRepaint && !hasRepaintNonBasePlane;
 						}
 
 						if ( bIsVBlankFromTimer )
@@ -9178,7 +9182,7 @@ steamcompmgr_main(int argc, char **argv)
 
 			if ( bShouldPaint )
 			{
-				paint_all( pPaintFocus, eFlipType == FlipType::Async );
+				paint_all( pPaintFocus, eFlipType == FlipType::Async, bRepeatFrame );
 
 				bPainted = true;
 			}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -295,6 +295,7 @@ update_runtime_info();
 gamescope::ConVar<bool> cv_adaptive_sync( "adaptive_sync", false, "Whether or not adaptive sync is enabled if available." );
 gamescope::ConVar<bool> cv_adaptive_sync_ignore_overlay( "adaptive_sync_ignore_overlay", false, "Whether or not to ignore overlay planes for pushing commits with adaptive sync." );
 gamescope::ConVar<int> cv_adaptive_sync_overlay_cycles( "adaptive_sync_overlay_cycles", 1, "Number of vblank cycles to ignore overlay repaints before forcing a commit with adaptive sync." );
+gamescope::ConVar<int> cv_adaptive_sync_cursor_min_fps( "adaptive_sync_cursor_min_fps", 30, "Content frame rate at or above which cursor repaints coalesce with content frames when adaptive sync is on. 0 = repaint the cursor immediately." );
 
 gamescope::ConVar<bool> cv_upscale_preemptive( "upscale_preemptive", true, "Allow pre-emptive upscaling" );
 gamescope::ConVar<bool> cv_upscale_preemptive_debug_force_sync( "upscale_preemptive_debug_force_sync", false, "Force synchronize pre-emptive upscaling" );
@@ -916,6 +917,7 @@ uint32_t		lastPublishedInputCounter;
 
 std::atomic<bool> hasRepaint = false;
 bool			hasRepaintNonBasePlane = false;
+std::atomic<bool> hasCursorRepaint = false;
 
 bool			g_bUpdateForwardedVROverlays = false;
 
@@ -1623,9 +1625,9 @@ void MouseCursor::checkSuspension()
 				}
 			}
 
-			// We're hiding the cursor, force redraw if we were showing it
+			// We're hiding the cursor, repaint if we were showing it
 			if (window && !m_imageEmpty ) {
-				hasRepaintNonBasePlane = true;
+				hasCursorRepaint = true;
 				nudge_steamcompmgr();
 			}
 		}
@@ -9008,6 +9010,7 @@ steamcompmgr_main(int argc, char **argv)
 		bool bPainted = false;
 
 		static int nIgnoredOverlayRepaints = 0;
+		static uint64_t s_ulLastContentPaintTime = 0;
 
 		if ( !hasRepaintNonBasePlane )
 			nIgnoredOverlayRepaints = 0;
@@ -9099,13 +9102,13 @@ steamcompmgr_main(int argc, char **argv)
 				{
 					case FlipType::Normal:
 					{
-						bShouldPaint = vblank && ( hasRepaint || hasRepaintNonBasePlane || bForceSyncFlip );
+						bShouldPaint = vblank && ( hasRepaint || hasRepaintNonBasePlane || hasCursorRepaint || bForceSyncFlip );
 						break;
 					}
 
 					case FlipType::Async:
 					{
-						bShouldPaint = hasRepaint;
+						bShouldPaint = hasRepaint || hasCursorRepaint;
 
 						if ( vblank && !bShouldPaint && hasRepaintNonBasePlane )
 							nIgnoredOverlayRepaints++;
@@ -9116,6 +9119,18 @@ steamcompmgr_main(int argc, char **argv)
 					case FlipType::VRR:
 					{
 						bShouldPaint = hasRepaint;
+
+						// A game presenting at or above adaptive_sync_cursor_min_fps paces
+						// the display alone, cursor damage rides along with its frames.
+						if ( !bShouldPaint && hasCursorRepaint )
+						{
+							const int nCursorMinFPS = cv_adaptive_sync_cursor_min_fps;
+							if ( nCursorMinFPS <= 0 ||
+							     get_time_in_nanos() - s_ulLastContentPaintTime >= 1'000'000'000ul / uint64_t( nCursorMinFPS ) )
+							{
+								bShouldPaint = true;
+							}
+						}
 
 						if ( bIsVBlankFromTimer )
 						{
@@ -9173,8 +9188,12 @@ steamcompmgr_main(int argc, char **argv)
 		{
 			GetBackend()->OnEndFrame();
 
+			if ( hasRepaint )
+				s_ulLastContentPaintTime = get_time_in_nanos();
+
 			hasRepaint = false;
 			hasRepaintNonBasePlane = false;
+			hasCursorRepaint = false;
 			nIgnoredOverlayRepaints = 0;
 
 			{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -296,6 +296,7 @@ gamescope::ConVar<bool> cv_adaptive_sync( "adaptive_sync", false, "Whether or no
 gamescope::ConVar<bool> cv_adaptive_sync_ignore_overlay( "adaptive_sync_ignore_overlay", false, "Whether or not to ignore overlay planes for pushing commits with adaptive sync." );
 gamescope::ConVar<int> cv_adaptive_sync_overlay_cycles( "adaptive_sync_overlay_cycles", 1, "Number of vblank cycles to ignore overlay repaints before forcing a commit with adaptive sync." );
 gamescope::ConVar<int> cv_adaptive_sync_cursor_min_fps( "adaptive_sync_cursor_min_fps", 30, "Content frame rate at or above which cursor repaints coalesce with content frames when adaptive sync is on. 0 = repaint the cursor immediately." );
+gamescope::ConVar<bool> cv_adaptive_sync_idle_hold( "adaptive_sync_idle_hold", true, "Hold the display at its refresh rate while the Steam UI is focused with adaptive sync." );
 
 gamescope::ConVar<bool> cv_upscale_preemptive( "upscale_preemptive", true, "Allow pre-emptive upscaling" );
 gamescope::ConVar<bool> cv_upscale_preemptive_debug_force_sync( "upscale_preemptive_debug_force_sync", false, "Force synchronize pre-emptive upscaling" );
@@ -9130,6 +9131,14 @@ steamcompmgr_main(int argc, char **argv)
 							{
 								bShouldPaint = true;
 							}
+						}
+
+						// Hold the panel at its refresh rate so it can't stretch toward
+						// the minimum and flicker. Games pace the display themselves.
+						if ( !bShouldPaint && bIsVBlankFromTimer && g_bSteamIsActiveWindow &&
+						     cv_adaptive_sync_idle_hold )
+						{
+							bShouldPaint = true;
 						}
 
 						if ( bIsVBlankFromTimer )

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -115,6 +115,7 @@ struct wlr_surface *wlserver_surface_to_main_surface( struct wlr_surface *pSurfa
 bool wlserver_process_hotkeys( wlr_keyboard *keyboard, uint32_t key, bool press );
 
 extern std::atomic<bool> hasRepaint;
+extern std::atomic<bool> hasCursorRepaint;
 
 std::vector<ResListEntry_t>& gamescope_xwayland_server_t::retrieve_commits()
 {
@@ -2543,7 +2544,7 @@ void wlserver_oncursorevent()
 
 	if ( !wlserver.bCursorHidden && wlserver.bCursorHasImage )
 	{
-		hasRepaint = true;
+		hasCursorRepaint = true;
 	}
 }
 
@@ -2616,7 +2617,7 @@ void wlserver_mousehide()
 	if ( wlserver.bCursorHidden != true )
 	{
 		wlserver.bCursorHidden = true;
-		hasRepaint = true;
+		hasCursorRepaint = true;
 	}
 }
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -116,6 +116,7 @@ struct wlr_surface *wlserver_surface_to_main_surface( struct wlr_surface *pSurfa
 bool wlserver_process_hotkeys( wlr_keyboard *keyboard, uint32_t key, bool press );
 
 extern std::atomic<bool> hasRepaint;
+extern std::atomic<bool> hasCursorRepaint;
 
 std::vector<ResListEntry_t>& gamescope_xwayland_server_t::retrieve_commits()
 {
@@ -2561,7 +2562,7 @@ void wlserver_oncursorevent()
 
 	if ( !wlserver.bCursorHidden && wlserver.bCursorHasImage )
 	{
-		hasRepaint = true;
+		hasCursorRepaint = true;
 	}
 }
 
@@ -2634,7 +2635,7 @@ void wlserver_mousehide()
 	if ( wlserver.bCursorHidden != true )
 	{
 		wlserver.bCursorHidden = true;
-		hasRepaint = true;
+		hasCursorRepaint = true;
 	}
 }
 


### PR DESCRIPTION
At present, when VRR is enabled but Steam is idle, displays drop to the bottom of their VRR-supported range on every idle. Then, when Steam exits an idle state, the refresh rate spikes back up to its maximum value, and on panels which are prone to VRR flicker, this process causes some pretty nasty flickering while navigating the Steam UI.

Mitigate this by holding the refresh rate while the Steam UI is focused. I checked power readings and there is minimal difference by doing this compared to keeping monitors at their minimum value, but the visible flicker still completely disappears. It's targeted only while the Steam UI is focused, as we want to make sure games still interact with VRR as cleanly as possible and keep LFC functioning correctly. The last commit skips recompositing for these repeated frames and presents the last composited image again, which is what keeps the power cost minimal.

Also, clamp the cursor to active content refresh rate when it's above a minimum threshold while VRR is enabled, mimicking KWin's implementation, as it offers a better user experience than spiking to max refresh rate every time the cursor moves while VRR is active in-game.