### PR TITLE
Frame limiter fixes for VR

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -5,11 +5,17 @@
 #include "xcb_helpers.hpp"
 #include "vulkan_operators.hpp"
 #include "gamescope-swapchain-client-protocol.h"
+#include "gamescope-limiter-client-protocol.h"
 #include "../src/color_helpers.h"
 #include "../src/layer_defines.h"
 
+#include <atomic>
+#include <cerrno>
 #include <charconv>
 #include <cstdio>
+#include <cstring>
+#include <memory>
+#include <utility>
 #include <vector>
 #include <algorithm>
 #include <functional>
@@ -319,11 +325,29 @@ namespace GamescopeWSILayer {
     return flags;
   }
 
-  // TODO: Maybe move to Wayland event or something.
-  // This just utilizes the same code as the Mesa path used
-  // for without the layer or GL though. Need to keep it around anyway.
+  // Frame limiter state received over the gamescope_limiter protocol.
+  // Owned by the surfaces holding copies of GamescopeWaylandObjects.
+  struct GamescopeLimiterState {
+    ~GamescopeLimiterState() {
+      if (proxy)
+        gamescope_limiter_destroy(proxy);
+    }
+
+    gamescope_limiter *proxy = nullptr;
+    std::atomic<uint32_t> state = { 0 };
+  };
+
+  static constexpr gamescope_limiter_listener s_limiterListener = {
+    .state = [](void *data, gamescope_limiter *limiter, uint32_t frameLimitState) {
+      reinterpret_cast<GamescopeLimiterState *>(data)->state = frameLimitState;
+    },
+  };
+
+  // Legacy fallback for compositors without gamescope_limiter. The Mesa DRI3
+  // path on SteamOS uses the same file. It may not be visible inside app
+  // containers.
   static std::mutex gamescopeSwapchainLimiterFDMutex;
-  static uint32_t gamescopeFrameLimiterOverride() {
+  static uint32_t gamescopeFrameLimiterFileOverride() {
     const char *path = getenv("GAMESCOPE_LIMITER_FILE");
     if (!path)
         return 0;
@@ -333,9 +357,13 @@ namespace GamescopeWSILayer {
       std::unique_lock lock(gamescopeSwapchainLimiterFDMutex);
 
       static int s_limiterFD = -1;
+      static bool s_warnedOpenFailure = false;
 
-      if (s_limiterFD < 0)
+      if (s_limiterFD < 0) {
         s_limiterFD = open(path, O_RDONLY);
+        if (s_limiterFD < 0 && !std::exchange(s_warnedOpenFailure, true))
+          fprintf(stderr, "[Gamescope WSI] Could not open GAMESCOPE_LIMITER_FILE (%s): %s\n", path, strerror(errno));
+      }
 
       fd = s_limiterFD;
     }
@@ -348,13 +376,10 @@ namespace GamescopeWSILayer {
     return overrideValue;
   }
 
-  static bool gamescopeIsForcingFifo() {
-    return gamescopeFrameLimiterOverride() == 1;
-  }
-
   struct GamescopeWaylandObjects {
     wl_compositor* compositor;
     gamescope_swapchain_factory_v2* gamescopeSwapchainFactory;
+    std::shared_ptr<GamescopeLimiterState> limiterState;
 
     static GamescopeWaylandObjects get(wl_display *display) {
       wl_registry *registry = wl_display_get_registry(display);
@@ -385,11 +410,24 @@ namespace GamescopeWSILayer {
       } else if (interface == "gamescope_swapchain_factory_v2"sv) {
         objects->gamescopeSwapchainFactory = reinterpret_cast<gamescope_swapchain_factory_v2 *>(
           wl_registry_bind(registry, name, &gamescope_swapchain_factory_v2_interface, version));
+      } else if (interface == "gamescope_limiter"sv) {
+        objects->limiterState = std::make_shared<GamescopeLimiterState>();
+        // Cap at our version, binding higher is a fatal protocol error.
+        objects->limiterState->proxy = reinterpret_cast<gamescope_limiter *>(
+          wl_registry_bind(registry, name, &gamescope_limiter_interface, std::min(version, uint32_t(gamescope_limiter_interface.version))));
+        gamescope_limiter_add_listener(objects->limiterState->proxy, &s_limiterListener, objects->limiterState.get());
       }
     },
     .global_remove = [](void* data, wl_registry* registry, uint32_t name) {
     },
   };
+
+  static bool gamescopeIsForcingFifo(const GamescopeWaylandObjects& waylandObjects) {
+    if (waylandObjects.limiterState)
+      return waylandObjects.limiterState->state == 1;
+
+    return gamescopeFrameLimiterFileOverride() == 1;
+  }
 
   struct GamescopeInstanceData {
     wl_display* display;
@@ -906,7 +944,7 @@ namespace GamescopeWSILayer {
         return pDispatch->GetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities);
 
       // Incomplete writes here, do not return VK_INCOMPLETE.
-      if (gamescopeIsForcingFifo() && gamescopeSurface->frameLimiterAware()) {
+      if (gamescopeIsForcingFifo(gamescopeSurface->waylandObjects) && gamescopeSurface->frameLimiterAware()) {
         const auto *pPresentMode = vkroots::FindInChain<VkSurfacePresentModeEXT>(pSurfaceInfo);
         const std::array<VkPresentModeKHR, 1> s_SingleMode = {{
           pPresentMode ? pPresentMode->presentMode : VK_PRESENT_MODE_FIFO_KHR,
@@ -964,7 +1002,7 @@ namespace GamescopeWSILayer {
       }};
 
       if (auto state = GamescopeSurface::get(surface)) {
-        if (gamescopeIsForcingFifo() && state->frameLimiterAware())
+        if (gamescopeIsForcingFifo(state->waylandObjects) && state->frameLimiterAware())
           return vkroots::helpers::array(s_FifoPresentModes, pPresentModeCount, pPresentModes);
       }
 
@@ -1280,7 +1318,7 @@ namespace GamescopeWSILayer {
           .surface             = pCreateInfo->surface, // Always the Wayland side surface.
           .isWayland           = gamescopeSurface->isWayland(),
           .isBypassingXWayland = canBypass,
-          .forceFifo           = gamescopeIsForcingFifo(), // Were we forcing fifo when this swapchain was made?
+          .forceFifo           = gamescopeIsForcingFifo(gamescopeSurface->waylandObjects), // Were we forcing fifo when this swapchain was made?
           .presentMode         = pCreateInfo->presentMode, // The new present mode.
           .extent              = pCreateInfo->imageExtent,
           .serverId            = serverId,
@@ -1398,8 +1436,6 @@ namespace GamescopeWSILayer {
       const VkPresentInfoKHR*          pPresentInfo) {
       VkPresentInfoKHR presentInfo = *pPresentInfo;
 
-      bool forceFifo = gamescopeIsForcingFifo();
-
       auto pPresentTimes = vkroots::FindInChain<const VkPresentTimesInfoGOOGLE>(&presentInfo);
 
       wl_display *display = nullptr;
@@ -1477,6 +1513,17 @@ namespace GamescopeWSILayer {
           s_warned = true;
         }
       }
+
+      // After the pump, so the state reflects events received this frame.
+      bool forceFifo = [&]() {
+        for (uint32_t i = 0; i < presentInfo.swapchainCount; i++) {
+          if (auto gamescopeSwapchain = GamescopeSwapchain::get(presentInfo.pSwapchains[i])) {
+            if (auto gamescopeSurface = GamescopeSurface::get(gamescopeSwapchain->surface))
+              return gamescopeIsForcingFifo(gamescopeSurface->waylandObjects);
+          }
+        }
+        return false;
+      }();
 
       for (uint32_t i = 0; i < presentInfo.swapchainCount; i++) {
         if (auto gamescopeSwapchain = GamescopeSwapchain::get(presentInfo.pSwapchains[i])) {

--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -5,11 +5,17 @@
 #include "xcb_helpers.hpp"
 #include "vulkan_operators.hpp"
 #include "gamescope-swapchain-client-protocol.h"
+#include "gamescope-limiter-client-protocol.h"
 #include "../src/color_helpers.h"
 #include "../src/layer_defines.h"
 
+#include <atomic>
+#include <cerrno>
 #include <charconv>
 #include <cstdio>
+#include <cstring>
+#include <memory>
+#include <utility>
 #include <vector>
 #include <algorithm>
 #include <functional>
@@ -319,11 +325,29 @@ namespace GamescopeWSILayer {
     return flags;
   }
 
-  // TODO: Maybe move to Wayland event or something.
-  // This just utilizes the same code as the Mesa path used
-  // for without the layer or GL though. Need to keep it around anyway.
+  // Frame limiter state received over the gamescope_limiter protocol.
+  // Owned by the surfaces holding copies of GamescopeWaylandObjects.
+  struct GamescopeLimiterState {
+    ~GamescopeLimiterState() {
+      if (proxy)
+        gamescope_limiter_destroy(proxy);
+    }
+
+    gamescope_limiter *proxy = nullptr;
+    std::atomic<uint32_t> state = { 0 };
+  };
+
+  static constexpr gamescope_limiter_listener s_limiterListener = {
+    .state = [](void *data, gamescope_limiter *limiter, uint32_t frameLimitState) {
+      reinterpret_cast<GamescopeLimiterState *>(data)->state = frameLimitState;
+    },
+  };
+
+  // Legacy fallback for compositors without gamescope_limiter. The Mesa DRI3
+  // path on SteamOS uses the same file. It may not be visible inside app
+  // containers.
   static std::mutex gamescopeSwapchainLimiterFDMutex;
-  static uint32_t gamescopeFrameLimiterOverride() {
+  static uint32_t gamescopeFrameLimiterFileOverride() {
     const char *path = getenv("GAMESCOPE_LIMITER_FILE");
     if (!path)
         return 0;
@@ -333,9 +357,13 @@ namespace GamescopeWSILayer {
       std::unique_lock lock(gamescopeSwapchainLimiterFDMutex);
 
       static int s_limiterFD = -1;
+      static bool s_warnedOpenFailure = false;
 
-      if (s_limiterFD < 0)
+      if (s_limiterFD < 0) {
         s_limiterFD = open(path, O_RDONLY);
+        if (s_limiterFD < 0 && !std::exchange(s_warnedOpenFailure, true))
+          fprintf(stderr, "[Gamescope WSI] Could not open GAMESCOPE_LIMITER_FILE (%s): %s\n", path, strerror(errno));
+      }
 
       fd = s_limiterFD;
     }
@@ -348,13 +376,10 @@ namespace GamescopeWSILayer {
     return overrideValue;
   }
 
-  static bool gamescopeIsForcingFifo() {
-    return gamescopeFrameLimiterOverride() == 1;
-  }
-
   struct GamescopeWaylandObjects {
     wl_compositor* compositor;
     gamescope_swapchain_factory_v2* gamescopeSwapchainFactory;
+    std::shared_ptr<GamescopeLimiterState> limiterState;
 
     static GamescopeWaylandObjects get(wl_display *display) {
       wl_registry *registry = wl_display_get_registry(display);
@@ -385,11 +410,24 @@ namespace GamescopeWSILayer {
       } else if (interface == "gamescope_swapchain_factory_v2"sv) {
         objects->gamescopeSwapchainFactory = reinterpret_cast<gamescope_swapchain_factory_v2 *>(
           wl_registry_bind(registry, name, &gamescope_swapchain_factory_v2_interface, version));
+      } else if (interface == "gamescope_limiter"sv) {
+        objects->limiterState = std::make_shared<GamescopeLimiterState>();
+        // Cap at our version, binding higher is a fatal protocol error.
+        objects->limiterState->proxy = reinterpret_cast<gamescope_limiter *>(
+          wl_registry_bind(registry, name, &gamescope_limiter_interface, std::min(version, uint32_t(gamescope_limiter_interface.version))));
+        gamescope_limiter_add_listener(objects->limiterState->proxy, &s_limiterListener, objects->limiterState.get());
       }
     },
     .global_remove = [](void* data, wl_registry* registry, uint32_t name) {
     },
   };
+
+  static bool gamescopeIsForcingFifo(const GamescopeWaylandObjects& waylandObjects) {
+    if (waylandObjects.limiterState)
+      return waylandObjects.limiterState->state == 1;
+
+    return gamescopeFrameLimiterFileOverride() == 1;
+  }
 
   struct GamescopeInstanceData {
     wl_display* display;
@@ -906,7 +944,7 @@ namespace GamescopeWSILayer {
         return pDispatch->GetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities);
 
       // Incomplete writes here, do not return VK_INCOMPLETE.
-      if (gamescopeIsForcingFifo() && gamescopeSurface->frameLimiterAware()) {
+      if (gamescopeIsForcingFifo(gamescopeSurface->waylandObjects) && gamescopeSurface->frameLimiterAware()) {
         const auto *pPresentMode = vkroots::FindInChain<VkSurfacePresentModeEXT>(pSurfaceInfo);
         const std::array<VkPresentModeKHR, 1> s_SingleMode = {{
           pPresentMode ? pPresentMode->presentMode : VK_PRESENT_MODE_FIFO_KHR,
@@ -964,7 +1002,7 @@ namespace GamescopeWSILayer {
       }};
 
       if (auto state = GamescopeSurface::get(surface)) {
-        if (gamescopeIsForcingFifo() && state->frameLimiterAware())
+        if (gamescopeIsForcingFifo(state->waylandObjects) && state->frameLimiterAware())
           return vkroots::helpers::array(s_FifoPresentModes, pPresentModeCount, pPresentModes);
       }
 
@@ -1280,7 +1318,7 @@ namespace GamescopeWSILayer {
           .surface             = pCreateInfo->surface, // Always the Wayland side surface.
           .isWayland           = gamescopeSurface->isWayland(),
           .isBypassingXWayland = canBypass,
-          .forceFifo           = gamescopeIsForcingFifo(), // Were we forcing fifo when this swapchain was made?
+          .forceFifo           = gamescopeIsForcingFifo(gamescopeSurface->waylandObjects), // Were we forcing fifo when this swapchain was made?
           .presentMode         = pCreateInfo->presentMode, // The new present mode.
           .extent              = pCreateInfo->imageExtent,
           .serverId            = serverId,
@@ -1350,8 +1388,6 @@ namespace GamescopeWSILayer {
             VkQueue                    queue,
       const VkPresentInfoKHR*          pPresentInfo) {
       VkPresentInfoKHR presentInfo = *pPresentInfo;
-
-      bool forceFifo = gamescopeIsForcingFifo();
 
       auto pPresentTimes = vkroots::FindInChain<const VkPresentTimesInfoGOOGLE>(&presentInfo);
 
@@ -1430,6 +1466,17 @@ namespace GamescopeWSILayer {
           s_warned = true;
         }
       }
+
+      // After the pump, so the state reflects events received this frame.
+      bool forceFifo = [&]() {
+        for (uint32_t i = 0; i < presentInfo.swapchainCount; i++) {
+          if (auto gamescopeSwapchain = GamescopeSwapchain::get(presentInfo.pSwapchains[i])) {
+            if (auto gamescopeSurface = GamescopeSurface::get(gamescopeSwapchain->surface))
+              return gamescopeIsForcingFifo(gamescopeSurface->waylandObjects);
+          }
+        }
+        return false;
+      }();
 
       for (uint32_t i = 0; i < presentInfo.swapchainCount; i++) {
         if (auto gamescopeSwapchain = GamescopeSwapchain::get(presentInfo.pSwapchains[i])) {

--- a/protocol/gamescope-limiter.xml
+++ b/protocol/gamescope-limiter.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="gamescope_limiter">
+
+  <copyright>
+    Copyright © 2026 Valve Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="frame limiter state feedback">
+    Feedback about gamescope's frame limiter for presenting clients. Any
+    client may bind this interface, it carries no privileged requests.
+  </description>
+
+  <interface name="gamescope_limiter" version="1">
+    <description summary="frame limiter state">
+      Broadcasts the compositor's frame limiter state to presentation
+      layers. This supersedes the GAMESCOPE_LIMITER_FILE mechanism, which
+      relies on a file that may not be visible inside app containers.
+    </description>
+
+    <request name="destroy" type="destructor"></request>
+
+    <event name="state">
+      <description summary="current frame limiter state">
+        Sent once when the client binds and again whenever the state
+        changes. The values match the legacy GAMESCOPE_LIMITER_FILE
+        contents. 1 means the frame limiter is engaged and clients should
+        present in FIFO so the compositor can pace them. 0 means no
+        override. Other values are reserved.
+      </description>
+      <arg name="frame_limit_state" type="uint" summary="1 = present in FIFO, 0 = no override"/>
+    </event>
+  </interface>
+</protocol>

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -38,6 +38,7 @@ protocols = [
 	'gamescope-control.xml',
 	'gamescope-reshade.xml',
 	'gamescope-swapchain.xml',
+	'gamescope-limiter.xml',
 	'gamescope-private.xml',
 	'gamescope-action-binding.xml',
 

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -39,6 +39,7 @@ protocols = [
 	'gamescope-control.xml',
 	'gamescope-reshade.xml',
 	'gamescope-swapchain.xml',
+	'gamescope-limiter.xml',
 	'gamescope-private.xml',
 	'gamescope-action-binding.xml',
 

--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -106,6 +106,42 @@ namespace gamescope::Process
         return nPids;
     }
 
+    bool IsProcessRunning( const char *pszComm )
+    {
+        DIR *pProcDir = opendir( "/proc" );
+        if ( !pProcDir )
+            return false;
+        defer( closedir( pProcDir ) );
+
+        struct dirent *pEntry;
+        while ( ( pEntry = readdir( pProcDir ) ) )
+        {
+            if ( pEntry->d_type != DT_DIR )
+                continue;
+
+            if ( !IsDigit( pEntry->d_name[0] ) )
+                continue;
+
+            char szPath[ PATH_MAX ];
+            snprintf( szPath, sizeof( szPath ), "/proc/%s/comm", pEntry->d_name );
+
+            FILE *pCommFile = fopen( szPath, "r" );
+            if ( !pCommFile )
+                continue;
+            defer( fclose( pCommFile ) );
+
+            char szComm[ 32 ] = {};
+            if ( !fgets( szComm, sizeof( szComm ), pCommFile ) )
+                continue;
+            szComm[ strcspn( szComm, "\n" ) ] = '\0';
+
+            if ( !strcmp( szComm, pszComm ) )
+                return true;
+        }
+
+        return false;
+    }
+
     void KillProcessTree( std::vector<pid_t> nPids, int nSignal )
     {
         for ( pid_t nPid : nPids )

--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 
 #include <errno.h>
 #include <pthread.h>
@@ -98,6 +99,42 @@ namespace gamescope::Process
         }
 
         return nPids;
+    }
+
+    bool IsProcessRunning( const char *pszComm )
+    {
+        DIR *pProcDir = opendir( "/proc" );
+        if ( !pProcDir )
+            return false;
+        defer( closedir( pProcDir ) );
+
+        struct dirent *pEntry;
+        while ( ( pEntry = readdir( pProcDir ) ) )
+        {
+            if ( pEntry->d_type != DT_DIR )
+                continue;
+
+            if ( !IsDigit( pEntry->d_name[0] ) )
+                continue;
+
+            char szPath[ PATH_MAX ];
+            snprintf( szPath, sizeof( szPath ), "/proc/%s/comm", pEntry->d_name );
+
+            FILE *pCommFile = fopen( szPath, "r" );
+            if ( !pCommFile )
+                continue;
+            defer( fclose( pCommFile ) );
+
+            char szComm[ 32 ] = {};
+            if ( !fgets( szComm, sizeof( szComm ), pCommFile ) )
+                continue;
+            szComm[ strcspn( szComm, "\n" ) ] = '\0';
+
+            if ( !strcmp( szComm, pszComm ) )
+                return true;
+        }
+
+        return false;
     }
 
     void KillProcessTree( std::vector<pid_t> nPids, int nSignal )

--- a/src/Utils/Process.h
+++ b/src/Utils/Process.h
@@ -13,6 +13,9 @@ namespace gamescope::Process
     void BecomeSubreaper();
     void SetDeathSignal( int nSignal );
 
+    // Matches against comm, which the kernel truncates to 15 chars.
+    bool IsProcessRunning( const char *pszComm );
+
     void KillAllChildren( pid_t nParentPid, int nSignal );
     void KillProcess( pid_t nPid, int nSignal );
 

--- a/src/Utils/Process.h
+++ b/src/Utils/Process.h
@@ -11,6 +11,9 @@ namespace gamescope::Process
     void BecomeSubreaper();
     void SetDeathSignal( int nSignal );
 
+    // Matches against comm, which the kernel truncates to 15 chars.
+    bool IsProcessRunning( const char *pszComm );
+
     void KillAllChildren( pid_t nParentPid, int nSignal );
     void KillProcess( pid_t nPid, int nSignal );
 

--- a/src/WaylandServer/GamescopeLimiter.h
+++ b/src/WaylandServer/GamescopeLimiter.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "WaylandProtocol.h"
+
+#include "gamescope-limiter-protocol.h"
+
+#include <span>
+#include <vector>
+
+uint32_t wlserver_get_frame_limiter_state( void );
+
+namespace gamescope::WaylandServer
+{
+
+	class CGamescopeLimiter : public CWaylandResource
+	{
+	public:
+		WL_PROTO_DEFINE( gamescope_limiter, 1 );
+
+		CGamescopeLimiter( WaylandResourceDesc_t desc )
+			: CWaylandResource( desc )
+		{
+			s_Limiters.push_back( this );
+			SendState( wlserver_get_frame_limiter_state() );
+		}
+
+		~CGamescopeLimiter()
+		{
+			std::erase_if( s_Limiters, [this]( CGamescopeLimiter *pLimiter ){ return pLimiter == this; } );
+		}
+
+		void SendState( uint32_t uState )
+		{
+			gamescope_limiter_send_state( GetResource(), uState );
+		}
+
+		static std::span<CGamescopeLimiter *> GetLimiters()
+		{
+			return s_Limiters;
+		}
+
+	private:
+		static std::vector<CGamescopeLimiter *> s_Limiters;
+	};
+
+	const struct gamescope_limiter_interface CGamescopeLimiter::Implementation =
+	{
+		.destroy = WL_PROTO_DESTROY(),
+	};
+
+	std::vector<CGamescopeLimiter *> CGamescopeLimiter::s_Limiters;
+
+}

--- a/src/WaylandServer/WaylandDecls.h
+++ b/src/WaylandServer/WaylandDecls.h
@@ -18,4 +18,7 @@ namespace gamescope::WaylandServer
     class CGamescopeActionBindingManager;
     using CGamescopeActionBindingProtocol = CWaylandProtocol<CGamescopeActionBindingManager>;
 
+    class CGamescopeLimiter;
+    using CGamescopeLimiterProtocol = CWaylandProtocol<CGamescopeLimiter>;
+
 }

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8177,6 +8177,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 
 	ctx->atoms.gamescopeXWaylandModeControl = XInternAtom( ctx->dpy, "GAMESCOPE_XWAYLAND_MODE_CONTROL", false );
 	ctx->atoms.gamescopeFPSLimit = XInternAtom( ctx->dpy, "GAMESCOPE_FPS_LIMIT", false );
+	ctx->atoms.gamescopeLimiterFeedback = XInternAtom( ctx->dpy, "GAMESCOPE_LIMITER_FEEDBACK", false );
 	ctx->atoms.gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_INTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH", false );
 	ctx->atoms.gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_EXTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH_EXTERNAL", false );
 	ctx->atoms.gamescopeLowLatency = XInternAtom( ctx->dpy, "GAMESCOPE_LOW_LATENCY", false );
@@ -8285,6 +8286,9 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 
 	uint32_t unVROverlayForwardingSupported = GetBackend()->SupportsVROverlayForwarding() ? 3 : 0;
 	XChangeProperty(ctx->dpy, ctx->root, ctx->atoms.gamescopeVROverlayForwarding, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&unVROverlayForwardingSupported, 1 );
+
+	uint32_t uLimiterFeedback = wlserver_get_frame_limiter_state();
+	XChangeProperty(ctx->dpy, ctx->root, ctx->atoms.gamescopeLimiterFeedback, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&uLimiterFeedback, 1 );
 
 	XGrabServer(ctx->dpy);
 
@@ -8401,6 +8405,34 @@ void update_vrr_atoms(xwayland_ctx_t *root_ctx, bool force, bool* needs_flush = 
 			(unsigned char *)&enabled_value, 1 );
 		if (needs_flush)
 			*needs_flush = true;
+	}
+}
+
+static uint32_t g_uLimiterFeedback_CachedValue = 0;
+
+void update_limiter_atoms(xwayland_ctx_t *root_ctx, bool force, bool* needs_flush = nullptr)
+{
+	uint32_t uLimiterFeedback = wlserver_get_frame_limiter_state();
+	if ( uLimiterFeedback == g_uLimiterFeedback_CachedValue && !force )
+		return;
+
+	g_uLimiterFeedback_CachedValue = uLimiterFeedback;
+
+	gamescope_xwayland_server_t *server = NULL;
+	for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
+	{
+		XChangeProperty(server->ctx->dpy, server->ctx->root, server->ctx->atoms.gamescopeLimiterFeedback, XA_CARDINAL, 32, PropModeReplace,
+			(unsigned char *)&uLimiterFeedback, 1 );
+
+		if (server->ctx.get() == root_ctx)
+		{
+			if (needs_flush)
+				*needs_flush = true;
+		}
+		else
+		{
+			XFlush(server->ctx->dpy);
+		}
 	}
 }
 
@@ -8780,6 +8812,7 @@ steamcompmgr_main(int argc, char **argv)
 	}
 
 	update_vrr_atoms(root_ctx, true);
+	update_limiter_atoms(root_ctx, true);
 	update_mode_atoms(root_ctx);
 	XFlush(root_ctx->dpy);
 
@@ -9487,6 +9520,8 @@ steamcompmgr_main(int argc, char **argv)
 		update_vrr_atoms(root_ctx, false, &flush_root);
 
 		wlserver_flush_frame_limiter_state();
+
+		update_limiter_atoms(root_ctx, false, &flush_root);
 
 		if (GetCurrentFocus() && GetCurrentFocus()->cursor)
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1065,9 +1065,25 @@ window_is_vr_scene_app( steamcompmgr_win_t *w )
 
 bool g_bChangeDynamicRefreshBasedOnGameOpenRatherThanActive = false;
 
+// Windows the limiter never covers. The streaming client video window
+// carries the remote game, so the cap still applies to it.
+static bool
+window_is_limiter_exempt( steamcompmgr_win_t *w )
+{
+	if ( !w )
+		return true;
+
+	if ( w->isSteamStreamingClientVideo )
+		return false;
+
+	// Under -vrgamepadui the Steam UI panels carry a VR overlay target instead of the Steam appid.
+	return window_is_steam( w ) || w->oulTargetVROverlay.has_value() ||
+		w->isOverlay || w->isExternalOverlay || window_is_vr_scene_app( w );
+}
+
 bool steamcompmgr_window_should_limit_fps( steamcompmgr_win_t *w )
 {
-	return w && !window_is_steam( w ) && !window_is_vr_scene_app( w ) && !w->isOverlay && !w->isExternalOverlay;
+	return !window_is_limiter_exempt( w );
 }
 
 static bool

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6053,10 +6053,14 @@ T bit_cast(const J& src) {
 static void
 update_runtime_info()
 {
+	uint32_t limiter_enabled = g_nSteamCompMgrTargetFPS != 0 ? 1 : 0;
+
+	// The file is a legacy fallback for clients without gamescope_limiter.
+	wlserver_set_frame_limiter_state( limiter_enabled );
+
 	if ( g_nRuntimeInfoFd < 0 )
 		return;
 
-	uint32_t limiter_enabled = g_nSteamCompMgrTargetFPS != 0 ? 1 : 0;
 	pwrite( g_nRuntimeInfoFd, &limiter_enabled, sizeof( limiter_enabled ), 0 );
 }
 
@@ -6064,10 +6068,9 @@ static void
 init_runtime_info()
 {
 	const char *path = getenv( "GAMESCOPE_LIMITER_FILE" );
-	if ( !path )
-		return;
+	if ( path )
+		g_nRuntimeInfoFd = open( path, O_CREAT | O_RDWR , 0644 );
 
-	g_nRuntimeInfoFd = open( path, O_CREAT | O_RDWR , 0644 );
 	update_runtime_info();
 }
 
@@ -9482,6 +9485,8 @@ steamcompmgr_main(int argc, char **argv)
 #endif
 
 		update_vrr_atoms(root_ctx, false, &flush_root);
+
+		wlserver_flush_frame_limiter_state();
 
 		if (GetCurrentFocus() && GetCurrentFocus()->cursor)
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -48,6 +48,7 @@
 #include <fstream>
 #include <string>
 #include <filesystem>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <assert.h>
@@ -92,6 +93,7 @@
 #include "commit.h"
 #include "reshade_effect_manager.hpp"
 #include "BufferMemo.h"
+#include "vrclient_detect.h"
 #include "Utils/Process.h"
 
 #include "wlr_begin.hpp"
@@ -1063,8 +1065,6 @@ window_is_vr_scene_app( steamcompmgr_win_t *w )
 	return w && w->appID && w->appID == g_unCurrentVRSceneAppId.load( std::memory_order_relaxed );
 }
 
-bool g_bChangeDynamicRefreshBasedOnGameOpenRatherThanActive = false;
-
 // Windows the limiter never covers. The streaming client video window
 // carries the remote game, so the cap still applies to it.
 static bool
@@ -1081,9 +1081,168 @@ window_is_limiter_exempt( steamcompmgr_win_t *w )
 		w->isOverlay || w->isExternalOverlay || window_is_vr_scene_app( w );
 }
 
+gamescope::ConVar<bool> cv_limiter_vr_exempt( "limiter_vr_exempt", true, "Exempt VR app windows from the fps limiter during VR sessions." );
+
+// Poller thread <-> steamcompmgr shared state. Leaked so shutdown never
+// races the detached thread.
+struct VRSessionPollState_t
+{
+	std::mutex mutex;
+	bool bEnabled = false;
+	bool bLimiterActive = false;
+	std::vector<pid_t> vecWantPids;
+	bool bSessionActive = false;
+	std::unordered_set<pid_t> setVRClientPids;
+};
+static VRSessionPollState_t *s_pVRSessionPollState = nullptr;
+
+// Only touched on the steamcompmgr thread, so safe under wlserver_lock.
+static bool s_bVRSessionActive = false;
+static std::unordered_set<pid_t> s_setVRClientPids;
+
+// The probes block on /proc, so they live on their own thread. A VR
+// session is "a vrserver process exists".
+static void
+vr_session_poll_thread( VRSessionPollState_t *pState )
+{
+	pthread_setname_np( pthread_self(), "gamescope-vrmon" );
+
+	struct VRClientEntry_t
+	{
+		bool bMapped = false;
+		uint64_t ulLastCheckTime = 0;
+	};
+	std::unordered_map<pid_t, VRClientEntry_t> cache;
+	bool bSessionActive = false;
+	uint64_t ulLastSessionCheckTime = 0;
+
+	bool bEnabled = true;
+
+	for ( ;; )
+	{
+		std::this_thread::sleep_for( std::chrono::seconds( bEnabled ? 1 : 5 ) );
+
+		bool bLimiterActive;
+		std::vector<pid_t> vecWantPids;
+		{
+			std::scoped_lock lock{ pState->mutex };
+			bEnabled = pState->bEnabled;
+			bLimiterActive = pState->bLimiterActive;
+			vecWantPids = pState->vecWantPids;
+		}
+
+		// No candidate windows makes the session state unobservable, skip scanning.
+		if ( !bEnabled || vecWantPids.empty() )
+		{
+			bSessionActive = false;
+			ulLastSessionCheckTime = 0;
+			cache.clear();
+		}
+		else
+		{
+			uint64_t now = get_time_in_nanos();
+
+			// Back off when nothing needs a prompt answer.
+			uint64_t ulSessionRecheckInterval = ( bSessionActive || bLimiterActive )
+				? 5'000'000'000ul
+				: 30'000'000'000ul;
+			if ( !ulLastSessionCheckTime || now - ulLastSessionCheckTime >= ulSessionRecheckInterval )
+			{
+				ulLastSessionCheckTime = now;
+				bSessionActive = gamescope::Process::IsProcessRunning( "vrserver" );
+			}
+
+			if ( bSessionActive )
+			{
+				// Re-validates in both directions, vrclient can unload.
+				static constexpr uint64_t k_ulVRClientRecheckInterval = 2'000'000'000ul;
+				for ( pid_t pid : vecWantPids )
+				{
+					VRClientEntry_t &entry = cache[ pid ];
+					if ( !entry.ulLastCheckTime || now - entry.ulLastCheckTime >= k_ulVRClientRecheckInterval )
+					{
+						entry.ulLastCheckTime = now;
+						entry.bMapped = gamescope::ProcessHasVRClientMapped( pid );
+					}
+				}
+
+				std::erase_if( cache, [&]( const auto &entry )
+				{
+					return std::find( vecWantPids.begin(), vecWantPids.end(), entry.first ) == vecWantPids.end();
+				});
+			}
+			else
+			{
+				cache.clear();
+			}
+		}
+
+		std::unordered_set<pid_t> setVRClientPids;
+		for ( const auto &entry : cache )
+		{
+			if ( entry.second.bMapped )
+				setVRClientPids.insert( entry.first );
+		}
+
+		std::scoped_lock lock{ pState->mutex };
+		pState->bSessionActive = bSessionActive;
+		if ( pState->setVRClientPids != setVRClientPids )
+			pState->setVRClientPids = std::move( setVRClientPids );
+	}
+}
+
+// Hands the poller the pids worth probing and mirrors its results.
+static void
+steamcompmgr_update_vr_session_state()
+{
+	if ( GetBackend()->UsesVirtualConnectors() )
+		return;
+
+	if ( !s_pVRSessionPollState )
+	{
+		s_pVRSessionPollState = new VRSessionPollState_t;
+		std::thread( vr_session_poll_thread, s_pVRSessionPollState ).detach();
+	}
+
+	static std::vector<pid_t> vecWantPids;
+	vecWantPids.clear();
+	gamescope_xwayland_server_t *server = NULL;
+	for ( size_t i = 0; ( server = wlserver_get_xwayland_server( i ) ); i++ )
+	{
+		for ( steamcompmgr_win_t *w = server->ctx->list; w; w = w->xwayland().next )
+		{
+			if ( w->pid <= 0 || window_is_limiter_exempt( w ) )
+				continue;
+
+			if ( std::find( vecWantPids.begin(), vecWantPids.end(), w->pid ) == vecWantPids.end() )
+				vecWantPids.push_back( w->pid );
+		}
+	}
+
+	std::scoped_lock lock{ s_pVRSessionPollState->mutex };
+	s_pVRSessionPollState->bEnabled = cv_limiter_vr_exempt;
+	s_pVRSessionPollState->bLimiterActive = g_nSteamCompMgrTargetFPS != 0;
+	s_pVRSessionPollState->vecWantPids = vecWantPids;
+	s_bVRSessionActive = s_pVRSessionPollState->bSessionActive;
+	if ( s_setVRClientPids != s_pVRSessionPollState->setVRClientPids )
+		s_setVRClientPids = s_pVRSessionPollState->setVRClientPids;
+}
+
+// Limiting a VR app's flat companion presents throttles its VR render loop.
+// Residual: a flat game that probed for VR keeps vrclient mapped and slips
+// the limiter while a session runs.
+static bool
+window_is_vr_app( steamcompmgr_win_t *w )
+{
+	return window_is_vr_scene_app( w ) ||
+		( w && cv_limiter_vr_exempt && s_bVRSessionActive && s_setVRClientPids.count( w->pid ) > 0 );
+}
+
+bool g_bChangeDynamicRefreshBasedOnGameOpenRatherThanActive = false;
+
 bool steamcompmgr_window_should_limit_fps( steamcompmgr_win_t *w )
 {
-	return !window_is_limiter_exempt( w );
+	return !window_is_limiter_exempt( w ) && !window_is_vr_app( w );
 }
 
 static bool
@@ -1433,6 +1592,9 @@ import_commit (
 	commit->desired_present_time = desired_present_time;
 	if (window_is_vr_scene_app( w )) {
 		commit->async = true;
+		commit->fifo = false;
+	} else if (window_is_vr_app( w )) {
+		// Heuristic match keeps vblank-aligned flips, no async tearing.
 		commit->fifo = false;
 	}
 
@@ -9136,6 +9298,8 @@ steamcompmgr_main(int argc, char **argv)
 		{
 			{
 				uint64_t now = get_time_in_nanos();
+
+				steamcompmgr_update_vr_session_state();
 
 				gamescope_xwayland_server_t *server = NULL;
 				for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -7274,22 +7274,18 @@ void handle_done_commits_xwayland( xwayland_ctx_t *ctx, bool vblank, uint64_t vb
 	// very fast loop yes
 	for ( auto& entry : ctx->doneCommits.listCommitsDone )
 	{
-		bool entry_vblank = vblank;
-
-		if ( GetBackend()->GetCurrentConnector() && GetBackend()->GetCurrentConnector()->IsVRRActive() )
+		steamcompmgr_win_t *entry_win = nullptr;
+		for ( steamcompmgr_win_t *w = ctx->list; w; w = w->xwayland().next )
 		{
-			for ( steamcompmgr_win_t *w = ctx->list; w; w = w->xwayland().next )
-			{
-				if (w->seq != entry.winSeq)
-					continue;
+			if (w->seq != entry.winSeq)
+				continue;
 
-				entry_vblank = entry_vblank && steamcompmgr_should_vblank_window( true, vblank_idx, w, now );
-			}
+			entry_win = w;
+			break;
 		}
-		else
-		{
-			entry_vblank = entry_vblank && steamcompmgr_should_vblank_window( true, vblank_idx );
-		}
+
+		// Only pace windows the FPS limiter covers.
+		const bool entry_vblank = vblank && steamcompmgr_should_vblank_window( entry_win, vblank_idx, now );
 
 		if (entry.fifo && (!entry_vblank || fifo_win_seqs.count(entry.winSeq) > 0))
 		{
@@ -7309,16 +7305,10 @@ void handle_done_commits_xwayland( xwayland_ctx_t *ctx, bool vblank, uint64_t vb
 			continue;
 		}
 
-		for ( steamcompmgr_win_t *w = ctx->list; w; w = w->xwayland().next )
+		if ( entry_win && handle_done_commit(entry_win, ctx, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime) )
 		{
-			if (w->seq != entry.winSeq)
-				continue;
-			if (handle_done_commit(w, ctx, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime))
-			{
-				if (entry.fifo)
-					fifo_win_seqs.insert(entry.winSeq);
-				break;
-			}
+			if (entry.fifo)
+				fifo_win_seqs.insert(entry.winSeq);
 		}
 	}
 
@@ -7343,12 +7333,23 @@ void handle_done_commits_xdg( bool vblank, uint64_t vblank_idx )
 
 	uint64_t now = get_time_in_nanos();
 
-	vblank = vblank && steamcompmgr_should_vblank_window( true, vblank_idx );
-
 	// very fast loop yes
 	for ( auto& entry : g_steamcompmgr_xdg_done_commits.listCommitsDone )
 	{
-		if (entry.fifo && (!vblank || fifo_win_seqs.count(entry.winSeq) > 0))
+		steamcompmgr_win_t *entry_win = nullptr;
+		for (const auto& xdg_win : g_steamcompmgr_xdg_wins)
+		{
+			if (xdg_win->seq != entry.winSeq)
+				continue;
+
+			entry_win = xdg_win.get();
+			break;
+		}
+
+		// Only pace windows the FPS limiter covers.
+		const bool entry_vblank = vblank && steamcompmgr_should_vblank_window( entry_win, vblank_idx, now );
+
+		if (entry.fifo && (!entry_vblank || fifo_win_seqs.count(entry.winSeq) > 0))
 		{
 			commits_before_their_time.push_back( entry );
 			continue;
@@ -7366,16 +7367,10 @@ void handle_done_commits_xdg( bool vblank, uint64_t vblank_idx )
 			break;
 		}
 
-		for (const auto& xdg_win : g_steamcompmgr_xdg_wins)
+		if ( entry_win && handle_done_commit(entry_win, nullptr, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime) )
 		{
-			if (xdg_win->seq != entry.winSeq)
-				continue;
-			if (handle_done_commit(xdg_win.get(), nullptr, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime))
-			{
-				if (entry.fifo)
-					fifo_win_seqs.insert(entry.winSeq);
-				break;
-			}
+			if (entry.fifo)
+				fifo_win_seqs.insert(entry.winSeq);
 		}
 	}
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6972,22 +6972,18 @@ void handle_done_commits_xwayland( xwayland_ctx_t *ctx, bool vblank, uint64_t vb
 	// very fast loop yes
 	for ( auto& entry : ctx->doneCommits.listCommitsDone )
 	{
-		bool entry_vblank = vblank;
-
-		if ( GetBackend()->GetCurrentConnector() && GetBackend()->GetCurrentConnector()->IsVRRActive() )
+		steamcompmgr_win_t *entry_win = nullptr;
+		for ( steamcompmgr_win_t *w = ctx->list; w; w = w->xwayland().next )
 		{
-			for ( steamcompmgr_win_t *w = ctx->list; w; w = w->xwayland().next )
-			{
-				if (w->seq != entry.winSeq)
-					continue;
+			if (w->seq != entry.winSeq)
+				continue;
 
-				entry_vblank = entry_vblank && steamcompmgr_should_vblank_window( true, vblank_idx, w, now );
-			}
+			entry_win = w;
+			break;
 		}
-		else
-		{
-			entry_vblank = entry_vblank && steamcompmgr_should_vblank_window( true, vblank_idx );
-		}
+
+		// Only pace windows the FPS limiter covers.
+		const bool entry_vblank = vblank && steamcompmgr_should_vblank_window( entry_win, vblank_idx, now );
 
 		if (entry.fifo && (!entry_vblank || fifo_win_seqs.count(entry.winSeq) > 0))
 		{
@@ -7007,16 +7003,10 @@ void handle_done_commits_xwayland( xwayland_ctx_t *ctx, bool vblank, uint64_t vb
 			continue;
 		}
 
-		for ( steamcompmgr_win_t *w = ctx->list; w; w = w->xwayland().next )
+		if ( entry_win && handle_done_commit(entry_win, ctx, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime) )
 		{
-			if (w->seq != entry.winSeq)
-				continue;
-			if (handle_done_commit(w, ctx, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime))
-			{
-				if (entry.fifo)
-					fifo_win_seqs.insert(entry.winSeq);
-				break;
-			}
+			if (entry.fifo)
+				fifo_win_seqs.insert(entry.winSeq);
 		}
 	}
 
@@ -7041,12 +7031,23 @@ void handle_done_commits_xdg( bool vblank, uint64_t vblank_idx )
 
 	uint64_t now = get_time_in_nanos();
 
-	vblank = vblank && steamcompmgr_should_vblank_window( true, vblank_idx );
-
 	// very fast loop yes
 	for ( auto& entry : g_steamcompmgr_xdg_done_commits.listCommitsDone )
 	{
-		if (entry.fifo && (!vblank || fifo_win_seqs.count(entry.winSeq) > 0))
+		steamcompmgr_win_t *entry_win = nullptr;
+		for (const auto& xdg_win : g_steamcompmgr_xdg_wins)
+		{
+			if (xdg_win->seq != entry.winSeq)
+				continue;
+
+			entry_win = xdg_win.get();
+			break;
+		}
+
+		// Only pace windows the FPS limiter covers.
+		const bool entry_vblank = vblank && steamcompmgr_should_vblank_window( entry_win, vblank_idx, now );
+
+		if (entry.fifo && (!entry_vblank || fifo_win_seqs.count(entry.winSeq) > 0))
 		{
 			commits_before_their_time.push_back( entry );
 			continue;
@@ -7064,16 +7065,10 @@ void handle_done_commits_xdg( bool vblank, uint64_t vblank_idx )
 			break;
 		}
 
-		for (const auto& xdg_win : g_steamcompmgr_xdg_wins)
+		if ( entry_win && handle_done_commit(entry_win, nullptr, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime) )
 		{
-			if (xdg_win->seq != entry.winSeq)
-				continue;
-			if (handle_done_commit(xdg_win.get(), nullptr, entry.commitID, entry.earliestPresentTime, entry.earliestLatchTime))
-			{
-				if (entry.fifo)
-					fifo_win_seqs.insert(entry.winSeq);
-				break;
-			}
+			if (entry.fifo)
+				fifo_win_seqs.insert(entry.winSeq);
 		}
 	}
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -52,6 +52,7 @@
 #include <queue>
 #include <filesystem>
 #include <variant>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <assert.h>
@@ -96,6 +97,7 @@
 #include "commit.h"
 #include "reshade_effect_manager.hpp"
 #include "BufferMemo.h"
+#include "vrclient_detect.h"
 #include "Utils/Process.h"
 #include "Utils/Algorithm.h"
 
@@ -1057,8 +1059,6 @@ window_is_vr_scene_app( steamcompmgr_win_t *w )
 	return w && w->appID && w->appID == g_unCurrentVRSceneAppId.load( std::memory_order_relaxed );
 }
 
-bool g_bChangeDynamicRefreshBasedOnGameOpenRatherThanActive = false;
-
 // Windows the limiter never covers. The streaming client video window
 // carries the remote game, so the cap still applies to it.
 static bool
@@ -1075,9 +1075,168 @@ window_is_limiter_exempt( steamcompmgr_win_t *w )
 		w->isOverlay || w->isExternalOverlay || window_is_vr_scene_app( w );
 }
 
+gamescope::ConVar<bool> cv_limiter_vr_exempt( "limiter_vr_exempt", true, "Exempt VR app windows from the fps limiter during VR sessions." );
+
+// Poller thread <-> steamcompmgr shared state. Leaked so shutdown never
+// races the detached thread.
+struct VRSessionPollState_t
+{
+	std::mutex mutex;
+	bool bEnabled = false;
+	bool bLimiterActive = false;
+	std::vector<pid_t> vecWantPids;
+	bool bSessionActive = false;
+	std::unordered_set<pid_t> setVRClientPids;
+};
+static VRSessionPollState_t *s_pVRSessionPollState = nullptr;
+
+// Only touched on the steamcompmgr thread, so safe under wlserver_lock.
+static bool s_bVRSessionActive = false;
+static std::unordered_set<pid_t> s_setVRClientPids;
+
+// The probes block on /proc, so they live on their own thread. A VR
+// session is "a vrserver process exists".
+static void
+vr_session_poll_thread( VRSessionPollState_t *pState )
+{
+	pthread_setname_np( pthread_self(), "gamescope-vrmon" );
+
+	struct VRClientEntry_t
+	{
+		bool bMapped = false;
+		uint64_t ulLastCheckTime = 0;
+	};
+	std::unordered_map<pid_t, VRClientEntry_t> cache;
+	bool bSessionActive = false;
+	uint64_t ulLastSessionCheckTime = 0;
+
+	bool bEnabled = true;
+
+	for ( ;; )
+	{
+		std::this_thread::sleep_for( std::chrono::seconds( bEnabled ? 1 : 5 ) );
+
+		bool bLimiterActive;
+		std::vector<pid_t> vecWantPids;
+		{
+			std::scoped_lock lock{ pState->mutex };
+			bEnabled = pState->bEnabled;
+			bLimiterActive = pState->bLimiterActive;
+			vecWantPids = pState->vecWantPids;
+		}
+
+		// No candidate windows makes the session state unobservable, skip scanning.
+		if ( !bEnabled || vecWantPids.empty() )
+		{
+			bSessionActive = false;
+			ulLastSessionCheckTime = 0;
+			cache.clear();
+		}
+		else
+		{
+			uint64_t now = get_time_in_nanos();
+
+			// Back off when nothing needs a prompt answer.
+			uint64_t ulSessionRecheckInterval = ( bSessionActive || bLimiterActive )
+				? 5'000'000'000ul
+				: 30'000'000'000ul;
+			if ( !ulLastSessionCheckTime || now - ulLastSessionCheckTime >= ulSessionRecheckInterval )
+			{
+				ulLastSessionCheckTime = now;
+				bSessionActive = gamescope::Process::IsProcessRunning( "vrserver" );
+			}
+
+			if ( bSessionActive )
+			{
+				// Re-validates in both directions, vrclient can unload.
+				static constexpr uint64_t k_ulVRClientRecheckInterval = 2'000'000'000ul;
+				for ( pid_t pid : vecWantPids )
+				{
+					VRClientEntry_t &entry = cache[ pid ];
+					if ( !entry.ulLastCheckTime || now - entry.ulLastCheckTime >= k_ulVRClientRecheckInterval )
+					{
+						entry.ulLastCheckTime = now;
+						entry.bMapped = gamescope::ProcessHasVRClientMapped( pid );
+					}
+				}
+
+				std::erase_if( cache, [&]( const auto &entry )
+				{
+					return std::find( vecWantPids.begin(), vecWantPids.end(), entry.first ) == vecWantPids.end();
+				});
+			}
+			else
+			{
+				cache.clear();
+			}
+		}
+
+		std::unordered_set<pid_t> setVRClientPids;
+		for ( const auto &entry : cache )
+		{
+			if ( entry.second.bMapped )
+				setVRClientPids.insert( entry.first );
+		}
+
+		std::scoped_lock lock{ pState->mutex };
+		pState->bSessionActive = bSessionActive;
+		if ( pState->setVRClientPids != setVRClientPids )
+			pState->setVRClientPids = std::move( setVRClientPids );
+	}
+}
+
+// Hands the poller the pids worth probing and mirrors its results.
+static void
+steamcompmgr_update_vr_session_state()
+{
+	if ( GetBackend()->UsesVirtualConnectors() )
+		return;
+
+	if ( !s_pVRSessionPollState )
+	{
+		s_pVRSessionPollState = new VRSessionPollState_t;
+		std::thread( vr_session_poll_thread, s_pVRSessionPollState ).detach();
+	}
+
+	static std::vector<pid_t> vecWantPids;
+	vecWantPids.clear();
+	gamescope_xwayland_server_t *server = NULL;
+	for ( size_t i = 0; ( server = wlserver_get_xwayland_server( i ) ); i++ )
+	{
+		for ( steamcompmgr_win_t *w = server->ctx->list; w; w = w->xwayland().next )
+		{
+			if ( w->pid <= 0 || window_is_limiter_exempt( w ) )
+				continue;
+
+			if ( std::find( vecWantPids.begin(), vecWantPids.end(), w->pid ) == vecWantPids.end() )
+				vecWantPids.push_back( w->pid );
+		}
+	}
+
+	std::scoped_lock lock{ s_pVRSessionPollState->mutex };
+	s_pVRSessionPollState->bEnabled = cv_limiter_vr_exempt;
+	s_pVRSessionPollState->bLimiterActive = g_nSteamCompMgrTargetFPS != 0;
+	s_pVRSessionPollState->vecWantPids = vecWantPids;
+	s_bVRSessionActive = s_pVRSessionPollState->bSessionActive;
+	if ( s_setVRClientPids != s_pVRSessionPollState->setVRClientPids )
+		s_setVRClientPids = s_pVRSessionPollState->setVRClientPids;
+}
+
+// Limiting a VR app's flat companion presents throttles its VR render loop.
+// Residual: a flat game that probed for VR keeps vrclient mapped and slips
+// the limiter while a session runs.
+static bool
+window_is_vr_app( steamcompmgr_win_t *w )
+{
+	return window_is_vr_scene_app( w ) ||
+		( w && cv_limiter_vr_exempt && s_bVRSessionActive && s_setVRClientPids.count( w->pid ) > 0 );
+}
+
+bool g_bChangeDynamicRefreshBasedOnGameOpenRatherThanActive = false;
+
 bool steamcompmgr_window_should_limit_fps( steamcompmgr_win_t *w )
 {
-	return !window_is_limiter_exempt( w );
+	return !window_is_limiter_exempt( w ) && !window_is_vr_app( w );
 }
 
 static bool
@@ -1427,6 +1586,9 @@ import_commit (
 	commit->desired_present_time = desired_present_time;
 	if (window_is_vr_scene_app( w )) {
 		commit->async = true;
+		commit->fifo = false;
+	} else if (window_is_vr_app( w )) {
+		// Heuristic match keeps vblank-aligned flips, no async tearing.
 		commit->fifo = false;
 	}
 
@@ -8854,6 +9016,8 @@ steamcompmgr_main(int argc, char **argv)
 		{
 			{
 				uint64_t now = get_time_in_nanos();
+
+				steamcompmgr_update_vr_session_state();
 
 				gamescope_xwayland_server_t *server = NULL;
 				for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1059,9 +1059,25 @@ window_is_vr_scene_app( steamcompmgr_win_t *w )
 
 bool g_bChangeDynamicRefreshBasedOnGameOpenRatherThanActive = false;
 
+// Windows the limiter never covers. The streaming client video window
+// carries the remote game, so the cap still applies to it.
+static bool
+window_is_limiter_exempt( steamcompmgr_win_t *w )
+{
+	if ( !w )
+		return true;
+
+	if ( w->isSteamStreamingClientVideo )
+		return false;
+
+	// Under -vrgamepadui the Steam UI panels carry a VR overlay target instead of the Steam appid.
+	return window_is_steam( w ) || w->oulTargetVROverlay.has_value() ||
+		w->isOverlay || w->isExternalOverlay || window_is_vr_scene_app( w );
+}
+
 bool steamcompmgr_window_should_limit_fps( steamcompmgr_win_t *w )
 {
-	return w && !window_is_steam( w ) && !window_is_vr_scene_app( w ) && !w->isOverlay && !w->isExternalOverlay;
+	return !window_is_limiter_exempt( w );
 }
 
 static bool

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5776,10 +5776,14 @@ T bit_cast(const J& src) {
 static void
 update_runtime_info()
 {
+	uint32_t limiter_enabled = g_nSteamCompMgrTargetFPS != 0 ? 1 : 0;
+
+	// The file is a legacy fallback for clients without gamescope_limiter.
+	wlserver_set_frame_limiter_state( limiter_enabled );
+
 	if ( g_nRuntimeInfoFd < 0 )
 		return;
 
-	uint32_t limiter_enabled = g_nSteamCompMgrTargetFPS != 0 ? 1 : 0;
 	pwrite( g_nRuntimeInfoFd, &limiter_enabled, sizeof( limiter_enabled ), 0 );
 }
 
@@ -5787,10 +5791,9 @@ static void
 init_runtime_info()
 {
 	const char *path = getenv( "GAMESCOPE_LIMITER_FILE" );
-	if ( !path )
-		return;
+	if ( path )
+		g_nRuntimeInfoFd = open( path, O_CREAT | O_RDWR , 0644 );
 
-	g_nRuntimeInfoFd = open( path, O_CREAT | O_RDWR , 0644 );
 	update_runtime_info();
 }
 
@@ -9196,6 +9199,8 @@ steamcompmgr_main(int argc, char **argv)
 		}
 
 		update_vrr_atoms(root_ctx, false, &flush_root);
+
+		wlserver_flush_frame_limiter_state();
 
 		if (GetCurrentFocus() && GetCurrentFocus()->cursor)
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -7867,6 +7867,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 
 	ctx->atoms.gamescopeXWaylandModeControl = XInternAtom( ctx->dpy, "GAMESCOPE_XWAYLAND_MODE_CONTROL", false );
 	ctx->atoms.gamescopeFPSLimit = XInternAtom( ctx->dpy, "GAMESCOPE_FPS_LIMIT", false );
+	ctx->atoms.gamescopeLimiterFeedback = XInternAtom( ctx->dpy, "GAMESCOPE_LIMITER_FEEDBACK", false );
 	ctx->atoms.gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_INTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH", false );
 	ctx->atoms.gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_EXTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH_EXTERNAL", false );
 	ctx->atoms.gamescopeLowLatency = XInternAtom( ctx->dpy, "GAMESCOPE_LOW_LATENCY", false );
@@ -7975,6 +7976,9 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 
 	uint32_t unVROverlayForwardingSupported = GetBackend()->SupportsVROverlayForwarding() ? 3 : 0;
 	XChangeProperty(ctx->dpy, ctx->root, ctx->atoms.gamescopeVROverlayForwarding, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&unVROverlayForwardingSupported, 1 );
+
+	uint32_t uLimiterFeedback = wlserver_get_frame_limiter_state();
+	XChangeProperty(ctx->dpy, ctx->root, ctx->atoms.gamescopeLimiterFeedback, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&uLimiterFeedback, 1 );
 
 	XGrabServer(ctx->dpy);
 
@@ -8091,6 +8095,34 @@ void update_vrr_atoms(xwayland_ctx_t *root_ctx, bool force, bool* needs_flush = 
 			(unsigned char *)&enabled_value, 1 );
 		if (needs_flush)
 			*needs_flush = true;
+	}
+}
+
+static uint32_t g_uLimiterFeedback_CachedValue = 0;
+
+void update_limiter_atoms(xwayland_ctx_t *root_ctx, bool force, bool* needs_flush = nullptr)
+{
+	uint32_t uLimiterFeedback = wlserver_get_frame_limiter_state();
+	if ( uLimiterFeedback == g_uLimiterFeedback_CachedValue && !force )
+		return;
+
+	g_uLimiterFeedback_CachedValue = uLimiterFeedback;
+
+	gamescope_xwayland_server_t *server = NULL;
+	for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
+	{
+		XChangeProperty(server->ctx->dpy, server->ctx->root, server->ctx->atoms.gamescopeLimiterFeedback, XA_CARDINAL, 32, PropModeReplace,
+			(unsigned char *)&uLimiterFeedback, 1 );
+
+		if (server->ctx.get() == root_ctx)
+		{
+			if (needs_flush)
+				*needs_flush = true;
+		}
+		else
+		{
+			XFlush(server->ctx->dpy);
+		}
 	}
 }
 
@@ -8500,6 +8532,7 @@ steamcompmgr_main(int argc, char **argv)
 	}
 
 	update_vrr_atoms(root_ctx, true);
+	update_limiter_atoms(root_ctx, true);
 	update_mode_atoms(root_ctx);
 	XFlush(root_ctx->dpy);
 
@@ -9201,6 +9234,8 @@ steamcompmgr_main(int argc, char **argv)
 		update_vrr_atoms(root_ctx, false, &flush_root);
 
 		wlserver_flush_frame_limiter_state();
+
+		update_limiter_atoms(root_ctx, false, &flush_root);
 
 		if (GetCurrentFocus() && GetCurrentFocus()->cursor)
 		{

--- a/src/vrclient_detect.h
+++ b/src/vrclient_detect.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+#include <sys/types.h>
+
+namespace gamescope
+{
+    // A /proc/<pid>/maps line names vrclient if the mapped file's basename
+    // contains "vrclient" (vrclient.so, vrclient_x64.so, Proton builds).
+    inline bool MapsLineNamesVRClient( std::string_view line )
+    {
+        size_t slash = line.rfind( '/' );
+        if ( slash == std::string_view::npos )
+            return false;
+
+        return line.substr( slash + 1 ).find( "vrclient" ) != std::string_view::npos;
+    }
+
+    // procfs files cannot be sized up front, stream line by line.
+    inline bool ProcMapsHasVRClient( const char *path )
+    {
+        std::ifstream maps( path );
+        std::string line;
+        while ( std::getline( maps, line ) )
+        {
+            if ( MapsLineNamesVRClient( line ) )
+                return true;
+        }
+        return false;
+    }
+
+    inline bool ProcessHasVRClientMapped( pid_t pid )
+    {
+        char path[64];
+        snprintf( path, sizeof( path ), "/proc/%d/maps", (int)pid );
+        return ProcMapsHasVRClient( path );
+    }
+}

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -21,6 +21,7 @@
 #include "WaylandServer/LinuxDrmSyncobj.h"
 #include "WaylandServer/Reshade.h"
 #include "WaylandServer/GamescopeActionBinding.h"
+#include "WaylandServer/GamescopeLimiter.h"
 
 #include "wlr_begin.hpp"
 #include <wlr/backend.h>
@@ -1066,14 +1067,40 @@ static void create_gamescope_swapchain_factory_v2( void )
 	wl_global_create( wlserver.display, &gamescope_swapchain_factory_v2_interface, version, NULL, gamescope_swapchain_factory_v2_bind );
 }
 
+////////////////////////
+// gamescope_limiter
+////////////////////////
 
+// Written from the steamcompmgr thread, sent from under the wlserver lock.
+static std::atomic<uint32_t> s_uFrameLimiterState = { 0 };
+static std::atomic<bool> s_bFrameLimiterStateDirty = { false };
 
+void wlserver_set_frame_limiter_state( uint32_t uState )
+{
+	if ( s_uFrameLimiterState.exchange( uState ) != uState )
+		s_bFrameLimiterStateDirty = true;
+}
 
+uint32_t wlserver_get_frame_limiter_state( void )
+{
+	return s_uFrameLimiterState;
+}
 
+void wlserver_flush_frame_limiter_state( void )
+{
+	using gamescope::WaylandServer::CGamescopeLimiter;
 
+	if ( !s_bFrameLimiterStateDirty.exchange( false ) )
+		return;
 
-
-
+	wlserver_lock();
+	uint32_t uState = s_uFrameLimiterState;
+	for ( CGamescopeLimiter *pLimiter : CGamescopeLimiter::GetLimiters() )
+	{
+		pLimiter->SendState( uState );
+	}
+	wlserver_unlock();
+}
 
 
 
@@ -2047,6 +2074,8 @@ bool wlserver_init( void ) {
 	create_gamescope_xwayland();
 
 	create_gamescope_swapchain_factory_v2();
+
+	new gamescope::WaylandServer::CGamescopeLimiterProtocol( wlserver.display );
 
 #if HAVE_PIPEWIRE
 	create_gamescope_pipewire();

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -21,6 +21,7 @@
 #include "WaylandServer/LinuxDrmSyncobj.h"
 #include "WaylandServer/Reshade.h"
 #include "WaylandServer/GamescopeActionBinding.h"
+#include "WaylandServer/GamescopeLimiter.h"
 
 #include "wlr_begin.hpp"
 #include <wlr/backend.h>
@@ -1096,14 +1097,40 @@ static void create_gamescope_swapchain_factory_v2( void )
 	wl_global_create( wlserver.display, &gamescope_swapchain_factory_v2_interface, version, NULL, gamescope_swapchain_factory_v2_bind );
 }
 
+////////////////////////
+// gamescope_limiter
+////////////////////////
 
+// Written from the steamcompmgr thread, sent from under the wlserver lock.
+static std::atomic<uint32_t> s_uFrameLimiterState = { 0 };
+static std::atomic<bool> s_bFrameLimiterStateDirty = { false };
 
+void wlserver_set_frame_limiter_state( uint32_t uState )
+{
+	if ( s_uFrameLimiterState.exchange( uState ) != uState )
+		s_bFrameLimiterStateDirty = true;
+}
 
+uint32_t wlserver_get_frame_limiter_state( void )
+{
+	return s_uFrameLimiterState;
+}
 
+void wlserver_flush_frame_limiter_state( void )
+{
+	using gamescope::WaylandServer::CGamescopeLimiter;
 
+	if ( !s_bFrameLimiterStateDirty.exchange( false ) )
+		return;
 
-
-
+	wlserver_lock();
+	uint32_t uState = s_uFrameLimiterState;
+	for ( CGamescopeLimiter *pLimiter : CGamescopeLimiter::GetLimiters() )
+	{
+		pLimiter->SendState( uState );
+	}
+	wlserver_unlock();
+}
 
 
 
@@ -2071,6 +2098,8 @@ bool wlserver_init( void ) {
 	create_gamescope_xwayland();
 
 	create_gamescope_swapchain_factory_v2();
+
+	new gamescope::WaylandServer::CGamescopeLimiterProtocol( wlserver.display );
 
 #if HAVE_PIPEWIRE
 	create_gamescope_pipewire();

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -300,6 +300,10 @@ void wlserver_shutdown();
 
 void wlserver_send_gamescope_control( wl_resource *control );
 
+void wlserver_set_frame_limiter_state( uint32_t uState );
+uint32_t wlserver_get_frame_limiter_state( void );
+void wlserver_flush_frame_limiter_state( void );
+
 bool wlsession_active();
 
 void wlserver_fake_mouse_pos( double x, double y );

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -305,6 +305,10 @@ void wlserver_shutdown();
 
 void wlserver_send_gamescope_control( wl_resource *control );
 
+void wlserver_set_frame_limiter_state( uint32_t uState );
+uint32_t wlserver_get_frame_limiter_state( void );
+void wlserver_flush_frame_limiter_state( void );
+
 bool wlsession_active();
 
 void wlserver_fake_mouse_pos( double x, double y );

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -166,6 +166,7 @@ struct xwayland_ctx_t final : public gamescope::IWaitable
 		Atom gamescopeXWaylandModeControl;
 
 		Atom gamescopeFPSLimit;
+		Atom gamescopeLimiterFeedback;
 		Atom gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_COUNT];
 		Atom gamescopeLowLatency;
 

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -170,6 +170,7 @@ struct xwayland_ctx_t final : public gamescope::IWaitable
 		Atom gamescopeXWaylandModeControl;
 
 		Atom gamescopeFPSLimit;
+		Atom gamescopeLimiterFeedback;
 		Atom gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_COUNT];
 		Atom gamescopeLowLatency;
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ endforeach
 
 test_convar = executable(
 	'test_convar',
-	unittest_src + ['test_convar.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_vrclient_detect.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ endforeach
 
 gamescope_tests = executable(
 	'gamescope_tests',
-	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
@@ -20,3 +20,4 @@ test('convar', gamescope_tests, args: ['[convar]'])
 test('utils/parsers', gamescope_tests, args: ['[parsers]'])
 test('utils/process', gamescope_tests, args: ['[process]'], depends: [reaper_test_helper])
 test('utils/string', gamescope_tests, args: ['[string]'])
+test('vrclient_detect', gamescope_tests, args: ['[vrclient_detect]'])

--- a/tests/test_vrclient_detect.cpp
+++ b/tests/test_vrclient_detect.cpp
@@ -1,0 +1,79 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include <unistd.h>
+
+#include "vrclient_detect.h"
+
+TEST_CASE("maps lines naming vrclient are detected", "[vrclient_detect]") {
+	// Native SteamVR, 64-bit and arm64, the latter captured verbatim from a Steam Frame.
+	REQUIRE(gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /home/user/.steam/steam/steamapps/common/SteamVR/bin/linux64/vrclient.so" ));
+	REQUIRE(gamescope::MapsLineNamesVRClient(
+		"ffff64200000-ffff647f8000 r-xp 00000000 00:1c 2751                       /opt/steamvr/bin/linuxarm64/vrclient.so" ));
+	// Proton's unixlib builds.
+	REQUIRE(gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /home/user/.steam/steam/steamapps/common/Proton 11.0/files/lib/wine/x86_64-unix/vrclient_x64.so" ));
+	// Proton's PE builds, Wine maps the .dll itself. Paths carry spaces and parens.
+	REQUIRE(gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /home/user/.steam/steam/steamapps/common/Proton - Experimental/files/lib/wine/x86_64-windows/vrclient_x64.dll" ));
+	REQUIRE(gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /home/user/.steam/steam/steamapps/common/Proton 9.0 (Beta)/files/lib/wine/i386-windows/vrclient.dll" ));
+	// Unlinked while mapped.
+	REQUIRE(gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /path/vrclient.so (deleted)" ));
+}
+
+TEST_CASE("non-vrclient maps lines are not detected", "[vrclient_detect]") {
+	REQUIRE(!gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /usr/lib/libvulkan.so.1" ));
+	// vrclient only in a directory component, not the mapped file.
+	REQUIRE(!gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /home/user/vrclient/game.so" ));
+	// Anonymous and pseudo mappings.
+	REQUIRE(!gamescope::MapsLineNamesVRClient(
+		"7f0e8c000000-7f0e8c021000 rw-p 00000000 00:00 0" ));
+	REQUIRE(!gamescope::MapsLineNamesVRClient( "[heap]" ));
+	REQUIRE(!gamescope::MapsLineNamesVRClient( "" ));
+}
+
+static std::string write_fixture( const char *contents ) {
+	char path[] = "/tmp/vrclient_detect_test_XXXXXX";
+	int fd = mkstemp( path );
+	REQUIRE(fd >= 0);
+	REQUIRE(write( fd, contents, strlen( contents ) ) == (ssize_t)strlen( contents ));
+	close( fd );
+	return path;
+}
+
+TEST_CASE("maps files scan positive and negative", "[vrclient_detect]") {
+	std::string positive = write_fixture(
+		"7f0e8b000000-7f0e8b021000 r-xp 00000000 103:02 1233 /usr/lib/libc.so.6\n"
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /path/bin/linux64/vrclient_x64.so\n"
+		"7f0e8d000000-7f0e8d021000 rw-p 00000000 00:00 0\n" );
+	REQUIRE(gamescope::ProcMapsHasVRClient( positive.c_str() ));
+	unlink( positive.c_str() );
+
+	// Final line without a trailing newline still scans.
+	std::string positiveNoNewline = write_fixture(
+		"7f0e8b000000-7f0e8b021000 r-xp 00000000 103:02 1233 /usr/lib/libc.so.6\n"
+		"7f0e8c000000-7f0e8c021000 r-xp 00000000 103:02 1234 /path/bin/linux64/vrclient.so" );
+	REQUIRE(gamescope::ProcMapsHasVRClient( positiveNoNewline.c_str() ));
+	unlink( positiveNoNewline.c_str() );
+
+	std::string negative = write_fixture(
+		"7f0e8b000000-7f0e8b021000 r-xp 00000000 103:02 1233 /usr/lib/libc.so.6\n"
+		"7f0e8d000000-7f0e8d021000 rw-p 00000000 00:00 0\n" );
+	REQUIRE(!gamescope::ProcMapsHasVRClient( negative.c_str() ));
+	unlink( negative.c_str() );
+}
+
+TEST_CASE("processes without vrclient scan as false", "[vrclient_detect]") {
+	// The test binary never loads vrclient.
+	REQUIRE(!gamescope::ProcessHasVRClientMapped( getpid() ));
+	// Nonexistent pid: unreadable maps degrade to false.
+	REQUIRE(!gamescope::ProcessHasVRClientMapped( -1 ));
+}


### PR DESCRIPTION
Fixes the frame limiter for Vulkan clients (dxvk/vkd3d-proton) on Steam Frame. No Frame mesa changes needed, as GL goes through Zink on there, which presents via the same Vulkan WSI layer this fixes. The existing dri3 limiter patch in SteamOS mesa on Deck keeps working unchanged, but I'll update it to read the new root property after further testing.