### PR TITLE
main: reject --xwayland-count below 1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -801,6 +801,10 @@ int main(int argc, char **argv)
 					g_bForceDisableColorMgmt = true;
 				} else if (strcmp(opt_name, "xwayland-count") == 0) {
 					g_nXWaylandCount = parse_integer( optarg, opt_name );
+					if ( g_nXWaylandCount < 1 ) {
+						fprintf( stderr, "gamescope: invalid value for --xwayland-count, must be at least 1\n" );
+						exit(1);
+					}
 				} else if (strcmp(opt_name, "xwayland-force-touch-pointer-emulation") == 0) {
 					g_bNoTouchPointerEmulation = false;
 				} else if (strcmp(opt_name, "composite-debug") == 0) {


### PR DESCRIPTION
`--xwayland-count 0` and negative values segfault at startup.

The creation loop in `wlserver_init()` is
`for (int i = 0; i < g_nXWaylandCount; i++)`, so a count below 1 leaves
`wlserver.wlr.xwayland_servers` empty. `main.cpp:1068` then does:

    gamescope_xwayland_server_t *base_server = wlserver_get_xwayland_server(0);
    setenv("DISPLAY", base_server->get_nested_display_name(), 1);

`wlserver_get_xwayland_server()` correctly returns NULL for an
out-of-range index, but the return value isn't checked here.

### Reproduction

    $ gamescope --xwayland-count 0 -- true
    Segmentation fault (core dumped)     # exit 139

    $ gamescope --xwayland-count -1 -- true
    Segmentation fault (core dumped)     # exit 139

Backtrace:

    #0  gamescope_xwayland_server_t::get_nested_display_name (this=0x0) at src/wlserver.cpp:3270
    #1  main (...) at src/main.cpp:1070

### Why validate instead of null-check

`wlserver_get_xwayland_server(0)` is used unchecked in `main.cpp` and in
roughly ten places in `steamcompmgr.cpp` (2573, 4413, 4436, 5582, 5992,
5997, 8783, ...), plus `wlserver.cpp` 367 and 872. Server 0 is assumed
to exist throughout, so guarding one call site would move the crash
rather than fix it. Rejecting the input at parse time matches the
existing `parse_integer()` and `--backend` error handling.

### After

    $ gamescope --xwayland-count 0 -- true
    gamescope: invalid value for --xwayland-count, must be at least 1    # exit 1

Normal operation unaffected. `meson test --suite gamescope` passes 2/2.
Builds clean with `--werror` (689/689). Tested on `fcc1341`.

Independent of #<your other PR number>, different file, different
mechanism and no dependency between them.