### PR TITLE
WaylandBackend: re-arm the forced pointer lock when focus returns

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2702,6 +2702,20 @@ namespace gamescope
 	void CWaylandBackend::Wayland_LockedPointer_Unlocked( zwp_locked_pointer_v1 *pLockedPointer )
 	{
 		m_bPointerLocked = false;
+
+		// The host deactivated our persistent constraint, typically because we
+		// lost focus. Some compositors (Mutter, Hyprland) never reactivate it, and
+		// SetRelativeMouseMode is a no-op while m_pLockedPointer is alive, so the
+		// pointer would stay free for good. Recreate the constraint while relative
+		// mode is still wanted; the new one stays pending until the host is willing
+		// to lock the pointer for us again.
+		if ( pLockedPointer == m_pLockedPointer && m_pLockedSurface )
+		{
+			zwp_locked_pointer_v1_destroy( m_pLockedPointer );
+			m_pLockedPointer = zwp_pointer_constraints_v1_lock_pointer( m_pPointerConstraints, m_pLockedSurface, m_pPointer, nullptr, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT );
+			zwp_locked_pointer_v1_add_listener( m_pLockedPointer, &s_LockedPointerListener, this );
+		}
+
 		UpdateCursor();
 	}
 

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -694,6 +694,7 @@ namespace gamescope
 
         void SetCursorImage( std::shared_ptr<INestedHints::CursorInfo> info );
         void SetRelativeMouseMode( wl_surface *pSurface, bool bRelative );
+        void ReArmForcedPointerLock();
         void UpdateCursor();
 
         friend CWaylandConnector;
@@ -837,6 +838,8 @@ namespace gamescope
         wl_touch *m_pTouch = nullptr;
         zwp_locked_pointer_v1 *m_pLockedPointer = nullptr;
 		bool m_bPointerLocked = false;
+		// Set when the host compositor deactivates our constraint, so we know to re-arm it.
+		bool m_bPointerUnlockedByHost = false;
         wl_surface *m_pLockedSurface = nullptr;
         zwp_relative_pointer_v1 *m_pRelativePointer = nullptr;
 
@@ -2419,7 +2422,8 @@ namespace gamescope
         if ( !m_pPointer )
             return;
 
-        if ( !!bRelative != !!m_pLockedPointer || ( pSurface != m_pLockedSurface && bRelative ) )
+        if ( !!bRelative != !!m_pLockedPointer || ( pSurface != m_pLockedSurface && bRelative ) ||
+             ( bRelative && m_bPointerUnlockedByHost ) )
         {
             if ( m_pLockedPointer )
             {
@@ -2443,12 +2447,24 @@ namespace gamescope
 				m_pRelativePointer = zwp_relative_pointer_manager_v1_get_relative_pointer( m_pRelativePointerManager, m_pPointer );
 
 				m_pLockedSurface = pSurface;
+				m_bPointerUnlockedByHost = false;
 			}
 
             m_InputThread.SetRelativePointer( bRelative );
 
             UpdateCursor();
         }
+    }
+
+    // With --force-grab-cursor the pointer lock is only ever armed once, from
+    // CWaylandConnector::Init(), because steamcompmgr's per-frame call to
+    // SetRelativeMouseMode is gated behind !g_bForceRelativeMouse. Re-arm it when
+    // focus returns, so the constraint survives the host dropping it while we
+    // were unfocused.
+    void CWaylandBackend::ReArmForcedPointerLock()
+    {
+        if ( g_bForceRelativeMouse && m_bPointerUnlockedByHost && m_pLockedSurface )
+            SetRelativeMouseMode( m_pLockedSurface, true );
     }
 
     void CWaylandBackend::UpdateCursor()
@@ -2662,6 +2678,8 @@ namespace gamescope
         m_uPointerEnterSerial = uSerial;
         m_bMouseEntered = true;
 
+        ReArmForcedPointerLock();
+
         UpdateCursor();
     }
     void CWaylandBackend::Wayland_Pointer_Leave( wl_pointer *pPointer, uint32_t uSerial, wl_surface *pSurface )
@@ -2681,6 +2699,8 @@ namespace gamescope
 
         m_uKeyboardEnterSerial = uSerial;
         m_bKeyboardEntered = true;
+
+        ReArmForcedPointerLock();
 
         UpdateCursor();
     }
@@ -2702,6 +2722,7 @@ namespace gamescope
 	void CWaylandBackend::Wayland_LockedPointer_Unlocked( zwp_locked_pointer_v1 *pLockedPointer )
 	{
 		m_bPointerLocked = false;
+		m_bPointerUnlockedByHost = true;
 		UpdateCursor();
 	}
 


### PR DESCRIPTION
### Problem

The cursor is confined to the game correctly at first, but as soon as focus leaves the gamescope window (alt-tab, workspace switch) and comes back, the confinement is gone for good: the cursor moves freely out of the game and onto other monitors. Clicking back into the window does not restore it.

Reproduced on GNOME 50 / Mutter, Wayland session, 3 monitors, NVIDIA 595.84. The same symptom is reported under Hyprland in #1285.

### Cause

`SetRelativeMouseMode`'s guard only compares `bRelative` against `m_pLockedPointer`, so it is a no-op while the locked pointer object is alive. When the host compositor deactivates our `LIFETIME_PERSISTENT` constraint on focus loss and does not reactivate it, `Wayland_LockedPointer_Unlocked` just clears `m_bPointerLocked` and nothing ever recreates the constraint.

This is not specific to `--force-grab-cursor`. In forced mode the lock is armed once from `CWaylandConnector::Init()`; for a game that requests relative mouse mode itself, steamcompmgr's per-frame call hits the same guard and is equally a no-op.

### Fix

Recreate the constraint from `Wayland_LockedPointer_Unlocked` while relative mode is still wanted (i.e. the event is for our current `m_pLockedPointer`). The new constraint stays pending until the host is willing to lock the pointer again. Nothing else changes: `SetRelativeMouseMode` and its guard are untouched, and a later `SetRelativeMouseMode(false)` from steamcompmgr tears the new constraint down exactly as before.

On a host that does reactivate persistent constraints on its own, this costs one destroy/create per host unlock, and nothing per enter event.

### Testing

Built against wlroots 0.19.2 (the Ubuntu 26.04 system library) and the vendored one on `master`. With the patch, confinement survives repeated alt-tabs and workspace switches with `--force-grab-cursor`, and the cursor stays visible and usable in game menus. Verified in a Proton game over XWayland and with a plain X11 client.
