### PR TITLE
Frame multiapp laser focus

### DIFF
--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -75,6 +75,7 @@ gamescope::ConVar<float> cv_vr_trackpad_click_max_delta( "vr_trackpad_click_max_
 gamescope::ConVar<bool> cv_vr_debug_force_opaque( "vr_debug_force_opaque", false, "Force textures to be treated as opaque." );
 gamescope::ConVar<bool> cv_vr_nudge_to_visible( "vr_nudge_to_visible", false, "" );
 gamescope::ConVar<bool> cv_vr_nudge_to_visible_per_connector( "vr_nudge_to_visible_per_connector", false, "" );
+gamescope::ConVar<bool> cv_vr_click_focus( "vr_click_focus", true, "Move keyboard focus to the overlay a click lands on, without waiting for SteamVR to grant it." );
 
 // Maximum interval between polling for VR events (normally paced by frame sync)
 gamescope::ConVar<uint32_t> cv_vr_poll_rate( "vr_poll_rate", 50ul, "Max time between input polls. In milliseconds." );
@@ -1358,6 +1359,12 @@ namespace gamescope
                     {
                         SetMouseFocus( hOverlay );
 
+                        // Games sharing an Xwayland share one X focus, so the click has to activate its game.
+                        if ( cv_vr_click_focus && vrEvent.eventType == vr::VREvent_MouseButtonDown )
+                        {
+                            SetKeyboardFocus( hOverlay );
+                        }
+
                         if (!pConnector->m_bUsingVRMouse)
                         {
                             pConnector->m_bUsingVRMouse = true;
@@ -1911,9 +1918,9 @@ namespace gamescope
 
             // SteamVR can fail to grant a launching app overlay input focus,
             // which would otherwise leave the previous connector current. Only
-            // defer to a holder SteamVR's grant actually points at. Every
-            // caller holds m_mutActiveConnectors, which keeps the holder alive
-            // across the plane lookup.
+            // defer to a holder that currently holds the input focus overlay.
+            // Every caller holds m_mutActiveConnectors, which keeps the holder
+            // alive across the plane lookup.
             if ( bVisible )
             {
                 COpenVRConnector *pKeyboardConnector = m_pBackend->m_pKeyboardFocusConnector.load();

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2315,6 +2315,7 @@ static bool is_fading_out()
 	return fadeOutStartTime || g_bPendingFade;
 }
 
+// The laser reads these, so follow the pointer's connector.
 static void update_touch_scaling( const struct FrameInfo_t *frameInfo )
 {
 	if ( !frameInfo->layers.count() )
@@ -2654,7 +2655,7 @@ paint_all( global_focus_t *pFocus, bool async )
 				if ( !bHasVideoUnderlay )
 					flags |= PaintWindowFlag::BasePlane;
 				paint_window(w, w, &frameInfo, pFocus->cursor, flags);
-				if ( pFocus == GetCurrentFocus() )
+				if ( pFocus == GetCurrentMouseFocus() )
 					update_touch_scaling( &frameInfo );
 				
 				// paint UI unless it's fully hidden, which it communicates to us through opacity=0
@@ -2691,7 +2692,7 @@ paint_all( global_focus_t *pFocus, bool async )
 					frameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR && needsScaling;
 					frameInfo.useNISLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::NIS && needsScaling;
 				}
-				if ( pFocus == GetCurrentFocus() )
+				if ( pFocus == GetCurrentMouseFocus() )
 					update_touch_scaling( &frameInfo );
 			}
 		}
@@ -2771,7 +2772,7 @@ paint_all( global_focus_t *pFocus, bool async )
 			paint_window(externalOverlay, externalOverlay, &frameInfo, pFocus->cursor, PaintWindowFlag::NoScale | PaintWindowFlag::NoFilter |
 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 ) );
 
-			if ( externalOverlay == pFocus->inputFocusWindow && pFocus == GetCurrentFocus() )
+			if ( externalOverlay == pFocus->inputFocusWindow && pFocus == GetCurrentMouseFocus() )
 				update_touch_scaling( &frameInfo );
 		}
 	}
@@ -2783,7 +2784,7 @@ paint_all( global_focus_t *pFocus, bool async )
 			paint_window(overlay, overlay, &frameInfo, pFocus->cursor, PaintWindowFlag::DrawBorders | PaintWindowFlag::NoFilter |
 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 )  );
 
-			if ( overlay == pFocus->inputFocusWindow && pFocus == GetCurrentFocus() )
+			if ( overlay == pFocus->inputFocusWindow && pFocus == GetCurrentMouseFocus() )
 				update_touch_scaling( &frameInfo );
 		}
 		else if ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4100,6 +4100,7 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	}
 
 	steamcompmgr_win_t *keyboardFocusWin = inputFocus;
+	steamcompmgr_win_t *mouseBaseWindow = nullptr;
 
 	if ( gamescope::VirtualConnectorIsSingleOutput() )
 	{
@@ -4120,6 +4121,7 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 			{
 				inputFocus = mouse_focus.overrideWindow ? mouse_focus.overrideWindow : mouse_focus.focusWindow;
 				ctx->focus.overrideWindowMouse = mouse_focus.overrideWindow;
+				mouseBaseWindow = mouse_focus.focusWindow;
 			}
 		}
 
@@ -4228,7 +4230,21 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	if ( inputFocus == ctx->focus.focusWindow && ctx->focus.overrideWindowMouse )
 		inputFocus = ctx->focus.overrideWindowMouse;
 
-	if ( ctx->list[0].xwayland().id != inputFocus->xwayland().id )
+	// X routes the pointer by stacking, so the mouse pick's base window goes under its override, above the rest.
+	bool bRaisedBase = false;
+	if ( mouseBaseWindow && mouseBaseWindow != inputFocus )
+	{
+		steamcompmgr_win_t *pTop = ctx->list;
+		bool bBaseStacked = pTop == mouseBaseWindow ||
+			( pTop == inputFocus && pTop->xwayland().next == mouseBaseWindow );
+		if ( !bBaseStacked )
+		{
+			mouseBaseWindow->Raise();
+			bRaisedBase = true;
+		}
+	}
+
+	if ( bRaisedBase || ctx->list[0].xwayland().id != inputFocus->xwayland().id )
 		inputFocus->Raise();
 
 	// X confines the pointer to the screen, so a screen-sized focus window only

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4054,7 +4054,8 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	gamescope::VirtualConnectorStrategy eStrategy = gamescope::VirtualConnectorStrategies::PerWindow;
 	gamescope::VirtualConnectorKey_t ulKey = 0;
 
-	if ( ctx->xwayland_server->get_index() != 0 )
+	// SteamControlled ignores the connector key, so it can't split a shared Xwayland.
+	if ( ctx->xwayland_server->get_index() != 0 && gamescope::VirtualConnectorIsSingleOutput() )
 	{
 		eStrategy = gamescope::VirtualConnectorStrategies::SteamControlled;
 		ulKey = 0;


### PR DESCRIPTION
Allows seamlessly switching the laser from pointing and clicking at one virtual connector to pointing and clicking at another virtual connector which is running at the same time. Currently, clicks bleed through to the other virtual connector if you run multiple run apps and have them both visible.