### PR TITLE
wlserver: Fix left-click stuck after 2-finger tap

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -3068,7 +3068,7 @@ void wlserver_touchdown( double x, double y, int touch_id, uint32_t time, gamesc
 
 			uint32_t button = TouchClickModeToLinuxButton( eMode );
 
-			if ( button != 0 && eMode < WLSERVER_BUTTON_COUNT )
+			if ( button != 0 && eMode < WLSERVER_BUTTON_COUNT && !wlserver.button_held[ eMode ] )
 			{
 				wlr_seat_pointer_notify_button( wlserver.wlr.seat, time, button, WL_POINTER_BUTTON_STATE_PRESSED );
 				wlr_seat_pointer_notify_frame( wlserver.wlr.seat );


### PR DESCRIPTION
Previously, after a two-finger tap, `WL_POINTER_BUTTON_STATE_PRESSED` had been sent twice, whereas the corresponding `WL_POINTER_BUTTON_STATE_RELEASED` had only been sent once. With the button stuck down, apps reject clicks on buttons.

This PR edits `wlserver_touchdown` to match how the logic in `wlserver_touchup` discards the second touch release, so we now discard the second concurrent touch press too. This only affects the mouse button emulation for single-cursor games needing this fix, and leaves multi-cursor passthrough untouched. When multiple fingers are pressed and released in complex ways, hover works when at least one finger is down, and an emulated (left)-click is held down if and only if the latest press of any finger was later than the latest release.

Out of scope is preventing jumping between two fingers, as I only suppress the button not the movement. I'd also prefer real double-click emulation via two-finger- or long- press but that'd be a feature.

Tested with the nested compositor, whose touch support is only active with https://github.com/ValveSoftware/gamescope/pull/2104 applied.