### PR TITLE
Add GBM Scanout Backend for NVIDIA to fix DRM Corruption

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -53,6 +53,8 @@
 #include "libdisplay-info/cta.h"
 #include "wlr_end.hpp"
 
+#include "DRMGbmScanout.h"
+
 #include "gamescope-control-protocol.h"
 
 extern int g_nPreferredOutputWidth;
@@ -73,6 +75,12 @@ gamescope::ConVar<bool> cv_drm_debug_disable_explicit_sync( "drm_debug_disable_e
 gamescope::ConVar<bool> cv_drm_debug_disable_in_fence_fd( "drm_debug_disable_in_fence_fd", false, "Force disable IN_FENCE_FD being set to avoid over-synchronization on the DRM backend." );
 
 gamescope::ConVar<bool> cv_drm_allow_dynamic_modes_for_external_display( "drm_allow_dynamic_modes_for_external_display", false, "Allow dynamic mode/refresh rate switching for external displays." );
+
+gamescope::ConVar<bool> cv_drm_nvidia_gbm_scanout( "drm_nvidia_gbm_scanout", false,
+	"On NVIDIA, allocate scanout buffers with GBM to guarantee the physically-contiguous "
+	"memory the display engine requires, and always composite (client buffers have no such "
+	"guarantee). Composition forcing applies immediately when toggled at runtime; the "
+	"scanout buffers themselves switch at the next output remake." );
 
 int HackyDRMPresent( const FrameInfo_t *pFrameInfo, bool bAsync );
 
@@ -109,6 +117,7 @@ struct drm_t {
 	uint64_t cursor_width, cursor_height;
 	bool allow_modifiers;
 	struct wlr_drm_format_set formats;
+	gamescope::CGbmScanoutAllocator gbmAllocator;
 
 	std::vector< std::unique_ptr< gamescope::CDRMPlane > > planes;
 	std::vector< std::unique_ptr< gamescope::CDRMCRTC > > crtcs;
@@ -1450,6 +1459,11 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
 
 	drm->needs_modeset = true;
 
+	// Always opened on NVIDIA (a gbm_device is free until allocated from) so
+	// drm_nvidia_gbm_scanout can be toggled at runtime.
+	if ( gamescope::DrmDeviceIsNvidia( drm->fd ) )
+		drm->gbmAllocator.Init( drm->fd );
+
 	return true;
 }
 
@@ -1608,6 +1622,7 @@ void finish_drm(struct drm_t *drm)
 	drm->crtcs.clear();
 	drm->connectors.clear();
 
+	drm->gbmAllocator.Shutdown();
 
 	// Signal the page-flip handler thread to exit and join it so it won't be
 	// using the DRM fd while we clean it up. Closing the pipe write end
@@ -3649,6 +3664,8 @@ namespace gamescope
 
 			bool bNeedsFullComposite = false;
 			bNeedsFullComposite |= cv_composite_force;
+			// Backend-allocated scanout: client buffers can't be flipped directly, always composite.
+			bNeedsFullComposite |= UsesBackendAllocatedScanout();
 			bNeedsFullComposite |= bWasFirstFrame;
 			bNeedsFullComposite |= pFrameInfo->useFSRLayer0;
 			bNeedsFullComposite |= pFrameInfo->useNISLayer0;
@@ -3946,6 +3963,18 @@ namespace gamescope
 		virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_dmabuf_attributes *pDmaBuf ) override
 		{
 			return drm_fbid_from_dmabuf( &g_DRM, pDmaBuf );
+		}
+
+		virtual bool UsesBackendAllocatedScanout() const override
+		{
+			return g_DRM.gbmAllocator.IsAvailable() && cv_drm_nvidia_gbm_scanout;
+		}
+
+		virtual bool CreateScanoutDmabuf( uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat,
+		                                  std::span<const uint64_t> ulModifiers,
+		                                  wlr_dmabuf_attributes *pDmaBuf ) override
+		{
+			return g_DRM.gbmAllocator.CreateScanoutDmabuf( uWidth, uHeight, uDrmFormat, ulModifiers, pDmaBuf );
 		}
 
 		virtual bool UsesModifiers() const override

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -1459,10 +1459,8 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
 
 	drm->needs_modeset = true;
 
-	// Always opened on NVIDIA (a gbm_device is free until allocated from) so
-	// drm_nvidia_gbm_scanout can be toggled at runtime.
-	if ( gamescope::DrmDeviceIsNvidia( drm->fd ) )
-		drm->gbmAllocator.Init( drm->fd );
+	// Opened regardless of drm_nvidia_gbm_scanout so it can be toggled at runtime.
+	drm->gbmAllocator.Init( drm->fd );
 
 	return true;
 }

--- a/src/Backends/DRMGbmScanout.cpp
+++ b/src/Backends/DRMGbmScanout.cpp
@@ -1,0 +1,131 @@
+#include "DRMGbmScanout.h"
+
+#include "drm_include.h"
+#include "log.hpp"
+#include "Utils/Algorithm.h"
+#include "Utils/Defer.h"
+
+#include <cstring>
+
+#if HAVE_GBM
+#include <gbm.h>
+#endif
+
+namespace gamescope
+{
+	static LogScope gbm_log( "gbm_scanout" );
+
+	bool DrmDeviceIsNvidia( int nDrmFd )
+	{
+		bool bIsNvidia = false;
+		if ( drmVersion *pVersion = drmGetVersion( nDrmFd ) )
+		{
+			bIsNvidia = pVersion->name && strcmp( pVersion->name, "nvidia-drm" ) == 0;
+			drmFreeVersion( pVersion );
+		}
+		return bIsNvidia;
+	}
+
+	CGbmScanoutAllocator::~CGbmScanoutAllocator()
+	{
+		Shutdown();
+	}
+
+#if HAVE_GBM
+
+	bool CGbmScanoutAllocator::Init( int nDrmFd )
+	{
+		m_pGbmDevice = gbm_create_device( nDrmFd );
+		if ( !m_pGbmDevice )
+		{
+			gbm_log.errorf( "Failed to create GBM device; Vulkan scanout allocation will be used." );
+			return false;
+		}
+		return true;
+	}
+
+	void CGbmScanoutAllocator::Shutdown()
+	{
+		if ( m_pGbmDevice )
+		{
+			gbm_device_destroy( m_pGbmDevice );
+			m_pGbmDevice = nullptr;
+		}
+	}
+
+	bool CGbmScanoutAllocator::CreateScanoutDmabuf( uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat,
+	                                                std::span<const uint64_t> ulModifiers,
+	                                                wlr_dmabuf_attributes *pDmaBuf )
+	{
+		*pDmaBuf = {};
+		if ( !m_pGbmDevice || ulModifiers.empty() )
+			return false;
+
+		gbm_bo *pBo = gbm_bo_create_with_modifiers2(
+			m_pGbmDevice, uWidth, uHeight, uDrmFormat,
+			ulModifiers.data(), ulModifiers.size(),
+			GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT );
+		if ( !pBo )
+		{
+			gbm_log.errorf_errno( "Failed to allocate GBM scanout buffer" );
+			return false;
+		}
+		defer( gbm_bo_destroy( pBo ) );
+
+		*pDmaBuf = {
+			.width = int32_t( uWidth ),
+			.height = int32_t( uHeight ),
+			.format = uDrmFormat,
+			.modifier = gbm_bo_get_modifier( pBo ),
+		};
+
+		const int nPlanes = gbm_bo_get_plane_count( pBo );
+		if ( nPlanes < 1 || nPlanes > WLR_DMABUF_MAX_PLANES ||
+		     !Algorithm::Contains( ulModifiers, pDmaBuf->modifier ) )
+		{
+			*pDmaBuf = {};
+			return false;
+		}
+
+		for ( int i = 0; i < nPlanes; i++ )
+		{
+			const int nFd = gbm_bo_get_fd_for_plane( pBo, i );
+			if ( nFd < 0 )
+			{
+				gbm_log.errorf_errno( "Failed to export GBM scanout buffer" );
+				wlr_dmabuf_attributes_finish( pDmaBuf );
+				*pDmaBuf = {};
+				return false;
+			}
+
+			pDmaBuf->fd[i] = nFd;
+			pDmaBuf->offset[i] = gbm_bo_get_offset( pBo, i );
+			pDmaBuf->stride[i] = gbm_bo_get_stride_for_plane( pBo, i );
+			pDmaBuf->n_planes = i + 1;
+		}
+
+		return true;
+	}
+
+#else // !HAVE_GBM
+
+	bool CGbmScanoutAllocator::Init( int )
+	{
+		gbm_log.errorf( "Gamescope was built without GBM support; Vulkan scanout allocation will be used." );
+		return false;
+	}
+
+	void CGbmScanoutAllocator::Shutdown()
+	{
+	}
+
+	bool CGbmScanoutAllocator::CreateScanoutDmabuf( uint32_t, uint32_t, uint32_t,
+	                                                std::span<const uint64_t>,
+	                                                wlr_dmabuf_attributes *pDmaBuf )
+	{
+		*pDmaBuf = {};
+		return false;
+	}
+
+#endif
+}

--- a/src/Backends/DRMGbmScanout.cpp
+++ b/src/Backends/DRMGbmScanout.cpp
@@ -15,7 +15,7 @@ namespace gamescope
 {
 	static LogScope gbm_log( "gbm_scanout" );
 
-	bool DrmDeviceIsNvidia( int nDrmFd )
+	static bool IsNvidiaDrm( int nDrmFd )
 	{
 		bool bIsNvidia = false;
 		if ( drmVersion *pVersion = drmGetVersion( nDrmFd ) )
@@ -31,26 +31,29 @@ namespace gamescope
 		Shutdown();
 	}
 
-#if HAVE_GBM
-
 	bool CGbmScanoutAllocator::Init( int nDrmFd )
 	{
+		if ( !IsNvidiaDrm( nDrmFd ) )
+			return false;
+#if HAVE_GBM
 		m_pGbmDevice = gbm_create_device( nDrmFd );
 		if ( !m_pGbmDevice )
-		{
 			gbm_log.errorf( "Failed to create GBM device; Vulkan scanout allocation will be used." );
-			return false;
-		}
-		return true;
+#else
+		gbm_log.errorf( "Gamescope was built without GBM support; Vulkan scanout allocation will be used on NVIDIA." );
+#endif
+		return m_pGbmDevice != nullptr;
 	}
 
 	void CGbmScanoutAllocator::Shutdown()
 	{
+#if HAVE_GBM
 		if ( m_pGbmDevice )
 		{
 			gbm_device_destroy( m_pGbmDevice );
 			m_pGbmDevice = nullptr;
 		}
+#endif
 	}
 
 	bool CGbmScanoutAllocator::CreateScanoutDmabuf( uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat,
@@ -58,6 +61,7 @@ namespace gamescope
 	                                                wlr_dmabuf_attributes *pDmaBuf )
 	{
 		*pDmaBuf = {};
+#if HAVE_GBM
 		if ( !m_pGbmDevice || ulModifiers.empty() )
 			return false;
 
@@ -105,27 +109,8 @@ namespace gamescope
 		}
 
 		return true;
-	}
-
-#else // !HAVE_GBM
-
-	bool CGbmScanoutAllocator::Init( int )
-	{
-		gbm_log.errorf( "Gamescope was built without GBM support; Vulkan scanout allocation will be used." );
+#else
 		return false;
-	}
-
-	void CGbmScanoutAllocator::Shutdown()
-	{
-	}
-
-	bool CGbmScanoutAllocator::CreateScanoutDmabuf( uint32_t, uint32_t, uint32_t,
-	                                                std::span<const uint64_t>,
-	                                                wlr_dmabuf_attributes *pDmaBuf )
-	{
-		*pDmaBuf = {};
-		return false;
-	}
-
 #endif
+	}
 }

--- a/src/Backends/DRMGbmScanout.h
+++ b/src/Backends/DRMGbmScanout.h
@@ -8,27 +8,19 @@ struct wlr_dmabuf_attributes;
 
 namespace gamescope
 {
-	// NVIDIA's display engine requires physically contiguous scanout memory, a
-	// placement constraint Vulkan external-memory allocation cannot express.
-	// GBM allocations with GBM_BO_USE_SCANOUT do satisfy it, so the DRM backend
-	// allocates its scanout buffers here and Vulkan imports them instead of
-	// allocating them itself.
-	//
-	// This can be deleted if/when nvidia-drm can reliably scan out
-	// Vulkan-allocated buffers.
+	// NVIDIA's display engine requires physically contiguous scanout memory,
+	// which Vulkan external-memory allocation cannot guarantee but GBM can.
+	// Delete this if/when nvidia-drm can scan out Vulkan-allocated buffers.
 	class CGbmScanoutAllocator
 	{
 	public:
 		~CGbmScanoutAllocator();
 
-		// Creates the GBM device. Logs and returns false on failure or when
-		// built without GBM support.
-		bool Init( int nDrmFd );
+		bool Init( int nDrmFd ); // no-op unless nvidia-drm
 		void Shutdown();
 
 		bool IsAvailable() const { return m_pGbmDevice != nullptr; }
 
-		// Allocates a scanout-capable buffer and exports it as a DMA-BUF.
 		// On failure, *pDmaBuf is left zeroed and owns nothing.
 		bool CreateScanoutDmabuf( uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat,
 		                          std::span<const uint64_t> ulModifiers,
@@ -37,7 +29,4 @@ namespace gamescope
 	private:
 		gbm_device *m_pGbmDevice = nullptr;
 	};
-
-	// True if the DRM fd is driven by the nvidia-drm kernel driver.
-	bool DrmDeviceIsNvidia( int nDrmFd );
 }

--- a/src/Backends/DRMGbmScanout.h
+++ b/src/Backends/DRMGbmScanout.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+struct gbm_device;
+struct wlr_dmabuf_attributes;
+
+namespace gamescope
+{
+	// NVIDIA's display engine requires physically contiguous scanout memory, a
+	// placement constraint Vulkan external-memory allocation cannot express.
+	// GBM allocations with GBM_BO_USE_SCANOUT do satisfy it, so the DRM backend
+	// allocates its scanout buffers here and Vulkan imports them instead of
+	// allocating them itself.
+	//
+	// This can be deleted if/when nvidia-drm can reliably scan out
+	// Vulkan-allocated buffers.
+	class CGbmScanoutAllocator
+	{
+	public:
+		~CGbmScanoutAllocator();
+
+		// Creates the GBM device. Logs and returns false on failure or when
+		// built without GBM support.
+		bool Init( int nDrmFd );
+		void Shutdown();
+
+		bool IsAvailable() const { return m_pGbmDevice != nullptr; }
+
+		// Allocates a scanout-capable buffer and exports it as a DMA-BUF.
+		// On failure, *pDmaBuf is left zeroed and owns nothing.
+		bool CreateScanoutDmabuf( uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat,
+		                          std::span<const uint64_t> ulModifiers,
+		                          wlr_dmabuf_attributes *pDmaBuf );
+
+	private:
+		gbm_device *m_pGbmDevice = nullptr;
+	};
+
+	// True if the DRM fd is driven by the nvidia-drm kernel driver.
+	bool DrmDeviceIsNvidia( int nDrmFd );
+}

--- a/src/Backends/DeferredBackend.h
+++ b/src/Backends/DeferredBackend.h
@@ -163,6 +163,20 @@ namespace gamescope
             return m_pChild->ImportDmabufToBackend( pDmaBuf );
 		}
 
+		virtual bool UsesBackendAllocatedScanout() const override
+		{
+            std::shared_lock lock{ m_mutInit };
+            return m_bInittedChild && m_pChild->UsesBackendAllocatedScanout();
+		}
+
+		virtual bool CreateScanoutDmabuf( uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat,
+		                                  std::span<const uint64_t> ulModifiers,
+		                                  wlr_dmabuf_attributes *pDmaBuf ) override
+		{
+            std::shared_lock lock{ m_mutInit };
+            return m_bInittedChild && m_pChild->CreateScanoutDmabuf( uWidth, uHeight, uDrmFormat, ulModifiers, pDmaBuf );
+		}
+
 		virtual bool UsesModifiers() const override
 		{
             return true;

--- a/src/backend.h
+++ b/src/backend.h
@@ -341,11 +341,8 @@ namespace gamescope
         // Rc manages acquire/release of buffer to/from client while imported.
         virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_dmabuf_attributes *pDmaBuf ) = 0;
 
-        // Some KMS drivers (nvidia-drm) impose scanout memory placement
-        // constraints (physical contiguity) that Vulkan external allocations
-        // cannot express. Such backends allocate the final scanout buffers
-        // themselves and let Vulkan import them; client buffers are never
-        // scanned out directly (full composition is forced).
+        // Some KMS drivers (nvidia-drm) need scanout memory placement that Vulkan
+        // cannot express; such backends allocate scanout buffers for Vulkan to import.
         virtual bool UsesBackendAllocatedScanout() const { return false; }
         virtual bool CreateScanoutDmabuf( uint32_t /*uWidth*/, uint32_t /*uHeight*/, uint32_t /*uDrmFormat*/,
                                           std::span<const uint64_t> /*ulModifiers*/,

--- a/src/backend.h
+++ b/src/backend.h
@@ -341,6 +341,16 @@ namespace gamescope
         // Rc manages acquire/release of buffer to/from client while imported.
         virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_dmabuf_attributes *pDmaBuf ) = 0;
 
+        // Some KMS drivers (nvidia-drm) impose scanout memory placement
+        // constraints (physical contiguity) that Vulkan external allocations
+        // cannot express. Such backends allocate the final scanout buffers
+        // themselves and let Vulkan import them; client buffers are never
+        // scanned out directly (full composition is forced).
+        virtual bool UsesBackendAllocatedScanout() const { return false; }
+        virtual bool CreateScanoutDmabuf( uint32_t /*uWidth*/, uint32_t /*uHeight*/, uint32_t /*uDrmFormat*/,
+                                          std::span<const uint64_t> /*ulModifiers*/,
+                                          wlr_dmabuf_attributes * /*pDmaBuf*/ ) { return false; }
+
         virtual bool UsesModifiers() const = 0;
         virtual std::span<const uint64_t> GetSupportedModifiers( uint32_t uDrmFormat ) const = 0;
 		inline bool SupportsFormat( uint32_t uDrmFormat ) const

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ dep_xmu = dependency('xmu')
 dep_xi = dependency('xi')
 
 drm_dep = dependency('libdrm', version: '>= 2.4.113', required: get_option('drm_backend'))
+gbm_dep = dependency('gbm', version: '>= 21.3', required: false)
 eis_dep = dependency('libeis-1.0', required : get_option('input_emulation'))
 
 wayland_server = dependency('wayland-server', version: '>=1.21')
@@ -130,6 +131,7 @@ libinput_dep = dependency('libinput', required: true)
 gamescope_cpp_args = []
 if drm_dep.found()
   src += 'Backends/DRMBackend.cpp'
+  src += 'Backends/DRMGbmScanout.cpp'
   src += 'modegen.cpp'
   required_wlroots_features += 'libinput_backend'
   liftoff_dep = dependency(
@@ -147,6 +149,7 @@ if sdl2_dep.found()
 endif
 
 gamescope_cpp_args += '-DHAVE_DRM=@0@'.format(drm_dep.found().to_int())
+gamescope_cpp_args += '-DHAVE_GBM=@0@'.format((drm_dep.found() and gbm_dep.found()).to_int())
 gamescope_cpp_args += '-DHAVE_SDL2=@0@'.format(sdl2_dep.found().to_int())
 gamescope_cpp_args += '-DHAVE_AVIF=@0@'.format(avif_dep.found().to_int())
 gamescope_cpp_args += '-DHAVE_LIBCAP=@0@'.format(cap_dep.found().to_int())
@@ -194,7 +197,7 @@ gamescope_version = configure_file(
     include_directories : [reshade_include, sol2_include],
     dependencies: [
       dep_wayland, dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
-      dep_xxf86vm, dep_xres, glm_dep, drm_dep, wayland_server,
+      dep_xxf86vm, dep_xres, glm_dep, drm_dep, gbm_dep, wayland_server,
       xkbcommon, thread_dep, sdl2_dep, wlroots_dep,
       vulkan_dep, liftoff_dep, dep_xtst, dep_xmu, cap_dep, epoll_dep, pipewire_dep, librt_dep,
       stb_dep, displayinfo_dep, openvr_dep, dep_xcursor, avif_dep, dep_xi,

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2048,7 +2048,7 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 		usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 	}
 
-	if ( flags.bFlippable == true )
+	if ( flags.bFlippable == true && pDMA == nullptr )
 	{
 		flags.bExportable = true;
 	}
@@ -2263,6 +2263,7 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 		vk_errorf( res, "vkCreateImage failed" );
 		return false;
 	}
+	m_bOwnsImage = true;
 	
 	VkMemoryRequirements memRequirements;
 	g_device.vk.GetImageMemoryRequirements(g_device.device(), m_vkImage, &memRequirements);
@@ -2325,6 +2326,31 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 				vk_log.errorf_errno( "dup failed" );
 				return false;
 			}
+
+			VkMemoryFdPropertiesKHR fdProperties = {
+				.sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR,
+			};
+			res = g_device.vk.GetMemoryFdPropertiesKHR(
+				g_device.device(), VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
+				fd, &fdProperties );
+			if ( res != VK_SUCCESS )
+			{
+				vk_errorf( res, "vkGetMemoryFdPropertiesKHR failed" );
+				close( fd );
+				return false;
+			}
+
+			const uint32_t uMemoryTypeBits = memRequirements.memoryTypeBits & fdProperties.memoryTypeBits;
+			int32_t nMemoryType = g_device.findMemoryType( properties, uMemoryTypeBits );
+			if ( nMemoryType < 0 )
+				nMemoryType = g_device.findMemoryType( 0, uMemoryTypeBits );
+			if ( nMemoryType < 0 )
+			{
+				vk_log.errorf( "No compatible Vulkan memory type for scanout DMA-BUF import" );
+				close( fd );
+				return false;
+			}
+			allocInfo.memoryTypeIndex = uint32_t( nMemoryType );
 
 			// Memory already provided by pDMA
 			importMemoryInfo = {
@@ -2490,13 +2516,37 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 
 		m_dmabuf = dmabuf;
 	}
+	else if ( pDMA != nullptr && flags.bFlippable == true )
+	{
+		// Backend-allocated scanout image: clone the imported dmabuf so the
+		// backend can make an FB from it. (Client imports are never flippable,
+		// they only set bSampled.)
+		m_dmabuf = *pDMA;
+		m_dmabuf.n_planes = 0;
+		for ( int i = 0; i < pDMA->n_planes; i++ )
+		{
+			m_dmabuf.fd[i] = dup( pDMA->fd[i] );
+			if ( m_dmabuf.fd[i] < 0 )
+			{
+				vk_log.errorf_errno( "dup failed" );
+				return false;
+			}
+			m_dmabuf.n_planes = i + 1;
+		}
+	}
 
 	if ( flags.bFlippable == true )
 	{
 		m_pBackendFb = GetBackend()->ImportDmabufToBackend( &m_dmabuf );
+		if ( pDMA != nullptr && m_pBackendFb == nullptr )
+			return false;
 	}
 
-	bool bHasAlpha = pDMA ? DRMFormatHasAlpha( pDMA->format ) : true;
+	// Imported client buffers with an X-format need alpha forced to 1 when
+	// sampled. Imported output images must keep the identity swizzle: they are
+	// storage images (swizzles are incompatible, see the assert below) and
+	// scanout ignores their alpha anyway.
+	bool bHasAlpha = ( pDMA && !flags.bOutputImage ) ? DRMFormatHasAlpha( pDMA->format ) : true;
 
 	if (!bHasAlpha )
 	{
@@ -2710,14 +2760,15 @@ CVulkanTexture::~CVulkanTexture( void )
 	if ( m_pBackendFb != nullptr )
 		m_pBackendFb = nullptr;
 
+	if ( m_vkImage != VK_NULL_HANDLE && m_bOwnsImage )
+	{
+		g_device.vk.DestroyImage( g_device.device(), m_vkImage, nullptr );
+		m_vkImage = VK_NULL_HANDLE;
+		m_bOwnsImage = false;
+	}
+
 	if ( m_vkImageMemory != VK_NULL_HANDLE )
 	{
-		if ( m_vkImage != VK_NULL_HANDLE )
-		{
-			g_device.vk.DestroyImage( g_device.device(), m_vkImage, nullptr );
-			m_vkImage = VK_NULL_HANDLE;
-		}
-
 		g_device.vk.FreeMemory( g_device.device(), m_vkImageMemory, nullptr );
 		m_vkImageMemory = VK_NULL_HANDLE;
 	}
@@ -3284,6 +3335,67 @@ bool vulkan_remake_swapchain( void )
 	return bRet;
 }
 
+static std::vector<uint64_t> vulkan_get_backend_scanout_modifiers( VulkanOutput_t *pOutput )
+{
+	std::vector<uint64_t> modifiers;
+	const bool bHasOverlay = pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition;
+
+	for ( uint64_t ulModifier : GetBackend()->GetSupportedModifiers( pOutput->uOutputFormat ) )
+	{
+		if ( ulModifier == DRM_FORMAT_MOD_INVALID )
+			continue;
+		if ( bHasOverlay &&
+		     !gamescope::Algorithm::Contains( GetBackend()->GetSupportedModifiers( pOutput->uOutputFormatOverlay ), ulModifier ) )
+			continue;
+		modifiers.push_back( ulModifier );
+	}
+
+	return modifiers;
+}
+
+static bool vulkan_make_backend_output_images( VulkanOutput_t *pOutput,
+	const CVulkanTexture::createFlags &outputImageflags,
+	uint32_t uWidth, uint32_t uHeight )
+{
+	const std::vector<uint64_t> modifiers = vulkan_get_backend_scanout_modifiers( pOutput );
+	if ( modifiers.empty() )
+		return false;
+
+	const bool bHasOverlay = pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition;
+	for ( size_t i = 0; i < pOutput->outputImages.size(); i++ )
+	{
+		wlr_dmabuf_attributes dmabuf = {};
+		if ( !GetBackend()->CreateScanoutDmabuf(
+			uWidth, uHeight, pOutput->uOutputFormat, modifiers, &dmabuf ) )
+			return false;
+
+		pOutput->outputImages[i] = new CVulkanTexture();
+		bool bSuccess = pOutput->outputImages[i]->BInit(
+			uWidth, uHeight, 1u, pOutput->uOutputFormat,
+			outputImageflags, &dmabuf );
+
+		// Unlike the Vulkan-allocated path (which aliases the primary image's
+		// memory via pExistingImageToReuseMemory), overlay images get their own
+		// backend allocation: GBM cannot alias memory that way, and overlay
+		// planes need their own flippable dmabuf anyway.
+		if ( bSuccess && bHasOverlay )
+		{
+			wlr_dmabuf_attributes overlayDmabuf = dmabuf;
+			overlayDmabuf.format = pOutput->uOutputFormatOverlay;
+			pOutput->outputImagesPartialOverlay[i] = new CVulkanTexture();
+			bSuccess = pOutput->outputImagesPartialOverlay[i]->BInit(
+				uWidth, uHeight, 1u, pOutput->uOutputFormatOverlay,
+				outputImageflags, &overlayDmabuf );
+		}
+
+		wlr_dmabuf_attributes_finish( &dmabuf );
+		if ( !bSuccess )
+			return false;
+	}
+
+	return true;
+}
+
 static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
 {
 	CVulkanTexture::createFlags outputImageflags;
@@ -3296,12 +3408,10 @@ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
 	pOutput->outputImages.resize(3); // extra image for partial composition.
 	pOutput->outputImagesPartialOverlay.resize(3);
 
-	pOutput->outputImages[0] = nullptr;
-	pOutput->outputImages[1] = nullptr;
-	pOutput->outputImages[2] = nullptr;
-	pOutput->outputImagesPartialOverlay[0] = nullptr;
-	pOutput->outputImagesPartialOverlay[1] = nullptr;
-	pOutput->outputImagesPartialOverlay[2] = nullptr;
+	for ( auto &pImage : pOutput->outputImages )
+		pImage = nullptr;
+	for ( auto &pImage : pOutput->outputImagesPartialOverlay )
+		pImage = nullptr;
 
 	uint32_t uDRMFormat = pOutput->uOutputFormat;
 
@@ -3311,61 +3421,52 @@ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
 	if ( g_uOutputRotation & 1u )
 		std::swap( uOutputWidth, uOutputHeight );
 
-	pOutput->outputImages[0] = new CVulkanTexture();
-	bool bSuccess = pOutput->outputImages[0]->BInit( uOutputWidth, uOutputHeight, 1u, uDRMFormat, outputImageflags );
-	if ( bSuccess != true )
+	// Backends with scanout placement constraints (e.g. NVIDIA physical
+	// contiguity) allocate the scanout buffers themselves; Vulkan imports them.
+	bool bBackendAllocated = false;
+	if ( GetBackend()->UsesBackendAllocatedScanout() )
 	{
-		vk_log.errorf( "failed to allocate buffer for KMS" );
-		return false;
+		bBackendAllocated = vulkan_make_backend_output_images( pOutput, outputImageflags, uOutputWidth, uOutputHeight );
+		if ( !bBackendAllocated )
+		{
+			vk_log.errorf( "Failed to create backend-allocated scanout buffers, falling back to Vulkan allocation." );
+			for ( auto &pImage : pOutput->outputImages )
+				pImage = nullptr;
+			for ( auto &pImage : pOutput->outputImagesPartialOverlay )
+				pImage = nullptr;
+		}
 	}
 
-	pOutput->outputImages[1] = new CVulkanTexture();
-	bSuccess = pOutput->outputImages[1]->BInit( uOutputWidth, uOutputHeight, 1u, uDRMFormat, outputImageflags );
-	if ( bSuccess != true )
+	if ( !bBackendAllocated )
 	{
-		vk_log.errorf( "failed to allocate buffer for KMS" );
-		return false;
-	}
+		for ( size_t i = 0; i < pOutput->outputImages.size(); i++ )
+		{
+			pOutput->outputImages[i] = new CVulkanTexture();
+			if ( !pOutput->outputImages[i]->BInit( uOutputWidth, uOutputHeight, 1u, uDRMFormat, outputImageflags ) )
+			{
+				vk_log.errorf( "failed to allocate buffer for KMS" );
+				return false;
+			}
+		}
 
-	pOutput->outputImages[2] = new CVulkanTexture();
-	bSuccess = pOutput->outputImages[2]->BInit( uOutputWidth, uOutputHeight, 1u, uDRMFormat, outputImageflags );
-	if ( bSuccess != true )
-	{
-		vk_log.errorf( "failed to allocate buffer for KMS" );
-		return false;
+		if ( pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition )
+		{
+			uint32_t uPartialDRMFormat = pOutput->uOutputFormatOverlay;
+
+			for ( size_t i = 0; i < pOutput->outputImagesPartialOverlay.size(); i++ )
+			{
+				pOutput->outputImagesPartialOverlay[i] = new CVulkanTexture();
+				if ( !pOutput->outputImagesPartialOverlay[i]->BInit( uOutputWidth, uOutputHeight, 1u, uPartialDRMFormat, outputImageflags, nullptr, 0, 0, pOutput->outputImages[i].get() ) )
+				{
+					vk_log.errorf( "failed to allocate buffer for KMS" );
+					return false;
+				}
+			}
+		}
 	}
 
 	// Oh no.
 	pOutput->temporaryHackyBlankImage = vulkan_create_debug_blank_texture();
-
-	if ( pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition )
-	{
-		uint32_t uPartialDRMFormat = pOutput->uOutputFormatOverlay;
-
-		pOutput->outputImagesPartialOverlay[0] = new CVulkanTexture();
-		bool bSuccess = pOutput->outputImagesPartialOverlay[0]->BInit( uOutputWidth, uOutputHeight, 1u, uPartialDRMFormat, outputImageflags, nullptr, 0, 0, pOutput->outputImages[0].get() );
-		if ( bSuccess != true )
-		{
-			vk_log.errorf( "failed to allocate buffer for KMS" );
-			return false;
-		}
-
-		pOutput->outputImagesPartialOverlay[1] = new CVulkanTexture();
-		bSuccess = pOutput->outputImagesPartialOverlay[1]->BInit( uOutputWidth, uOutputHeight, 1u, uPartialDRMFormat, outputImageflags, nullptr, 0, 0, pOutput->outputImages[1].get() );
-		if ( bSuccess != true )
-		{
-			vk_log.errorf( "failed to allocate buffer for KMS" );
-			return false;
-		}
-
-		pOutput->outputImagesPartialOverlay[2] = new CVulkanTexture();
-		bSuccess = pOutput->outputImagesPartialOverlay[2]->BInit( uOutputWidth, uOutputHeight, 1u, uPartialDRMFormat, outputImageflags, nullptr, 0, 0, pOutput->outputImages[2].get() );
-		if ( bSuccess != true )
-		{
-			vk_log.errorf( "failed to allocate buffer for KMS" );
-			return false;
-		}
-	}
 
 	return true;
 }

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2516,28 +2516,10 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 
 		m_dmabuf = dmabuf;
 	}
-	else if ( pDMA != nullptr && flags.bFlippable == true )
-	{
-		// Backend-allocated scanout image: clone the dmabuf for ImportDmabufToBackend.
-		m_dmabuf = *pDMA;
-		m_dmabuf.n_planes = 0;
-		for ( int i = 0; i < pDMA->n_planes; i++ )
-		{
-			m_dmabuf.fd[i] = dup( pDMA->fd[i] );
-			if ( m_dmabuf.fd[i] < 0 )
-			{
-				vk_log.errorf_errno( "dup failed" );
-				return false;
-			}
-			m_dmabuf.n_planes = i + 1;
-		}
-	}
 
-	if ( flags.bFlippable == true )
+	if ( flags.bFlippable == true && m_pBackendFb == nullptr )
 	{
 		m_pBackendFb = GetBackend()->ImportDmabufToBackend( &m_dmabuf );
-		if ( pDMA != nullptr && m_pBackendFb == nullptr )
-			return false;
 	}
 
 	// Imported output images stay identity-swizzled: they are storage images.
@@ -3358,19 +3340,29 @@ static bool vulkan_make_backend_output_images( VulkanOutput_t *pOutput,
 			uWidth, uHeight, pOutput->uOutputFormat, modifiers, &dmabuf ) )
 			return false;
 
-		pOutput->outputImages[i] = new CVulkanTexture();
-		bool bSuccess = pOutput->outputImages[i]->BInit(
-			uWidth, uHeight, 1u, pOutput->uOutputFormat,
-			outputImageflags, &dmabuf );
+		gamescope::OwningRc<gamescope::IBackendFb> pFb = GetBackend()->ImportDmabufToBackend( &dmabuf );
+		bool bSuccess = pFb != nullptr;
+		if ( bSuccess )
+		{
+			pOutput->outputImages[i] = new CVulkanTexture();
+			bSuccess = pOutput->outputImages[i]->BInit(
+				uWidth, uHeight, 1u, pOutput->uOutputFormat,
+				outputImageflags, &dmabuf, 0, 0, nullptr, std::move( pFb ) );
+		}
 
 		if ( bSuccess && bHasOverlay )
 		{
 			wlr_dmabuf_attributes overlayDmabuf = dmabuf;
 			overlayDmabuf.format = pOutput->uOutputFormatOverlay;
-			pOutput->outputImagesPartialOverlay[i] = new CVulkanTexture();
-			bSuccess = pOutput->outputImagesPartialOverlay[i]->BInit(
-				uWidth, uHeight, 1u, pOutput->uOutputFormatOverlay,
-				outputImageflags, &overlayDmabuf );
+			gamescope::OwningRc<gamescope::IBackendFb> pOverlayFb = GetBackend()->ImportDmabufToBackend( &overlayDmabuf );
+			bSuccess = pOverlayFb != nullptr;
+			if ( bSuccess )
+			{
+				pOutput->outputImagesPartialOverlay[i] = new CVulkanTexture();
+				bSuccess = pOutput->outputImagesPartialOverlay[i]->BInit(
+					uWidth, uHeight, 1u, pOutput->uOutputFormatOverlay,
+					outputImageflags, &overlayDmabuf, 0, 0, nullptr, std::move( pOverlayFb ) );
+			}
 		}
 
 		wlr_dmabuf_attributes_finish( &dmabuf );

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2518,9 +2518,7 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 	}
 	else if ( pDMA != nullptr && flags.bFlippable == true )
 	{
-		// Backend-allocated scanout image: clone the imported dmabuf so the
-		// backend can make an FB from it. (Client imports are never flippable,
-		// they only set bSampled.)
+		// Backend-allocated scanout image: clone the dmabuf for ImportDmabufToBackend.
 		m_dmabuf = *pDMA;
 		m_dmabuf.n_planes = 0;
 		for ( int i = 0; i < pDMA->n_planes; i++ )
@@ -2542,10 +2540,7 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 			return false;
 	}
 
-	// Imported client buffers with an X-format need alpha forced to 1 when
-	// sampled. Imported output images must keep the identity swizzle: they are
-	// storage images (swizzles are incompatible, see the assert below) and
-	// scanout ignores their alpha anyway.
+	// Imported output images stay identity-swizzled: they are storage images.
 	bool bHasAlpha = ( pDMA && !flags.bOutputImage ) ? DRMFormatHasAlpha( pDMA->format ) : true;
 
 	if (!bHasAlpha )
@@ -3335,33 +3330,24 @@ bool vulkan_remake_swapchain( void )
 	return bRet;
 }
 
-static std::vector<uint64_t> vulkan_get_backend_scanout_modifiers( VulkanOutput_t *pOutput )
-{
-	std::vector<uint64_t> modifiers;
-	const bool bHasOverlay = pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition;
-
-	for ( uint64_t ulModifier : GetBackend()->GetSupportedModifiers( pOutput->uOutputFormat ) )
-	{
-		if ( ulModifier == DRM_FORMAT_MOD_INVALID )
-			continue;
-		if ( bHasOverlay &&
-		     !gamescope::Algorithm::Contains( GetBackend()->GetSupportedModifiers( pOutput->uOutputFormatOverlay ), ulModifier ) )
-			continue;
-		modifiers.push_back( ulModifier );
-	}
-
-	return modifiers;
-}
-
 static bool vulkan_make_backend_output_images( VulkanOutput_t *pOutput,
 	const CVulkanTexture::createFlags &outputImageflags,
 	uint32_t uWidth, uint32_t uHeight )
 {
-	const std::vector<uint64_t> modifiers = vulkan_get_backend_scanout_modifiers( pOutput );
+	// Partial-composition overlay images alias the primary image's memory,
+	// which GBM cannot do.
+	if ( pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition )
+		return false;
+
+	std::vector<uint64_t> modifiers;
+	for ( uint64_t ulModifier : GetBackend()->GetSupportedModifiers( pOutput->uOutputFormat ) )
+	{
+		if ( ulModifier != DRM_FORMAT_MOD_INVALID )
+			modifiers.push_back( ulModifier );
+	}
 	if ( modifiers.empty() )
 		return false;
 
-	const bool bHasOverlay = pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition;
 	for ( size_t i = 0; i < pOutput->outputImages.size(); i++ )
 	{
 		wlr_dmabuf_attributes dmabuf = {};
@@ -3373,20 +3359,6 @@ static bool vulkan_make_backend_output_images( VulkanOutput_t *pOutput,
 		bool bSuccess = pOutput->outputImages[i]->BInit(
 			uWidth, uHeight, 1u, pOutput->uOutputFormat,
 			outputImageflags, &dmabuf );
-
-		// Unlike the Vulkan-allocated path (which aliases the primary image's
-		// memory via pExistingImageToReuseMemory), overlay images get their own
-		// backend allocation: GBM cannot alias memory that way, and overlay
-		// planes need their own flippable dmabuf anyway.
-		if ( bSuccess && bHasOverlay )
-		{
-			wlr_dmabuf_attributes overlayDmabuf = dmabuf;
-			overlayDmabuf.format = pOutput->uOutputFormatOverlay;
-			pOutput->outputImagesPartialOverlay[i] = new CVulkanTexture();
-			bSuccess = pOutput->outputImagesPartialOverlay[i]->BInit(
-				uWidth, uHeight, 1u, pOutput->uOutputFormatOverlay,
-				outputImageflags, &overlayDmabuf );
-		}
 
 		wlr_dmabuf_attributes_finish( &dmabuf );
 		if ( !bSuccess )
@@ -3421,20 +3393,12 @@ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
 	if ( g_uOutputRotation & 1u )
 		std::swap( uOutputWidth, uOutputHeight );
 
-	// Backends with scanout placement constraints (e.g. NVIDIA physical
-	// contiguity) allocate the scanout buffers themselves; Vulkan imports them.
 	bool bBackendAllocated = false;
 	if ( GetBackend()->UsesBackendAllocatedScanout() )
 	{
 		bBackendAllocated = vulkan_make_backend_output_images( pOutput, outputImageflags, uOutputWidth, uOutputHeight );
 		if ( !bBackendAllocated )
-		{
 			vk_log.errorf( "Failed to create backend-allocated scanout buffers, falling back to Vulkan allocation." );
-			for ( auto &pImage : pOutput->outputImages )
-				pImage = nullptr;
-			for ( auto &pImage : pOutput->outputImagesPartialOverlay )
-				pImage = nullptr;
-		}
 	}
 
 	if ( !bBackendAllocated )

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3334,16 +3334,19 @@ static bool vulkan_make_backend_output_images( VulkanOutput_t *pOutput,
 	const CVulkanTexture::createFlags &outputImageflags,
 	uint32_t uWidth, uint32_t uHeight )
 {
-	// Partial-composition overlay images alias the primary image's memory,
-	// which GBM cannot do.
-	if ( pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition )
-		return false;
+	const bool bHasOverlay = pOutput->uOutputFormatOverlay != VK_FORMAT_UNDEFINED && !kDisablePartialComposition;
 
+	// Overlay images alias the primary buffer with a different format, so the
+	// modifier must be valid for both.
 	std::vector<uint64_t> modifiers;
 	for ( uint64_t ulModifier : GetBackend()->GetSupportedModifiers( pOutput->uOutputFormat ) )
 	{
-		if ( ulModifier != DRM_FORMAT_MOD_INVALID )
-			modifiers.push_back( ulModifier );
+		if ( ulModifier == DRM_FORMAT_MOD_INVALID )
+			continue;
+		if ( bHasOverlay &&
+		     !gamescope::Algorithm::Contains( GetBackend()->GetSupportedModifiers( pOutput->uOutputFormatOverlay ), ulModifier ) )
+			continue;
+		modifiers.push_back( ulModifier );
 	}
 	if ( modifiers.empty() )
 		return false;
@@ -3359,6 +3362,16 @@ static bool vulkan_make_backend_output_images( VulkanOutput_t *pOutput,
 		bool bSuccess = pOutput->outputImages[i]->BInit(
 			uWidth, uHeight, 1u, pOutput->uOutputFormat,
 			outputImageflags, &dmabuf );
+
+		if ( bSuccess && bHasOverlay )
+		{
+			wlr_dmabuf_attributes overlayDmabuf = dmabuf;
+			overlayDmabuf.format = pOutput->uOutputFormatOverlay;
+			pOutput->outputImagesPartialOverlay[i] = new CVulkanTexture();
+			bSuccess = pOutput->outputImagesPartialOverlay[i]->BInit(
+				uWidth, uHeight, 1u, pOutput->uOutputFormatOverlay,
+				outputImageflags, &overlayDmabuf );
+		}
 
 		wlr_dmabuf_attributes_finish( &dmabuf );
 		if ( !bSuccess )

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -211,6 +211,7 @@ private:
 	bool m_bInitialized = false;
 	bool m_bExternal = false;
 	bool m_bOutputImage = false;
+	bool m_bOwnsImage = false;
 
 	uint32_t m_drmFormat = DRM_FORMAT_INVALID;
 
@@ -769,6 +770,7 @@ static inline uint32_t div_roundup(uint32_t x, uint32_t y)
 	VK_FUNC(GetImageMemoryRequirements) \
 	VK_FUNC(GetImageSubresourceLayout) \
 	VK_FUNC(GetMemoryFdKHR) \
+	VK_FUNC(GetMemoryFdPropertiesKHR) \
 	VK_FUNC(GetSemaphoreCounterValue) \
 	VK_FUNC(GetSwapchainImagesKHR) \
 	VK_FUNC(MapMemory) \


### PR DESCRIPTION
This PR delivers a GBM Scanout Backend for NVIDIA GPUs to fix the very long ongoing Issue with Nvidia Display Corruption over a Resolution of 1440p or with HDR.

When `gamescope_drm_nvidia_gbm_scanout=true` is set, GBM is used to do Scanout which is then imported into Vulkan for Presentation.

It also forces composition to be on to avoid direct scanout running into the corruption.

This has undergone 3 Days of Testing at around 5 Hours each in many Games varying from DX12, DX11, DX9, OpenGL and Vulkan.
Performance tests were also done and i was not able to see any Perfromance Degradation over two diffrent Systems. One running a 5080. The other one a 5070.

Other users also reported success with this.

Relevant Issues:
https://github.com/anatase-org/anatase/issues/1
https://github.com/ValveSoftware/gamescope/issues/1593#issuecomment-5389755829
https://github.com/ValveSoftware/gamescope/issues/2309#issuecomment-5379622707

Attempts at fixing the Black Transparancy Issue in Steam sadly failed, but I was able to track this down to the CEF Version used by Steam itself which seemingly does not produce transparancy in its rendered frames. So unrelated to this and not caused by this.

AI Disclosure: 
AI assisted in searching for the core of the Issue and in constructing the Solution.