### PR TITLE
steamcompmgr: place a screen-sized focus window at the origin

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4733,27 +4733,47 @@ get_win_icon(xwayland_ctx_t* ctx, steamcompmgr_win_t* w)
 	get_prop(ctx, w->xwayland().id, ctx->atoms.netWMIcon, *w->icon.get());
 }
 
+// Toplevels of desktop apps, whose geometry we manage.
+static bool
+win_is_desktop_window(steamcompmgr_win_t *w)
+{
+	if ( !w )
+		return false;
+
+	if ( win_has_game_id( w ) || w->bIsSteamPid || w->bIsSteamWebHelperPid || w->bIsVRWebHelperPid )
+		return false;
+
+	if ( w->type != steamcompmgr_win_type_t::XWAYLAND )
+		return false;
+
+	if ( w->xwayland().a.override_redirect || ( w->oulTargetVROverlay && !cv_vr_show_forwarded_overlays ) )
+		return false;
+
+	if ( win_maybe_a_dropdown( w ) || win_is_useless( w ) )
+		return false;
+
+	return true;
+}
+
+// Desktop toplevels we size to the screen, which can only be reached at the origin.
+static bool
+win_sized_to_screen(steamcompmgr_win_t *w)
+{
+	if ( !win_is_desktop_window( w ) )
+		return false;
+
+	return !w->sizeHintsSpecified || window_is_fullscreen( w ) || w->xwayland().ctx->force_windows_fullscreen;
+}
+
 static void
 handle_desktop_window(steamcompmgr_win_t *w)
 {
-	if ( !w )
-		return;
-
-	if ( win_has_game_id( w ) || w->bIsSteamPid || w->bIsSteamWebHelperPid || w->bIsVRWebHelperPid )
-		return;
-
-	if ( w->type != steamcompmgr_win_type_t::XWAYLAND )
-		return;
-
-	if ( w->xwayland().a.override_redirect || ( w->oulTargetVROverlay && !cv_vr_show_forwarded_overlays ) )
-		return;
-
-	if ( win_maybe_a_dropdown( w ) || win_is_useless( w ) )
+	if ( !win_is_desktop_window( w ) )
 		return;
 
 	xwayland_ctx_t *ctx = w->xwayland().ctx;
 
-	if ( w->sizeHintsSpecified && !(window_is_fullscreen( w ) || ctx->force_windows_fullscreen) )
+	if ( !win_sized_to_screen( w ) )
 	{
 		if ((unsigned)w->GetGeometry().nWidth != w->requestedWidth || (unsigned)w->GetGeometry().nHeight != w->requestedHeight)
 		{
@@ -5311,7 +5331,45 @@ static void configure_request(xwayland_ctx_t *ctx, XConfigureRequestEvent *confi
 		.stack_mode = configureRequest->detail
 	};
 
-	XConfigureWindow( ctx->dpy, configureRequest->window, configureRequest->value_mask, &changes );
+	// Honoring a move here would only take its input off screen. Size hints are not read before map.
+	unsigned long value_mask = configureRequest->value_mask;
+	steamcompmgr_win_t *w = find_win( ctx, configureRequest->window, false );
+	bool bRefuseMove = win_sized_to_screen( w ) && w->xwayland().a.map_state == IsViewable && ( value_mask & ( CWX | CWY ) );
+	if ( bRefuseMove )
+		value_mask &= ~( CWX | CWY );
+
+	XConfigureWindow( ctx->dpy, configureRequest->window, value_mask, &changes );
+
+	// X sends nothing for a change that did not happen, so ICCCM 4.1.5 has us tell the client where it still is.
+	// See http://tronche.com/gui/x/icccm/sec-4.html#s-4.1.5
+	if ( bRefuseMove )
+	{
+		bool bSizeChanges = ( ( value_mask & CWWidth ) && changes.width != w->xwayland().a.width ) ||
+		                    ( ( value_mask & CWHeight ) && changes.height != w->xwayland().a.height ) ||
+		                    ( ( value_mask & CWBorderWidth ) && changes.border_width != w->xwayland().a.border_width );
+		if ( bSizeChanges )
+			return;
+
+		XEvent notify =
+		{
+			.xconfigure =
+			{
+				.type = ConfigureNotify,
+				.send_event = True,
+				.display = ctx->dpy,
+				.event = configureRequest->window,
+				.window = configureRequest->window,
+				.x = w->xwayland().a.x,
+				.y = w->xwayland().a.y,
+				.width = w->xwayland().a.width,
+				.height = w->xwayland().a.height,
+				.border_width = w->xwayland().a.border_width,
+				.above = None,
+				.override_redirect = False,
+			},
+		};
+		XSendEvent( ctx->dpy, configureRequest->window, False, StructureNotifyMask, &notify );
+	}
 }
 
 static void circulate_request( xwayland_ctx_t *ctx, XCirculateRequestEvent *circulateRequest )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3981,6 +3981,20 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 		ctx->focus.focusWindow->nudged = true;
 	}
 
+	// X confines the pointer to the screen, so a screen-sized focus window only
+	// sees all of it at the origin. Place it there once, a client that moves it
+	// afterwards keeps its position. Oversized windows stay put, clients centre
+	// those to keep the middle reachable.
+	const Rect rect = w->GetGeometry();
+
+	if ( !w->placed && rect.nWidth == ctx->root_width && rect.nHeight == ctx->root_height )
+	{
+		if ( rect.nX != 0 || rect.nY != 0 )
+			XMoveWindow(ctx->dpy, w->xwayland().id, 0, 0);
+
+		w->placed = true;
+	}
+
 	if ( win_has_game_id( w ) )
 	{
 		if ( window_is_fullscreen( ctx->focus.focusWindow ) || ctx->force_windows_fullscreen )
@@ -5167,6 +5181,7 @@ add_win(xwayland_ctx_t *ctx, Window id, Window prev, unsigned long sequence)
 	new_win->requestedWidth = 0;
 	new_win->requestedHeight = 0;
 	new_win->nudged = false;
+	new_win->placed = false;
 	new_win->ignoreOverrideRedirect = false;
 
 	wlserver_x11_surface_info_init( &new_win->xwayland().surface, ctx->xwayland_server, id );
@@ -5233,6 +5248,10 @@ configure_win(xwayland_ctx_t *ctx, XConfigureEvent *ce)
 			ctx->root_height = ce->height;
 			MakeFocusDirty();
 
+			// Screen-sized is relative to the screen, re-arm every placement.
+			for ( steamcompmgr_win_t *pWindow = ctx->list; pWindow; pWindow = pWindow->xwayland().next )
+				pWindow->placed = false;
+
 			gamescope_xwayland_server_t *root_server = wlserver_get_xwayland_server(0);
 			xwayland_ctx_t *root_ctx = root_server->ctx.get();
 			XDeleteProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeXWaylandModeControl );
@@ -5240,6 +5259,11 @@ configure_win(xwayland_ctx_t *ctx, XConfigureEvent *ce)
 		}
 		return;
 	}
+
+	// Resizing re-arms the placement. Moving does not, so we never fight a
+	// client that drags its window off.
+	if ( ce->width != w->xwayland().a.width || ce->height != w->xwayland().a.height )
+		w->placed = false;
 
 	w->xwayland().a.x = ce->x;
 	w->xwayland().a.y = ce->y;

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -151,6 +151,7 @@ struct steamcompmgr_win_t {
 	bool bHasHadNonSRGBColorSpace = false;
 
 	bool nudged = false;
+	bool placed = false;
 	bool ignoreOverrideRedirect = false;
 
 	bool unlockedForFrameCallback = false;


### PR DESCRIPTION
Xwayland turns pointer positions into root coordinates and X confines the pointer to the screen, so a focus window as large as the screen never sees input past whatever edge it hangs off. Nothing bounds checked it. It only kept working while focus windows were pinned near the origin, first by the snap a563226d431d dropped and then by the orphaned nudge that 33f3776918b8 removed, so a client that centers itself and then grows to the screen size in place is now left hanging off it.

Place a window exactly that size at the origin once, re-armed only when a resize or a screen size change makes covering the screen mean something different, so a client that moves the window afterwards keeps its position rather than fighting us.

Fixes: https://github.com/ValveSoftware/gamescope/issues/2294 (cherry picked from commit 8e72b0ae783a19d2e3cd181816b164cae2bbcd27)