### PR TITLE
Utils: bound the "true" compare in Parse<bool> to the view's length

### DIFF
--- a/src/Utils/Parsers.h
+++ b/src/Utils/Parsers.h
@@ -26,7 +26,8 @@ namespace gamescope
         if ( oNumber )
             return !!*oNumber;
 
-        if ( strcasecmp ( chars.data(), "true" ) == 0 )
+        // chars is not null-terminated.
+        if ( chars.size() == 4 && strncasecmp( chars.data(), "true", 4 ) == 0 )
             return true;
         else
             return false;

--- a/tests/test_convar.cpp
+++ b/tests/test_convar.cpp
@@ -46,4 +46,11 @@ TEST_CASE("ConVar", "[convar]") {
 		ConVar<bool>* cv = proxy;
 		REQUIRE(cv == nullptr);
 	}
+
+	{
+		// The trailing space leaves the token not null-terminated.
+		REQUIRE(cv_bool_var.Get() == false);
+		cv_bool_var.CallWithArgString("true ");
+		REQUIRE(cv_bool_var.Get() == true);
+	}
 }

--- a/tests/test_utils_parsers.cpp
+++ b/tests/test_utils_parsers.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <string_view>
 #include <type_traits>
 
 #include "Utils/Parsers.h"
@@ -91,5 +92,12 @@ TEST_CASE("Utils/Parsers", "[parsers]") {
         REQUIRE(Parse<bool>("0.1") == false);
         REQUIRE(Parse<bool>("foo") == false);
         REQUIRE(Parse<bool>("") == false);
+
+        std::string_view trueBar = "true bar";
+        REQUIRE(Parse<bool>(trueBar.substr(0, 4)) == true);
+        REQUIRE(Parse<bool>(trueBar.substr(0, 3)) == false);
+        REQUIRE(Parse<bool>(trueBar) == false);
+        const char unterminated[4] = { 't', 'r', 'u', 'e' };
+        REQUIRE(Parse<bool>(std::string_view(unterminated, 4)) == true);
     }
 }


### PR DESCRIPTION
Parse<bool> takes a std::string_view but hands chars.data() to strcasecmp, which ignores the view's length. Tokens coming out of Split, which ConVar::CallWithArgString produces, are not null-terminated when a delimiter follows them, so calling a bool convar with "true " compares "true " against "true" and yields false.

Compare exactly chars.size() bytes with strncasecmp and require the length to match, so the check stays case-insensitive but never looks outside the view. Add tests as well.