### PR TITLE
main: reject negative --nested-refresh

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -747,6 +747,11 @@ int main(int argc, char **argv)
 				break;
 			case 'r':
 				g_nNestedRefresh = gamescope::ConvertHztomHz( parse_integer( optarg, "nested-refresh" ) );
+				if ( g_nNestedRefresh < 0 )
+				{
+					fprintf( stderr, "gamescope: invalid value for --nested-refresh, must be >= 0\n" );
+					exit(1);
+				}
 				break;
 			case 'W':
 				g_nPreferredOutputWidth = parse_integer( optarg, "output-width" );


### PR DESCRIPTION
`gamescope -r -1` hangs at startup with a thread spinning at 100% CPU.
No output, no exit, no crash.

### Mechanism

`ConvertHztomHz(-100)` gives `-100000`, which reaches
`RefreshCycleTomHz(int32_t nCycle)` in `refresh_rate.h`:

    return ( 1'000'000'000'000ul + ( nCycle / 2 ) - 1 ) / nCycle;

The `ul` literal forces unsigned arithmetic, so the negative divisor
converts to a huge unsigned value and the quotient truncates to 0.

`CVBlankTimer::GetNextVBlank` then cannot terminate:

    while ( ulTargetPoint < ulNow )
        ulTargetPoint += ulIntervalNSecs;   // += 0

Confirmed under gdb with `-r -100`:

    Thread 8 "gamescope-xwm"
    #0  CVBlankTimer::GetNextVBlank (...) at src/vblankmanager.cpp:90
    #1  CVBlankTimer::CalcNextWakeupTime (bPreemptive=true) at src/vblankmanager.cpp:179
    #2  CVBlankTimer::ArmNextVBlank (bPreemptive=true) at src/vblankmanager.cpp:240
    #3  steamcompmgr_main (...) at src/steamcompmgr.cpp:8815

    (gdb) p ulIntervalNSecs
    $4 = 0
    (gdb) p g_nNestedRefresh
    $3 = -100000

### Fix

Reject negative values at parse time. 0 stays valid: it's the default
(`int g_nNestedRefresh = 0`) and the sentinel for "use the output
refresh rate", consumed as such in `wlserver.cpp`.

    $ gamescope -r -1 -- true
    gamescope: invalid value for --nested-refresh, must be >= 0    # exit 1
    $ gamescope -r 0 -- true      # exit 0, unchanged
    $ gamescope -r 60 -- true     # exit 0, unchanged

### Note

The signed/unsigned mixing in `RefreshCycleTomHz` is arguably the
underlying defect, but it's `constexpr` and used in several places, so
this patch only stops the hang. Happy to look at that separately if
you'd prefer it fixed there.

`meson test --suite gamescope` 2/2, `--werror` build clean (689/689).
Tested on `fcc1341`.