### PR TITLE
WaylandBackend: clear Frog transfer on passthrough

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1556,7 +1556,7 @@ namespace gamescope
                     default:
                     case GAMESCOPE_APP_TEXTURE_COLORSPACE_PASSTHRU:
                         frog_color_managed_surface_set_known_container_color_volume( m_pFrogColorManagedSurface, FROG_COLOR_MANAGED_SURFACE_PRIMARIES_UNDEFINED );
-                        frog_color_managed_surface_set_known_container_color_volume( m_pFrogColorManagedSurface, FROG_COLOR_MANAGED_SURFACE_TRANSFER_FUNCTION_UNDEFINED );
+                        frog_color_managed_surface_set_known_transfer_function( m_pFrogColorManagedSurface, FROG_COLOR_MANAGED_SURFACE_TRANSFER_FUNCTION_UNDEFINED );
                         break;
                     case GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR:
                     case GAMESCOPE_APP_TEXTURE_COLORSPACE_SRGB:


### PR DESCRIPTION
## Summary

Frog passthrough transitions leave the previous transfer function active because Gamescope sends the undefined transfer value through the container-color-volume request; this uses the matching transfer-function request.

## Why This Exists

When a nested Gamescope session transitions from an HDR10/PQ client back to a passthrough surface, the compositor receives undefined primaries but never receives an undefined transfer function. A persistent surface can therefore remain tagged PQ after HDR content exits.

## Resolution

Send `FROG_COLOR_MANAGED_SURFACE_TRANSFER_FUNCTION_UNDEFINED` with `frog_color_managed_surface_set_known_transfer_function`, matching the request used by the SRGB, HDR10/PQ, and scRGB branches below it.

## Reviewer Considerations

- This is a one-call correction in the Frog protocol path; no state or fallback behavior is added.
- The failure is visible only across a transition because destroying the surface also clears the stale state.

## Behavior Changes

Persistent nested surfaces correctly clear their PQ transfer state when returning to passthrough output.

## Verification

- `git diff --check`
- Compared the passthrough request pair with the typed requests in the SRGB, HDR10/PQ, and scRGB branches.

## Risk

Low; the value and request now use the same Frog transfer-function enum and API.
