### PR TITLE
WaylandBackend: don't gate HDR10 on color-management features we never request

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -712,6 +712,9 @@ namespace gamescope
         wp_presentation *GetPresentation() const { return m_pPresentation; }
         frog_color_management_factory_v1 *GetFrogColorManagementFactory() const { return m_pFrogColorMgmtFactory; }
         wp_color_manager_v1 *GetWPColorManager() const { return m_pWPColorManager; }
+        bool SupportsWPSCRGB() const { return m_WPColorManagerFeatures.bSupportsSCRGB; }
+        bool SupportsWPSaturationScale() const { return m_WPColorManagerFeatures.bSupportsSaturationScale; }
+        bool SupportsWPMasteringMetadata() const { return m_WPColorManagerFeatures.bSupportsMasteringMetadata; }
         wp_image_description_v1 *GetWPImageDescription( GamescopeAppTextureColorspace eColorspace ) const { return m_pWPImageDescriptions[ (uint32_t)eColorspace ]; }
         wp_fractional_scale_manager_v1 *GetFractionalScaleManager() const { return m_pFractionalScaleManager; }
         xdg_toplevel_icon_manager_v1 *GetToplevelIconManager() const { return m_pToplevelIconManager; }
@@ -824,7 +827,13 @@ namespace gamescope
             std::vector<wp_color_manager_v1_render_intent> eRenderIntents;
             std::vector<wp_color_manager_v1_feature> eFeatures;
 
-            bool bSupportsGamescopeColorManagement = false; // Has everything we want and need?
+            bool bSupportsGamescopeColorManagement = false; // Can we drive HDR10 through wp_color_manager_v1?
+
+            // Optional extras. Each guards only the request that needs it, so a
+            // compositor advertising a partial feature set still gets HDR10.
+            bool bSupportsSCRGB = false;             // create_windows_scrgb
+            bool bSupportsSaturationScale = false;   // explicit set_primaries
+            bool bSupportsMasteringMetadata = false; // set_mastering_display_primaries
         } m_WPColorManagerFeatures;
 
         std::unordered_map<wl_output *, WaylandOutputInfo> m_pOutputs;
@@ -1485,7 +1494,7 @@ namespace gamescope
                         m_pCurrentImageDescription = nullptr;
                     }
 
-                    if ( oState->eColorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB )
+                    if ( oState->eColorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB && m_pBackend->SupportsWPSCRGB() )
                     {
                         m_pCurrentImageDescription = wp_color_manager_v1_create_windows_scrgb( m_pBackend->GetWPColorManager() );
                     }
@@ -1493,7 +1502,7 @@ namespace gamescope
                     {
                         wp_image_description_creator_params_v1 *pParams = wp_color_manager_v1_create_parametric_creator( m_pBackend->GetWPColorManager() );
 
-                        if ( close_enough( flScale, 1.0f ) )
+                        if ( close_enough( flScale, 1.0f ) || !m_pBackend->SupportsWPSaturationScale() )
                         {
                             wp_image_description_creator_params_v1_set_primaries_named( pParams, WP_COLOR_MANAGER_V1_PRIMARIES_BT2020 );
                         }
@@ -1510,7 +1519,7 @@ namespace gamescope
                                 (int32_t)(0.3290 * 1'000'000.0) );
                         }
                         wp_image_description_creator_params_v1_set_tf_named( pParams, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ );
-                        if ( m_ColorState->pHDRMetadata )
+                        if ( m_ColorState->pHDRMetadata && m_pBackend->SupportsWPMasteringMetadata() )
                         {
                             const hdr_metadata_infoframe *pInfoframe = &m_ColorState->pHDRMetadata->View<hdr_output_metadata>().hdmi_metadata_type1;
 
@@ -2020,20 +2029,21 @@ namespace gamescope
 
         if ( m_pWPColorManager )
         {
-            m_WPColorManagerFeatures.bSupportsGamescopeColorManagement = [this]() -> bool
+            auto HasFeature = [this]( wp_color_manager_v1_feature eFeature ) -> bool
             {
-                // Features
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_PARAMETRIC ) )
-                    return false;
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_SET_PRIMARIES ) )
-                    return false;
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_SET_MASTERING_DISPLAY_PRIMARIES ) )
-                    return false;
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_EXTENDED_TARGET_VOLUME ) )
-                    return false;
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_SET_LUMINANCES ) )
-                    return false;
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, WP_COLOR_MANAGER_V1_FEATURE_WINDOWS_SCRGB ) )
+                return Algorithm::Contains( m_WPColorManagerFeatures.eFeatures, eFeature );
+            };
+
+            m_WPColorManagerFeatures.bSupportsSCRGB             = HasFeature( WP_COLOR_MANAGER_V1_FEATURE_WINDOWS_SCRGB );
+            m_WPColorManagerFeatures.bSupportsSaturationScale   = HasFeature( WP_COLOR_MANAGER_V1_FEATURE_SET_PRIMARIES );
+            m_WPColorManagerFeatures.bSupportsMasteringMetadata = HasFeature( WP_COLOR_MANAGER_V1_FEATURE_SET_MASTERING_DISPLAY_PRIMARIES );
+
+            m_WPColorManagerFeatures.bSupportsGamescopeColorManagement = [&]() -> bool
+            {
+                // HDR10 needs a parametric creator, the named BT2020 primaries and the
+                // named ST2084 PQ transfer function. Named primaries and transfer
+                // functions are advertised on their own events and have no feature bit.
+                if ( !HasFeature( WP_COLOR_MANAGER_V1_FEATURE_PARAMETRIC ) )
                     return false;
 
                 // Transfer Functions
@@ -2049,6 +2059,13 @@ namespace gamescope
                 return true;
             }();
 
+            xdg_log.infof( "wp_color_manager_v1: host advertised %zu features -> hdr10=%s scrgb=%s saturation_scale=%s mastering_metadata=%s",
+                m_WPColorManagerFeatures.eFeatures.size(),
+                m_WPColorManagerFeatures.bSupportsGamescopeColorManagement ? "yes" : "no",
+                m_WPColorManagerFeatures.bSupportsSCRGB ? "yes" : "no",
+                m_WPColorManagerFeatures.bSupportsSaturationScale ? "yes" : "no",
+                m_WPColorManagerFeatures.bSupportsMasteringMetadata ? "yes" : "no" );
+
             if ( m_WPColorManagerFeatures.bSupportsGamescopeColorManagement )
             {
                 // HDR10.
@@ -2060,6 +2077,7 @@ namespace gamescope
                 }
 
                 // scRGB
+                if ( m_WPColorManagerFeatures.bSupportsSCRGB )
                 {
                     m_pWPImageDescriptions[ GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB ] = wp_color_manager_v1_create_windows_scrgb( m_pWPColorManager );
                 }


### PR DESCRIPTION
## What does this change?

This implements the fix @randyp-git described in #2249. They diagnosed it on Mutter 49
against gamescope 3.16.24, worked out that the aggregate capability gate rejects a
perfectly usable HDR10 PQ subset, spotted that gamescope also sends mastering-display
requests the compositor never advertised, and confirmed both with a proof of concept.
The issue has sat open with no PR, so I have written it up against current master and
tested it on Mutter 50. The analysis below is theirs; I checked each point against the
tree as it stands now.

`CWaylandBackend`'s `wp_color_manager_v1` check is a single all-or-nothing gate that
wants six features before gamescope will enable any color management at all, and it
asks for a good deal more than the code ever issues:

1. `set_luminances` has no call site anywhere in the tree.
2. `extended_target_volume` is referenced only by the gate itself.
3. `windows_scrgb` is only used to create the scRGB image description.
4. `set_primaries` is only used when `wayland_hdr10_saturation_scale` is not 1.0, and
   it defaults to 1.0.
5. `set_mastering_display_primaries` is only used when the app supplies HDR metadata.

That leaves `parametric` as the only feature HDR10 genuinely needs. The HDR10 path
also calls `set_primaries_named` and `set_tf_named`, but named primaries and transfer
functions are advertised through `supported_primaries_named` / `supported_tf_named`,
have no entry in the `feature` enum, and are already checked separately against
`ePrimaries` and `eTransferFunctions`.

So I split the gate. It now requires what HDR10 needs, and the three optional
capabilities are tracked as their own flags, each guarding the call site that issues
the matching request: scRGB leaves the image description unset, saturation scaling
falls back to named BT2020 primaries, and the mastering metadata block is skipped.
This is a split rather than a relaxation, and every request is still gated on the
feature that actually covers it.

One difference from the proof of concept in #2249: they also had to handle a missing
target luminance, since Mutter 49 reported `uMaxLum: 203`, equal to the reference
luminance. On Mutter 50 I get `uMaxLum: 10000`, so I have left that path alone and this
change is smaller as a result. If that is still a problem on older Mutter it probably
wants its own fix.

I also added a line at startup reporting what the host advertised, since the gate
failing silently is what made this hard to pin down in the first place:

```
wp_color_manager_v1: host advertised 5 features -> hdr10=yes scrgb=no saturation_scale=yes mastering_metadata=no
```

## Why?

Nested gamescope reports no HDR support at all on GNOME. Mutter advertises five of the
six, missing `windows_scrgb` and `set_mastering_display_primaries`. Neither is needed
for HDR10, but because the gate is all-or-nothing, missing either one throws away
color management entirely and `bExposeHDRSupport` comes out false.

**Environment:** GNOME Shell 50.1 / Mutter 50, Wayland session, RTX 4090 on nvidia-open
610.43.02, 5120x1440 HDR OLED. Nested backend, no TTY and no DRM backend involved.

I had been running gamescope's DRM backend from a TTY to get HDR at all, which does
work, but it means dropping out of the desktop session every time I want to play
something. With this the nested path works and I can stay in a normal session.

Worth saying that the fallbacks are not theoretical here. My host does not advertise
`set_mastering_display_primaries`, DOOM: The Dark Ages supplies HDR metadata anyway,
the block gets skipped, and HDR10 presentation is unaffected. That path is exercised
on every run on this machine.

I have not tested against a compositor that advertises all six, so I want to be clear
that part is by inspection rather than measurement. When all six are present each new
guard reduces to its previous form: the two `&&` guards become `&& true`, the
saturation-scale guard becomes `|| false` and collapses back to the original
`close_enough` test, and the scRGB image description is created unconditionally as
before. The gate wanted all six plus the transfer function and primaries checks and
now wants `parametric` plus the same transfer function and primaries checks, so it
evaluates identically. The only added statement is the log line, which issues no
requests. A full-support compositor should see exactly the same sequence of requests
it saw before.

## How to test

1. In a GNOME Wayland session with HDR enabled on the display, run gamescope nested
   with `--hdr-enabled` and a real HDR title. I used DOOM: The Dark Ages (app 3017860)
   under Proton with `PROTON_ENABLE_HDR=1`.
2. Without this change: `bExposeHDRSupport: false`, the Gamescope WSI layer reports
   `server hdr output enabled: false` and `hdr formats exposed to client: false`, and
   the game's HDR option is unavailable.
3. With this change: `bExposeHDRSupport: true`, WSI reports both as `true`, and turning
   HDR on in the game's display settings recreates the swapchain as HDR10 inside the
   same process:

```
Creating swapchain ... format: VK_FORMAT_B8G8R8A8_UNORM - colorspace: VK_COLOR_SPACE_SRGB_NONLINEAR_KHR
...
Creating swapchain ... format: VK_FORMAT_A2B10G10R10_UNORM_PACK32 - colorspace: VK_COLOR_SPACE_HDR10_ST2084_EXT
VkHdrMetadataEXT: display primaries:
                      r: 0.708 0.292
                      g: 0.17 0.797
                      b: 0.131 0.046
                      w: 0.3127 0.329
                  mastering luminance: min 0.0001 nits, max 4000 nits
                  maxContentLightLevel: 4000 nits
                  maxFrameAverageLightLevel: 500 nits
```

Those are the BT.2020 primaries with a D65 white point, so the metadata is going
through intact. I played for about 15 minutes with no visual problems and a clean exit.

## Checklist

- [x] Builds cleanly on current master (3.16.28)
- [x] Tested nested under Mutter with a real HDR title
- [ ] Not tested under a compositor advertising all six features (KWin)

Addresses #2249.

## Credit

The diagnosis and both fixes in this PR are @randyp-git's, from their report in #2249.
I implemented them against current master and tested them on a different Mutter
version; the underlying analysis is theirs.

I did this work on top of NightHammer1000's gamescope fork, which I run for its NVIDIA
GBM scanout patches. None of that code is in this PR. The change touches only
`WaylandBackend.cpp`, which is identical to master, and the commit applies on its own.

---

Side note, unrelated but noticed while I was in there: the gate still requires
`WP_COLOR_MANAGER_V1_PRIMARIES_SRGB` in `ePrimaries`. HDR10 uses the named BT2020
primaries and does not need the sRGB ones, so this looks like the same kind of
over-demand the rest of this PR removes. I left it alone to keep the change scoped,
and my host advertises it so it costs me nothing, but given the history of gamescope
requiring sRGB entries that some compositors do not send it may be worth a look. Happy
to open a separate issue if there is interest.
