### PR TITLE
Per-connector composite + mangoapp

### DIFF
--- a/src/Apps/gamescopereaper.cpp
+++ b/src/Apps/gamescopereaper.cpp
@@ -139,7 +139,8 @@ namespace gamescope
         {
             // Wait for the primary child to die, then forward the death signal to
             // all of the other children, if we aren't in a PID namespace.
-            Process::WaitForAllChildren( nPrimaryChild );
+            if ( s_bRun )
+                Process::WaitForAllChildren( nPrimaryChild );
 
             if ( bRespawn )
             {
@@ -148,7 +149,8 @@ namespace gamescope
                     s_ReaperLog.infof( "\"%s\" process shut down. Restarting.", argv[ nSubCommandArgc ] );
 
                     nPrimaryChild = Process::SpawnProcess( &argv[ nSubCommandArgc ] );
-                    Process::WaitForAllChildren( nPrimaryChild );
+                    if ( s_bRun )
+                        Process::WaitForAllChildren( nPrimaryChild );
                 }
             }
 

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -3647,7 +3647,7 @@ namespace gamescope
 
 			bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
-			bool bNeedsCompositeFromFilter = (g_upscaleFilter == GamescopeUpscaleFilter::NEAREST || g_upscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
+			bool bNeedsCompositeFromFilter = (pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::NEAREST || pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
 
 			bool bNeedsFullComposite = false;
 			bNeedsFullComposite |= cv_composite_force;

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -2133,10 +2133,12 @@ namespace gamescope
             m_sDashboardOverlayKey = sOverlayKey;
             openvr_log.debugf( "Creating new dashboard overlay: %s", m_sDashboardOverlayKey.c_str() );
 
-            vr::VROverlay()->CreateDashboardOverlay(
+            vr::EVROverlayError err = vr::VROverlay()->CreateDashboardOverlay(
                 sOverlayKey.c_str(),
                 m_pBackend->GetOverlayName(),
                 &m_hOverlay, &m_hOverlayThumbnail );
+            if ( err != vr::VROverlayError_None )
+                openvr_log.errorf( "Failed to create dashboard overlay %s: %s", sOverlayKey.c_str(), vr::VROverlay()->GetOverlayErrorNameFromEnum( err ) );
 
             vr::VROverlay()->SetOverlayFlag( m_hOverlay, vr::VROverlayFlags_EnableControlBar,		  m_pBackend->ShouldEnableControlBar() || bExplicitNonSteam );
             vr::VROverlay()->SetOverlayFlag( m_hOverlay, vr::VROverlayFlags_EnableControlBarKeyboard, m_pBackend->ShouldEnableControlBarKeyboard() || bExplicitNonSteam );
@@ -2162,7 +2164,9 @@ namespace gamescope
         else
         {
             std::string szSubviewName = sOverlayKey + std::string(".layer") + std::to_string( m_uSortOrder );
-            vr::VROverlay()->CreateSubviewOverlay( pParent->GetOverlay(), szSubviewName.c_str(), "Gamescope Layer", &m_hOverlay );
+            vr::EVROverlayError err = vr::VROverlay()->CreateSubviewOverlay( pParent->GetOverlay(), szSubviewName.c_str(), "Gamescope Layer", &m_hOverlay );
+            if ( err != vr::VROverlayError_None )
+                openvr_log.errorf( "Failed to create subview overlay %s: %s", szSubviewName.c_str(), vr::VROverlay()->GetOverlayErrorNameFromEnum( err ) );
         }
 
         vr::VROverlay()->SetOverlayFlag( m_hOverlay, vr::VROverlayFlags_EnableClickStabilization, m_pBackend->ShouldEnableClickStabilization() );

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -395,6 +395,7 @@ namespace gamescope
 
         bool ConsumeNudgeToVisible() { return std::exchange( m_bNudgeToVisible, false ); }
         bool IsRelativeMouse() const { return m_bRelativeMouse; }
+        void UpdateCursorOverride( const FrameInfo_t::Layer_t *pCursorLayer );
 
         // Thread safe.
         bool IsVisible() const
@@ -1653,6 +1654,28 @@ namespace gamescope
         return "Virtual Display";
     }
 
+    // A physical mouse moves SteamVR's own pointer, the laser draws itself.
+    void COpenVRConnector::UpdateCursorOverride( const FrameInfo_t::Layer_t *pCursorLayer )
+    {
+        bool bUsingPhysicalMouse = m_pBackend->GetCurrentMouseConnector() == this && !m_bUsingVRMouse;
+        if ( pCursorLayer && bUsingPhysicalMouse && !IsRelativeMouse() )
+        {
+            vr::HmdVector2_t vMousePos =
+            {
+                static_cast<float>( -pCursorLayer->offset.x ),
+                static_cast<float>( static_cast<float>( g_nOutputHeight ) + pCursorLayer->offset.y ),
+            };
+
+            vr::VROverlay()->SetOverlayCursorPositionOverride( GetPrimaryPlane()->GetOverlay(), &vMousePos );
+            m_bCurrentlyOverridingPosition = true;
+        }
+        else if ( m_bCurrentlyOverridingPosition )
+        {
+            vr::VROverlay()->ClearOverlayCursorPositionOverride( GetPrimaryPlane()->GetOverlay() );
+            m_bCurrentlyOverridingPosition = false;
+        }
+    }
+
     int COpenVRConnector::Present( const FrameInfo_t *pFrameInfo, bool bAsync )
     {
         bool bNeedsFullComposite = false;
@@ -1712,49 +1735,36 @@ namespace gamescope
                     } );
             }
 
-            bool bShouldHideCursor = true;
-
+            const FrameInfo_t::Layer_t *pCursorLayer = nullptr;
             for ( int i = 0; i < 8 && uCurrentPlane < 8; i++ )
             {
                 const FrameInfo_t::Layer_t *pLayer = i < pFrameInfo->layers.count() ? &pFrameInfo->layers.get( i ) : nullptr;
                 if ( pLayer && pLayer->zpos == g_zposCursor )
                 {
-                    bool bUsingPhysicalMouse = m_pBackend->GetCurrentMouseConnector() == this && !m_bUsingVRMouse;
-
-                    bool bShowCursor = !IsRelativeMouse();
-
-                    if (bUsingPhysicalMouse && bShowCursor)
-                    {
-                        vr::HmdVector2_t vMousePos =
-                        {
-                            static_cast<float>( -pLayer->offset.x ),
-                            static_cast<float>( static_cast<float>( g_nOutputHeight ) + pLayer->offset.y ),
-                        };
-
-                        vr::VROverlay()->SetOverlayCursorPositionOverride( GetPrimaryPlane()->GetOverlay(), &vMousePos );
-                        m_bCurrentlyOverridingPosition = true;
-
-                        bShouldHideCursor = false;
-                    }
-
-                    pLayer = nullptr; // Handled here.
+                    pCursorLayer = pLayer;
+                    pLayer = nullptr; // Handled by the override.
                 }
                 m_Planes[uCurrentPlane++].Present( pLayer );
             }
-
-            if ( bShouldHideCursor )
-            {
-                if ( m_bCurrentlyOverridingPosition )
-                {
-                    vr::VROverlay()->ClearOverlayCursorPositionOverride( GetPrimaryPlane()->GetOverlay() );
-
-                    m_bCurrentlyOverridingPosition = false;
-                }
-            }
+            UpdateCursorOverride( pCursorLayer );
         }
         else
         {
-            std::optional oCompositeResult = vulkan_composite( (FrameInfo_t *)pFrameInfo, nullptr, false );
+            // SteamVR draws the pointer, so compositing the layer too would paint a second one.
+            FrameInfo_t trimmedFrameInfo = *pFrameInfo;
+            trimmedFrameInfo.layers.truncate( 0 );
+            const FrameInfo_t::Layer_t *pCursorLayer = nullptr;
+            for ( int i = 0; i < pFrameInfo->layers.count(); i++ )
+            {
+                const FrameInfo_t::Layer_t &layer = pFrameInfo->layers.get( i );
+                if ( layer.zpos == g_zposCursor )
+                    pCursorLayer = &layer;
+                else if ( FrameInfo_t::Layer_t *pDst = trimmedFrameInfo.layers.push() )
+                    *pDst = layer;
+            }
+            UpdateCursorOverride( pCursorLayer );
+
+            std::optional oCompositeResult = vulkan_composite( &trimmedFrameInfo, nullptr, false );
             if ( !oCompositeResult )
             {
                 openvr_log.errorf( "vulkan_composite failed" );

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -1683,7 +1683,7 @@ namespace gamescope
         // TODO: Dedupe some of this composite check code between us and drm.cpp
         bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
-        bool bNeedsCompositeFromFilter = (g_upscaleFilter == GamescopeUpscaleFilter::NEAREST || g_upscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
+        bool bNeedsCompositeFromFilter = (pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::NEAREST || pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
 
         bNeedsFullComposite |= cv_composite_force;
         bNeedsFullComposite |= pFrameInfo->useFSRLayer0;

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -396,6 +396,7 @@ namespace gamescope
         bool ConsumeNudgeToVisible() { return std::exchange( m_bNudgeToVisible, false ); }
         bool IsRelativeMouse() const { return m_bRelativeMouse; }
         void UpdateCursorOverride( const FrameInfo_t::Layer_t *pCursorLayer );
+        gamescope::Rc<CVulkanTexture> GetCompositeTarget();
 
         // Thread safe.
         bool IsVisible() const
@@ -436,6 +437,11 @@ namespace gamescope
         bool m_bWasVisible = false; // Event thread only
         std::atomic<bool> m_bOverlayShown = { false };
         std::atomic<bool> m_bSceneAppVisible = { false };
+
+        // Composite targets, a shared rotation would recycle an image another connector still shows. Steamcompmgr thread only.
+        std::vector<gamescope::OwningRc<CVulkanTexture>> m_pCompositeImages;
+        uint32_t m_uNextCompositeImage = 0;
+        bool m_bWarnedCompositeExhaustion = false;
 
         bool m_bForbidTouchMode = false;
     };
@@ -1676,6 +1682,54 @@ namespace gamescope
         }
     }
 
+    gamescope::Rc<CVulkanTexture> COpenVRConnector::GetCompositeTarget()
+    {
+        if ( m_pCompositeImages.size() )
+        {
+            if ( m_pCompositeImages[0]->width() != g_nOutputWidth ||
+                 m_pCompositeImages[0]->height() != g_nOutputHeight ||
+                 m_pCompositeImages[0]->drmFormat() != g_output.uOutputFormat )
+            {
+                m_pCompositeImages.clear();
+                m_uNextCompositeImage = 0;
+            }
+        }
+
+        // Round robin so a slot rests as long as possible, SteamVR can still be sampling a freed one.
+        for ( size_t i = 0; i < m_pCompositeImages.size(); i++ )
+        {
+            gamescope::OwningRc<CVulkanTexture> &pImage =
+                m_pCompositeImages[ ( m_uNextCompositeImage + i ) % m_pCompositeImages.size() ];
+            if ( !pImage->IsInUse() )
+            {
+                m_uNextCompositeImage = ( m_uNextCompositeImage + i + 1 ) % m_pCompositeImages.size();
+                return pImage;
+            }
+        }
+
+        // The target, the plane's queued and visible pair, and one resting.
+        if ( m_pCompositeImages.size() < 4 )
+        {
+            gamescope::OwningRc<CVulkanTexture> pTexture = new CVulkanTexture();
+
+            CVulkanTexture::createFlags imageFlags;
+            imageFlags.bFlippable = true;
+            imageFlags.bStorage = true;
+            imageFlags.bSampled = true;
+
+            if ( !pTexture->BInit( g_nOutputWidth, g_nOutputHeight, 1u, g_output.uOutputFormat, imageFlags ) )
+                return nullptr;
+
+            m_pCompositeImages.push_back( std::move( pTexture ) );
+            return m_pCompositeImages.back();
+        }
+
+        // Every image is still referenced, the shared images at least keep the frame.
+        if ( !std::exchange( m_bWarnedCompositeExhaustion, true ) )
+            openvr_log.warnf( "No composite image free, using the shared output images" );
+        return nullptr;
+    }
+
     int COpenVRConnector::Present( const FrameInfo_t *pFrameInfo, bool bAsync )
     {
         bool bNeedsFullComposite = false;
@@ -1710,6 +1764,9 @@ namespace gamescope
 
         if ( !bNeedsFullComposite )
         {
+            m_pCompositeImages.clear();
+            m_uNextCompositeImage = 0;
+
             bool bNeedsBacking = true;
             if ( pFrameInfo->layers.count() >= 1 )
             {
@@ -1764,7 +1821,8 @@ namespace gamescope
             }
             UpdateCursorOverride( pCursorLayer );
 
-            std::optional oCompositeResult = vulkan_composite( &trimmedFrameInfo, nullptr, false );
+            gamescope::Rc<CVulkanTexture> pCompositeTarget = GetCompositeTarget();
+            std::optional oCompositeResult = vulkan_composite( &trimmedFrameInfo, nullptr, false, pCompositeTarget );
             if ( !oCompositeResult )
             {
                 openvr_log.errorf( "vulkan_composite failed" );
@@ -1779,7 +1837,7 @@ namespace gamescope
             compositeLayer.opacity = 1.0;
             compositeLayer.zpos = g_zposBase;
 
-            compositeLayer.tex = vulkan_get_last_output_image( false, false );
+            compositeLayer.tex = pCompositeTarget != nullptr ? pCompositeTarget : vulkan_get_last_output_image( false, false );
             compositeLayer.applyColorMgmt = false;
 
             compositeLayer.filter = GamescopeUpscaleFilter::NEAREST;

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1067,7 +1067,7 @@ namespace gamescope
             // TODO: Dedupe some of this composite check code between us and drm.cpp
             bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
-            bool bNeedsCompositeFromFilter = (g_upscaleFilter == GamescopeUpscaleFilter::NEAREST || g_upscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
+            bool bNeedsCompositeFromFilter = (pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::NEAREST || pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
 
             bNeedsFullComposite |= cv_composite_force;
             bNeedsFullComposite |= pFrameInfo->useFSRLayer0;

--- a/src/commit.cpp
+++ b/src/commit.cpp
@@ -128,9 +128,9 @@ void commit_t::SetFence( int nFence, bool bMangoNudge, CommitDoneList_t *pDoneCo
     m_pDoneCommits = pDoneCommits;
 }
 
-void calc_scale_factor(float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight);
+void calc_scale_factor(GamescopeUpscaleScaler eScaler, float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight);
 
-bool commit_t::ShouldPreemptivelyUpscale()
+bool commit_t::ShouldPreemptivelyUpscale( GamescopeUpscaleFilter eFilter, GamescopeUpscaleScaler eScaler )
 {
     // Don't pre-emptively upscale if we are not a FIFO commit.
     // Don't want to FSR upscale 1000fps content.
@@ -139,7 +139,7 @@ bool commit_t::ShouldPreemptivelyUpscale()
 
     // If we support the upscaling filter in hardware, don't
     // pre-emptively do it via shaders.
-    if ( DoesHardwareSupportUpscaleFilter( g_upscaleFilter ) )
+    if ( DoesHardwareSupportUpscaleFilter( eFilter ) )
         return false;
 
     if ( !vulkanTex )
@@ -149,7 +149,7 @@ bool commit_t::ShouldPreemptivelyUpscale()
     float flScaleY = 1.0f;
     // I wish this function was more programatic with its inputs, but it does do exactly what we want right now...
     // It should also return a std::pair or a glm uvec
-    calc_scale_factor( flScaleX, flScaleY, vulkanTex->width(), vulkanTex->height() );
+    calc_scale_factor( eScaler, flScaleX, flScaleY, vulkanTex->width(), vulkanTex->height() );
 
     return !close_enough( flScaleX, 1.0f ) || !close_enough( flScaleY, 1.0f );
 }

--- a/src/commit.cpp
+++ b/src/commit.cpp
@@ -69,14 +69,6 @@ void commit_t::Signal()
     uint64_t now = get_time_in_nanos();
     present_time = now;
 
-    uint64_t frametime;
-    if ( m_bMangoNudge )
-    {
-        static uint64_t lastFrameTime = now;
-        frametime = now - lastFrameTime;
-        lastFrameTime = now;
-    }
-
     // TODO: Move this so it's called in the main loop.
     // Instead of looping over all the windows like before.
     // When we get the new IWaitable stuff in there.
@@ -91,7 +83,9 @@ void commit_t::Signal()
     }
 
     if ( m_bMangoNudge )
-        mangoapp_update( uint64_t(~0ull), frametime, uint64_t(~0ull) );
+        mangoapp_nudge_app_frame( k_uMangoappLegacyMsgType, now );
+    if ( m_uMangoMsgType != 0 )
+        mangoapp_nudge_app_frame( m_uMangoMsgType, now );
 }
 
 void commit_t::OnPollHangUp()
@@ -118,13 +112,14 @@ bool commit_t::CloseFenceInternal()
     return true;
 }
 
-void commit_t::SetFence( int nFence, bool bMangoNudge, CommitDoneList_t *pDoneCommits )
+void commit_t::SetFence( int nFence, bool bMangoNudge, uint32_t uMangoMsgType, CommitDoneList_t *pDoneCommits )
 {
     std::unique_lock lock( m_WaitableCommitStateMutex );
     CloseFenceInternal();
 
     m_nCommitFence = nFence;
     m_bMangoNudge = bMangoNudge;
+    m_uMangoMsgType = uMangoMsgType;
     m_pDoneCommits = pDoneCommits;
 }
 

--- a/src/commit.h
+++ b/src/commit.h
@@ -34,7 +34,7 @@ struct commit_t final : public gamescope::RcObject, public gamescope::IWaitable,
 
 	// Returns true if we had a fence that was closed.
 	bool CloseFenceInternal();
-	void SetFence( int nFence, bool bMangoNudge, CommitDoneList_t *pDoneCommits );
+	void SetFence( int nFence, bool bMangoNudge, uint32_t uMangoMsgType, CommitDoneList_t *pDoneCommits );
 
 	bool ShouldPreemptivelyUpscale( GamescopeUpscaleFilter eFilter, GamescopeUpscaleScaler eScaler );
 
@@ -79,5 +79,7 @@ struct commit_t final : public gamescope::RcObject, public gamescope::IWaitable,
 	std::mutex m_WaitableCommitStateMutex;
 	int m_nCommitFence = -1;
 	bool m_bMangoNudge = false;
+	// Typed mangoapp stream to nudge, 0 for none, never the legacy type.
+	uint32_t m_uMangoMsgType = 0;
 	CommitDoneList_t *m_pDoneCommits = nullptr; // I hate this
 };

--- a/src/commit.h
+++ b/src/commit.h
@@ -36,7 +36,7 @@ struct commit_t final : public gamescope::RcObject, public gamescope::IWaitable,
 	bool CloseFenceInternal();
 	void SetFence( int nFence, bool bMangoNudge, CommitDoneList_t *pDoneCommits );
 
-	bool ShouldPreemptivelyUpscale();
+	bool ShouldPreemptivelyUpscale( GamescopeUpscaleFilter eFilter, GamescopeUpscaleScaler eScaler );
 
 	struct wlr_buffer *buf = nullptr;
 	gamescope::Rc<CVulkanTexture> vulkanTex;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,9 +311,6 @@ bool g_bGrabbed = false;
 
 float g_mouseSensitivity = 1.0;
 
-GamescopeUpscaleFilter g_upscaleFilter = GamescopeUpscaleFilter::LINEAR;
-GamescopeUpscaleScaler g_upscaleScaler = GamescopeUpscaleScaler::AUTO;
-
 GamescopeUpscaleFilter g_wantedUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 GamescopeUpscaleScaler g_wantedUpscaleScaler = GamescopeUpscaleScaler::AUTO;
 int g_upscaleFilterSharpness = 2;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -59,8 +59,25 @@ enum class GamescopeUpscaleScaler : uint32_t
     STRETCH,
 };
 
-extern GamescopeUpscaleFilter g_upscaleFilter;
-extern GamescopeUpscaleScaler g_upscaleScaler;
+struct UpscaleSettings_t
+{
+    GamescopeUpscaleFilter eFilter{};
+    GamescopeUpscaleScaler eScaler{};
+};
+
+// XXX(misyl): This is bad! We shouldnt change the upscaler like this at all!!!
+// We should move this to business logic in paint_window or something!
+static constexpr UpscaleSettings_t GetUpscaleSettings(
+    bool bFocusIsSteam,
+    GamescopeUpscaleFilter eWantedFilter,
+    GamescopeUpscaleScaler eWantedScaler )
+{
+    if ( bFocusIsSteam )
+        return UpscaleSettings_t{ GamescopeUpscaleFilter::LINEAR, GamescopeUpscaleScaler::FIT };
+
+    return UpscaleSettings_t{ eWantedFilter, eWantedScaler };
+}
+
 extern GamescopeUpscaleFilter g_wantedUpscaleFilter;
 extern GamescopeUpscaleScaler g_wantedUpscaleScaler;
 extern int g_upscaleFilterSharpness;

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -1,7 +1,10 @@
 #include <sys/ipc.h>
 #include <unistd.h>
 #include <sys/msg.h>
-#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
 
 #include "steamcompmgr.hpp"
 #include "refresh_rate.h"
@@ -9,6 +12,8 @@
 
 static bool inited = false;
 static int msgid = 0;
+static std::mutex s_SnapshotMutex;
+static std::unordered_map<uint32_t, MangoappSnapshot_t> s_ConnectorSnapshots;
 extern bool g_bAppWantsHDRCached;
 extern uint32_t g_focusedBaseAppId;
 
@@ -32,42 +37,83 @@ struct mangoapp_msg_v1 {
     bool bAppWantsHDR : 1;
     bool bSteamFocused : 1;
     char engineName[40];
-    
+
     // WARNING: Always ADD fields, never remove or repurpose fields
-} __attribute__((packed)) mangoapp_msg_v1;
+} __attribute__((packed));
 
 void init_mangoapp(){
     int key = ftok("mangoapp", 65);
     msgid = msgget(key, 0666 | IPC_CREAT);
-    mangoapp_msg_v1.hdr.msg_type = 1;
-    mangoapp_msg_v1.hdr.version = 1;
-    mangoapp_msg_v1.fsrUpscale = 0;
-    mangoapp_msg_v1.fsrSharpness = 0;
     inited = true;
 }
 
-void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns ) {
+void mangoapp_set_connector_snapshots( std::unordered_map<uint32_t, MangoappSnapshot_t> snapshots )
+{
+    std::unique_lock lock( s_SnapshotMutex );
+    s_ConnectorSnapshots = std::move( snapshots );
+}
+
+void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns, uint32_t uMsgType ) {
     if (!inited)
         init_mangoapp();
 
-    mangoapp_msg_v1.visible_frametime_ns = visible_frametime;
-    mangoapp_msg_v1.fsrUpscale = g_bFSRActive;
-    mangoapp_msg_v1.fsrSharpness = g_upscaleFilterSharpness;
-    mangoapp_msg_v1.app_frametime_ns = app_frametime_ns;
-    mangoapp_msg_v1.latency_ns = latency_ns;
-    mangoapp_msg_v1.pid = focusWindow_pid;
-    mangoapp_msg_v1.outputWidth = g_nOutputWidth;
-    mangoapp_msg_v1.outputHeight = g_nOutputHeight;
-    mangoapp_msg_v1.displayRefresh = (uint16_t) gamescope::ConvertmHzToHz( g_nOutputRefresh );
-    mangoapp_msg_v1.bAppWantsHDR = g_bAppWantsHDRCached;
-    mangoapp_msg_v1.bSteamFocused = g_focusedBaseAppId == 769;
-    memset(mangoapp_msg_v1.engineName, 0, sizeof(mangoapp_msg_v1.engineName));
-    std::shared_ptr<std::string> engine = focusWindow_engine;
-    if (engine)
-        engine->copy(mangoapp_msg_v1.engineName, sizeof(mangoapp_msg_v1.engineName) / sizeof(char));
+    MangoappSnapshot_t snapshot;
+    if ( uMsgType == k_uMangoappLegacyMsgType )
+    {
+        snapshot.bFSRActive = g_bFSRActive;
+        snapshot.uFSRSharpness = (uint8_t) g_upscaleFilterSharpness;
+        snapshot.nPid = focusWindow_pid;
+        snapshot.uOutputWidth = g_nOutputWidth;
+        snapshot.uOutputHeight = g_nOutputHeight;
+        snapshot.nOutputRefreshmHz = g_nOutputRefresh;
+        snapshot.bAppWantsHDR = g_bAppWantsHDRCached;
+        snapshot.bSteamFocused = g_focusedBaseAppId == 769;
+        snapshot.pEngineName = focusWindow_engine;
+    }
     else
-        std::string("gamescope").copy(mangoapp_msg_v1.engineName, sizeof(mangoapp_msg_v1.engineName) / sizeof(char));
-    msgsnd(msgid, &mangoapp_msg_v1, sizeof(mangoapp_msg_v1) - sizeof(mangoapp_msg_v1.hdr.msg_type), IPC_NOWAIT);
+    {
+        std::unique_lock lock( s_SnapshotMutex );
+        auto iter = s_ConnectorSnapshots.find( uMsgType );
+        if ( iter == s_ConnectorSnapshots.end() )
+            return;
+        snapshot = iter->second;
+    }
+
+    struct mangoapp_msg_v1 msg = {};
+    msg.hdr.version = 1;
+    msg.hdr.msg_type = uMsgType;
+    msg.visible_frametime_ns = visible_frametime;
+    msg.app_frametime_ns = app_frametime_ns;
+    msg.latency_ns = latency_ns;
+    msg.fsrUpscale = snapshot.bFSRActive;
+    msg.fsrSharpness = snapshot.uFSRSharpness;
+    msg.pid = snapshot.nPid;
+    msg.outputWidth = snapshot.uOutputWidth;
+    msg.outputHeight = snapshot.uOutputHeight;
+    msg.displayRefresh = (uint16_t) gamescope::ConvertmHzToHz( snapshot.nOutputRefreshmHz );
+    msg.bAppWantsHDR = snapshot.bAppWantsHDR;
+    msg.bSteamFocused = snapshot.bSteamFocused;
+    if (snapshot.pEngineName)
+        snapshot.pEngineName->copy(msg.engineName, sizeof(msg.engineName) / sizeof(char));
+    else
+        std::string("gamescope").copy(msg.engineName, sizeof(msg.engineName) / sizeof(char));
+
+    msgsnd(msgid, &msg, sizeof(msg) - sizeof(msg.hdr.msg_type), IPC_NOWAIT);
+}
+
+void mangoapp_nudge_app_frame( uint32_t uMsgType, uint64_t ulNow )
+{
+    static std::mutex s_FrameTimeMutex;
+    static std::unordered_map<uint32_t, uint64_t> s_LastFrameTimes;
+
+    uint64_t frametime;
+    {
+        std::unique_lock lock( s_FrameTimeMutex );
+        auto iter = s_LastFrameTimes.find( uMsgType );
+        frametime = ( iter != s_LastFrameTimes.end() ) ? ulNow - iter->second : 0;
+        s_LastFrameTimes[ uMsgType ] = ulNow;
+    }
+    mangoapp_update( uint64_t(~0ull), frametime, uint64_t(~0ull), uMsgType );
 }
 
 extern uint64_t g_uCurrentBasePlaneCommitID;

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -47,6 +47,37 @@ void init_mangoapp(){
     inited = true;
 }
 
+static std::mutex s_FrameTimeMutex;
+static std::unordered_map<uint32_t, uint64_t> s_LastFrameTimes;
+
+// A queue message, mtype first, sized past any control message mangoapp defines.
+struct MangoappRawMsg_t
+{
+    long mtype;
+    uint8_t data[1016];
+};
+
+// The queue outlives gamescope and types start over every run, so leave nothing behind.
+void mangoapp_drop_stream( uint32_t uMsgType )
+{
+    if (!inited)
+        init_mangoapp();
+
+    {
+        // Ahead of the drain, so commits finishing later find nothing to send.
+        std::unique_lock lock( s_SnapshotMutex );
+        s_ConnectorSnapshots.erase( uMsgType );
+    }
+
+    MangoappRawMsg_t rawMsg;
+    for (uint32_t uType : { uMsgType, MangoappControlMsgType(uMsgType) })
+        while (msgrcv(msgid, &rawMsg, sizeof(rawMsg.data), uType, IPC_NOWAIT | MSG_NOERROR) >= 0)
+            ;
+
+    std::unique_lock lock( s_FrameTimeMutex );
+    s_LastFrameTimes.erase( uMsgType );
+}
+
 void mangoapp_set_connector_snapshots( std::unordered_map<uint32_t, MangoappSnapshot_t> snapshots )
 {
     std::unique_lock lock( s_SnapshotMutex );
@@ -103,9 +134,6 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
 
 void mangoapp_nudge_app_frame( uint32_t uMsgType, uint64_t ulNow )
 {
-    static std::mutex s_FrameTimeMutex;
-    static std::unordered_map<uint32_t, uint64_t> s_LastFrameTimes;
-
     uint64_t frametime;
     {
         std::unique_lock lock( s_FrameTimeMutex );

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -1,10 +1,12 @@
 #include <sys/ipc.h>
 #include <unistd.h>
 #include <sys/msg.h>
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "steamcompmgr.hpp"
 #include "refresh_rate.h"
@@ -82,6 +84,65 @@ void mangoapp_set_connector_snapshots( std::unordered_map<uint32_t, MangoappSnap
 {
     std::unique_lock lock( s_SnapshotMutex );
     s_ConnectorSnapshots = std::move( snapshots );
+}
+
+// Sends that did not fit, finished in order before the next message. Steamcompmgr thread only.
+struct MangoappPendingControl_t
+{
+    uint32_t uMsgType;
+    size_t size;
+    MangoappRawMsg_t msg;
+};
+static std::vector<MangoappPendingControl_t> s_PendingControl;
+
+// System V hands each message to one reader, so fan it out to every instance.
+// Returns how many sends are still waiting for room.
+uint32_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes )
+{
+    if (msgTypes.empty())
+        return 0;
+
+    if (!inited)
+        init_mangoapp();
+
+    // Finish the last fan-out first, so no instance sees commands out of order.
+    while (!s_PendingControl.empty())
+    {
+        const MangoappPendingControl_t &pending = s_PendingControl.front();
+        bool bConnectorGone = std::find(msgTypes.begin(), msgTypes.end(), pending.uMsgType) == msgTypes.end();
+        if (!bConnectorGone && msgsnd(msgid, &pending.msg, pending.size, IPC_NOWAIT) < 0)
+            return (uint32_t) s_PendingControl.size();
+        s_PendingControl.erase(s_PendingControl.begin());
+    }
+
+    uint32_t uDeferred = 0;
+    MangoappRawMsg_t rawMsg;
+    for (;;)
+    {
+        ssize_t size = msgrcv(msgid, &rawMsg, sizeof(rawMsg.data), k_uMangoappControlMsgType, IPC_NOWAIT | MSG_NOERROR);
+        if (size < 0)
+            break;
+
+        // Truncated, so fanning it out would hand every instance a corrupt message.
+        if (size == ssize_t(sizeof(rawMsg.data)))
+            continue;
+
+        // A type nobody reads yet holds the message until that instance starts.
+        for (uint32_t uMsgType : msgTypes)
+        {
+            rawMsg.mtype = MangoappControlMsgType(uMsgType);
+            // Once one send does not fit, hold the rest rather than deliver them ahead of it.
+            if (uDeferred || msgsnd(msgid, &rawMsg, size, IPC_NOWAIT) < 0)
+            {
+                s_PendingControl.push_back( MangoappPendingControl_t{ uMsgType, size_t(size), rawMsg } );
+                uDeferred++;
+            }
+        }
+
+        if (uDeferred)
+            break;
+    }
+    return uDeferred;
 }
 
 void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns, uint32_t uMsgType ) {

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1303,6 +1303,9 @@ uint64_t CVulkanDevice::submitInternal( CVulkanCmdBuffer* cmdBuffer )
 	// This is the seq no of the command buffer we are going to submit.
 	const uint64_t nextSeqNo = lastSubmissionSeqNo + 1;
 
+	for ( uint32_t uIndex : cmdBuffer->GetUsedDescriptorSets() )
+		m_descriptorSetSeqNos[ uIndex ] = nextSeqNo;
+
 	std::vector<VkSemaphore> pSignalSemaphores;
 	std::vector<uint64_t> ulSignalPoints;
 
@@ -1354,6 +1357,27 @@ uint64_t CVulkanDevice::submitInternal( CVulkanCmdBuffer* cmdBuffer )
 	return nextSeqNo;
 }
 
+VkDescriptorSet CVulkanDevice::descriptorSet( CVulkanCmdBuffer *pCmdBuffer )
+{
+	const uint32_t uIndex = m_currentDescriptorSet;
+	m_currentDescriptorSet = ( m_currentDescriptorSet + 1 ) % m_descriptorSets.size();
+
+	// Not wait(), its ring reset would clobber constants this recording already uploaded.
+	if ( const uint64_t ulSeqNo = m_descriptorSetSeqNos[ uIndex ] )
+	{
+		VkSemaphoreWaitInfo waitInfo = {
+			.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO,
+			.semaphoreCount = 1,
+			.pSemaphores = &m_scratchTimelineSemaphore,
+			.pValues = &ulSeqNo,
+		};
+		vk_check( vk.WaitSemaphores( device(), &waitInfo, ~0ull ) );
+	}
+
+	pCmdBuffer->AddDescriptorSet( uIndex );
+	return m_descriptorSets[ uIndex ];
+}
+
 uint64_t CVulkanDevice::submit( std::unique_ptr<CVulkanCmdBuffer> cmdBuffer)
 {
 	uint64_t nextSeqNo = submitInternal(cmdBuffer.get());
@@ -1365,6 +1389,10 @@ void CVulkanDevice::garbageCollect( void )
 {
 	uint64_t currentSeqNo;
 	vk_check( vk.GetSemaphoreCounterValue(device(), m_scratchTimelineSemaphore, &currentSeqNo) );
+
+	// wait() only resets the ring on a latest-wait, which stale waits never are.
+	if ( currentSeqNo == m_submissionSeqNo )
+		m_uploadBufferOffset = 0;
 
 	resetCmdBuffers(currentSeqNo);
 }
@@ -1547,6 +1575,7 @@ void CVulkanCmdBuffer::reset()
 {
 	vk_check( m_device->vk.ResetCommandBuffer(m_cmdBuffer, 0) );
 	m_textureRefs.clear();
+	m_usedDescriptorSets.clear();
 	m_textureState.clear();
 
 	m_ExternalDependencies.clear();
@@ -1649,7 +1678,7 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 	prepareDestImage(m_target);
 	insertBarrier();
 
-	VkDescriptorSet descriptorSet = m_device->descriptorSet();
+	VkDescriptorSet descriptorSet = m_device->descriptorSet( this );
 
 	std::array<VkWriteDescriptorSet, 7> writeDescriptorSets;
 	std::array<VkDescriptorImageInfo, VKR_SAMPLER_SLOTS> imageDescriptors = {};

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -296,6 +296,11 @@ struct FrameInfo_t
 	bool applyOutputColorMgmt; // drm only
 	EOTF outputEncodingEOTF;
 
+	// Maps output space onto the focused window's own space for absolute input.
+	// Not the base layer's transform, whose texture may already be upscaled.
+	vec2_t focusedWindowScale = { 1.0f, 1.0f };
+	vec2_t focusedWindowOffset = { 0.0f, 0.0f };
+
 	struct Layer_t
 	{
 		gamescope::Rc<CVulkanTexture> tex;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -282,6 +282,9 @@ struct FrameInfo_t
 {
 	bool useFSRLayer0;
 	bool useNISLayer0;
+	// Upscale settings for this frame.
+	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
+	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
 	bool bFadingOut;
 	BlurMode blurLayer0;
 	int blurRadius;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -824,12 +824,7 @@ public:
 	void wait(uint64_t sequence, bool reset = true);
 	void waitIdle(bool reset = true);
 	void garbageCollect();
-	inline VkDescriptorSet descriptorSet()
-	{
-		VkDescriptorSet ret = m_descriptorSets[m_currentDescriptorSet];
-		m_currentDescriptorSet = (m_currentDescriptorSet + 1) % m_descriptorSets.size();
-		return ret;
-	}
+	VkDescriptorSet descriptorSet( CVulkanCmdBuffer *pCmdBuffer );
 
 	std::shared_ptr<VulkanTimelineSemaphore_t> CreateTimelineSemaphore( uint64_t ulStartingPoint, bool bShared = false );
 	std::shared_ptr<VulkanTimelineSemaphore_t> ImportTimelineSemaphore( gamescope::CTimeline *pTimeline );
@@ -928,10 +923,9 @@ protected:
 
 	static constexpr uint32_t k_uMaxConcurrentSubmits = 8;
 
-	// currently just one set, no need to double buffer because we
-	// vkQueueWaitIdle after each submit.
-	// should be moved to the output if we are going to support multiple outputs
+	// Round robin, each set stamped with the last submission that reads it.
 	std::array<VkDescriptorSet, k_uMaxConcurrentSubmits * 3> m_descriptorSets;
+	std::array<uint64_t, k_uMaxConcurrentSubmits * 3> m_descriptorSetSeqNos{};
 	uint32_t m_currentDescriptorSet = 0;
 
 	VkBuffer m_uploadBuffer;
@@ -1012,6 +1006,9 @@ public:
 	const std::vector<VulkanTimelinePoint_t> &GetExternalDependencies() const { return m_ExternalDependencies; }
 	const std::vector<VulkanTimelinePoint_t> &GetExternalSignals() const { return m_ExternalSignals; }
 
+	void AddDescriptorSet( uint32_t uIndex ) { m_usedDescriptorSets.push_back( uIndex ); }
+	const std::vector<uint32_t> &GetUsedDescriptorSets() const { return m_usedDescriptorSets; }
+
 private:
 	VkCommandBuffer m_cmdBuffer;
 	CVulkanDevice *m_device;
@@ -1021,6 +1018,7 @@ private:
 
 	// Per Use State
 	std::vector<gamescope::Rc<CVulkanTexture>> m_textureRefs;
+	std::vector<uint32_t> m_usedDescriptorSets;
 	std::unordered_map<CVulkanTexture *, TextureState> m_textureState;
 
 	// Draw State

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5820,6 +5820,8 @@ destroy_win(xwayland_ctx_t *ctx, Window id, bool gone, bool fade)
 			pFocus->inputFocusWindow = nullptr;
 		if (x11_win(pFocus->overlayWindow) == id && gone)
 			pFocus->overlayWindow = nullptr;
+		if (x11_win(pFocus->externalOverlayWindow) == id && gone)
+			pFocus->externalOverlayWindow = nullptr;
 		if (x11_win(pFocus->notificationWindow) == id && gone)
 			pFocus->notificationWindow = nullptr;
 		// These are dereferenced on a later focus pass, and finish_destroy_win frees the window

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -253,6 +253,7 @@ static int setDMemMemoryLow(const char *cgroupPath, bool focused) {
 }
 
 static std::vector< steamcompmgr_win_t* > GetGlobalPossibleFocusWindows();
+static uint32_t mangoapp_msg_type_for_key( gamescope::VirtualConnectorKey_t ulKey );
 static bool
 pick_primary_focus_and_override(
 	focus_t *out,
@@ -4343,7 +4344,8 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 			}
 		}
 
-		if (w->isExternalOverlay)
+		// The per-ctx pick only serves untagged (legacy) mangoapps.
+		if (w->isExternalOverlay && w->uMangoappMsgType == 0)
 		{
 			if (w->opacity > maxOpacityExternal)
 			{
@@ -4857,7 +4859,20 @@ determine_and_apply_focus( global_focus_t *pFocus )
 
 	// Pick overlay/notifications from root ctx
 	pFocus->overlayWindow = root_ctx->focus.overlayWindow;
-	pFocus->externalOverlayWindow = root_ctx->focus.externalOverlayWindow;
+	pFocus->externalOverlayWindow = nullptr;
+	if ( uint32_t uMsgType = mangoapp_msg_type_for_key( pFocus->ulVirtualFocusKey ) )
+	{
+		for ( steamcompmgr_win_t *w = root_ctx->list; w; w = w->xwayland().next )
+		{
+			if ( w->isExternalOverlay && w->uMangoappMsgType == uMsgType )
+			{
+				pFocus->externalOverlayWindow = w;
+				break;
+			}
+		}
+	}
+	if ( !pFocus->externalOverlayWindow )
+		pFocus->externalOverlayWindow = root_ctx->focus.externalOverlayWindow;
 	pFocus->notificationWindow = root_ctx->focus.notificationWindow;
 
 	if ( !pFocus->overlayWindow )
@@ -6509,7 +6524,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 				{
 					hasRepaintNonBasePlane = true;
 				}
-				if ( w == ctx->focus.externalOverlayWindow )
+				if ( w->isExternalOverlay )
 				{
 					hasRepaint = true;
 				}
@@ -6528,7 +6543,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 						maxOpacity = w->opacity;
 					}
 				}
-				if (w->isExternalOverlay)
+				if (w->isExternalOverlay && w->uMangoappMsgType == 0)
 				{
 					if (w->opacity >= maxOpacityExternal)
 					{
@@ -7727,6 +7742,15 @@ void handle_done_commits_xdg( bool vblank, uint64_t vblank_idx )
 }
 
 gamescope::ConVar<bool> cv_mangoapp_use_output_timing{ "mangoapp_use_output_timing", true };
+// A mangoapp that ignores MANGOAPP_MSG_TYPE needs this off, several of those would split one stream.
+gamescope::ConVar<bool> cv_mangoapp_per_connector{ "mangoapp_per_connector", true, "Spawn one mangoapp per virtual connector, each with its own stat stream" };
+
+// An untagged mangoapp reads the legacy stream, whoever spawned it.
+static bool has_legacy_mangoapp_reader()
+{
+	return wlserver_get_xwayland_server( 0 )->ctx->focus.externalOverlayWindow != nullptr ||
+		g_steamcompmgr_xdg_focus.externalOverlayWindow != nullptr;
+}
 
 void handle_presented_for_window( steamcompmgr_win_t* w )
 {
@@ -7981,13 +8005,39 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 
 	static bool bMangoappSocketDisable = env_to_bool( getenv( "GAMESCOPE_MANGOAPP_SOCKET_DISABLE" ));
 
-	// Whether or not to nudge mango app when this commit is done.
+	// Only send the legacy stream while an untagged mangoapp is there to drain it.
+	const bool bHasLegacyReader = !GetBackend()->UsesVirtualConnectors() || has_legacy_mangoapp_reader();
 	const bool mango_nudge = pCurrentFocus && ( ( w == pCurrentFocus->focusWindow && !w->isSteamStreamingClient ) ||
 								( pCurrentFocus->focusWindow && pCurrentFocus->focusWindow->isSteamStreamingClient && w->isSteamStreamingClientVideo ) )
-								&& !bMangoappSocketDisable;
+								&& !bMangoappSocketDisable && bHasLegacyReader;
 
 	// The window's own connector, not whichever one is current.
 	global_focus_t *pUpscaleFocus = GetFocusForWindow( w );
+
+	// Typed stream of the window's own connector, only while a tagged
+	// mangoapp is there to drain it.
+	uint32_t uMangoMsgType = 0;
+	if ( !bMangoappSocketDisable )
+	{
+		global_focus_t *pMangoFocus = nullptr;
+		if ( pUpscaleFocus && !w->isSteamStreamingClient )
+			pMangoFocus = pUpscaleFocus;
+		else if ( w->isSteamStreamingClientVideo )
+		{
+			// The streaming video plane feeds the connector focusing its client.
+			for ( auto &iter : g_VirtualConnectorFocuses )
+			{
+				if ( iter.second.focusWindow && iter.second.focusWindow->isSteamStreamingClient )
+				{
+					pMangoFocus = &iter.second;
+					break;
+				}
+			}
+		}
+		if ( pMangoFocus && pMangoFocus->externalOverlayWindow )
+			uMangoMsgType = pMangoFocus->externalOverlayWindow->uMangoappMsgType;
+	}
+
 	bool bValidPreemptiveScale = reslistentry.pAcquirePoint && pUpscaleFocus && cv_upscale_preemptive;
 	bool bPreemptiveUpscale = bValidPreemptiveScale && newCommit->ShouldPreemptivelyUpscale( pUpscaleFocus->eUpscaleFilter, pUpscaleFocus->eUpscaleScaler );
 
@@ -8105,7 +8155,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 
 	gpuvis_trace_printf( "pushing wait for commit %lu win %lx", newCommit->commitID, w->type == steamcompmgr_win_type_t::XWAYLAND ? w->xwayland().id : 0 );
 	{
-		newCommit->SetFence( fence, mango_nudge, 0, doneCommits );
+		newCommit->SetFence( fence, mango_nudge, uMangoMsgType, doneCommits );
 		if ( bKnownReady )
 			newCommit->Signal();
 		else
@@ -8900,6 +8950,11 @@ void update_edid_prop()
 
 extern bool g_bLaunchMangoapp;
 
+static bool mangoapp_per_connector()
+{
+	return g_bLaunchMangoapp && GetBackend()->UsesVirtualConnectors() && cv_mangoapp_per_connector;
+}
+
 extern void ShutdownGamescope();
 
 gamescope::ConVar<bool> cv_shutdown_on_primary_child_death( "shutdown_on_primary_child_death", true, "Should gamescope shutdown when the primary application launched in it was shut down?" );
@@ -8987,7 +9042,7 @@ void LaunchNestedChildren( char **ppPrimaryChildArgv )
 		waitThread.detach();
 	}
 
-	if ( g_bLaunchMangoapp )
+	if ( g_bLaunchMangoapp && !mangoapp_per_connector() )
 	{
 		char *ppMangoappArgv[] = { (char *)"mangoapp", NULL };
 		// The Steam overlay would latch onto mangoapp's own swapchain as if it were the game.
@@ -8999,6 +9054,92 @@ static gamescope::CTimerFunction g_FPSLimitVRRTimer{ []
 {
 	g_FPSLimitVRRTimer.DisarmTimer();
 }};
+
+struct MangoappInstance_t
+{
+	uint32_t uMsgType = 0;
+	pid_t nReaperPid = -1;
+};
+
+// Key -> spawned mangoapp. Steamcompmgr thread only.
+static std::unordered_map<gamescope::VirtualConnectorKey_t, MangoappInstance_t> s_MangoappInstances;
+static uint32_t s_uNextMangoappMsgType = k_uMangoappFirstConnectorMsgType;
+// Msg type -> last base plane commit id and when it landed, for the visible frametime.
+static std::unordered_map<uint32_t, std::pair<uint64_t, uint64_t>> s_LastBasePlanes;
+
+static uint32_t mangoapp_msg_type_for_key( gamescope::VirtualConnectorKey_t ulKey )
+{
+	auto iter = s_MangoappInstances.find( ulKey );
+	return iter != s_MangoappInstances.end() ? iter->second.uMsgType : 0;
+}
+
+static void UpdateMangoappInstances()
+{
+	if ( !mangoapp_per_connector() )
+		return;
+
+	static bool s_bLoggedSpawnFail = false;
+	for ( const auto &iter : g_VirtualConnectorFocuses )
+	{
+		// Steam draws its own overlays, an instance here would have nowhere to appear.
+		if ( gamescope::VirtualConnectorKeyIsSteam( iter.first ) )
+			continue;
+
+		if ( s_MangoappInstances.contains( iter.first ) )
+			continue;
+
+		// The control type is the stream type plus one, so types go in pairs.
+		uint32_t uMsgType = s_uNextMangoappMsgType;
+
+		// A previous run may have left messages on these types.
+		mangoapp_drop_stream( uMsgType );
+
+		char *ppMangoappArgv[] = { (char *)"mangoapp", NULL };
+		pid_t nPid = gamescope::Process::SpawnProcessInWatchdog( ppMangoappArgv, true, [ uMsgType ]()
+		{
+			gamescope::Process::RemoveSteamOverlayFromPreload();
+			char szMsgType[ 16 ];
+			snprintf( szMsgType, sizeof( szMsgType ), "%u", uMsgType );
+			setenv( "MANGOAPP_MSG_TYPE", szMsgType, 1 );
+		});
+		if ( nPid < 0 )
+		{
+			// The key stays unmapped and the types unclaimed, so the next pass tries again.
+			if ( !s_bLoggedSpawnFail )
+				s_LaunchLogScope.errorf( "Failed to spawn mangoapp for virtual connector key 0x%" PRIx64, iter.first );
+			s_bLoggedSpawnFail = true;
+			continue;
+		}
+		s_bLoggedSpawnFail = false;
+
+		s_uNextMangoappMsgType += 2;
+		s_MangoappInstances[ iter.first ] = MangoappInstance_t{ .uMsgType = uMsgType, .nReaperPid = nPid };
+	}
+
+	for ( auto iter = s_MangoappInstances.begin(); iter != s_MangoappInstances.end(); )
+	{
+		if ( !g_VirtualConnectorFocuses.contains( iter->first ) )
+		{
+			pid_t nReaperPid = iter->second.nReaperPid;
+			gamescope::Process::KillProcess( nReaperPid, SIGTERM );
+			std::thread reapThread([ nReaperPid ]()
+			{
+				pthread_setname_np( pthread_self(), "gamescope-reap" );
+				gamescope::Process::WaitForChild( nReaperPid );
+			});
+			reapThread.detach();
+
+			// Nothing drains this type once its instance is gone.
+			mangoapp_drop_stream( iter->second.uMsgType );
+			s_LastBasePlanes.erase( iter->second.uMsgType );
+			iter = s_MangoappInstances.erase( iter );
+		}
+		else
+		{
+			++iter;
+		}
+	}
+}
 
 // mangoapp_update also runs on the image waiter thread, so publish plain
 // globals here rather than have it walk the focus.
@@ -9014,6 +9155,53 @@ static void publish_mangoapp_snapshot()
 	g_uCurrentBasePlaneCommitID = pFocus->ulBasePlaneCommitID;
 	g_uCurrentBasePlaneAppID = pFocus->uBasePlaneAppID;
 	g_bCurrentBasePlaneIsFifo = pFocus->bBasePlaneIsFifo;
+}
+
+static void publish_mangoapp_connector_snapshots()
+{
+	if ( !GetBackend()->UsesVirtualConnectors() )
+		return;
+
+	std::unordered_map<uint32_t, MangoappSnapshot_t> snapshots;
+	for ( auto &iter : g_VirtualConnectorFocuses )
+	{
+		uint32_t uMsgType = mangoapp_msg_type_for_key( iter.first );
+		if ( !uMsgType )
+			continue;
+
+		// The output fields are global, no connector exposes a mode of its own.
+		global_focus_t *pFocus = &iter.second;
+		snapshots[ uMsgType ] = MangoappSnapshot_t
+		{
+			.nPid = pFocus->nFocusWindowPid,
+			.bFSRActive = pFocus->bFSRActive,
+			.uFSRSharpness = (uint8_t) g_upscaleFilterSharpness,
+			.pEngineName = pFocus->pFocusWindowEngine,
+			.bSteamFocused = window_is_steam( pFocus->inputFocusWindow ),
+			.bAppWantsHDR = g_bAppWantsHDRCached,
+			.uOutputWidth = g_nOutputWidth,
+			.uOutputHeight = g_nOutputHeight,
+			.nOutputRefreshmHz = g_nOutputRefresh,
+		};
+	}
+	mangoapp_set_connector_snapshots( std::move( snapshots ) );
+
+	// mangoapp only repaints on a visible frametime, which no flip path sends here.
+	uint64_t ulNow = get_time_in_nanos();
+	for ( auto &iter : g_VirtualConnectorFocuses )
+	{
+		uint32_t uMsgType = iter.second.externalOverlayWindow ? iter.second.externalOverlayWindow->uMangoappMsgType : 0;
+		if ( !uMsgType )
+			continue;
+
+		auto &lastBasePlane = s_LastBasePlanes[ uMsgType ];
+		if ( lastBasePlane.first == iter.second.ulBasePlaneCommitID )
+			continue;
+
+		if ( lastBasePlane.second && ulNow > lastBasePlane.second )
+			mangoapp_update( ulNow - lastBasePlane.second, uint64_t(~0ull), uint64_t(~0ull), uMsgType );
+		lastBasePlane = { iter.second.ulBasePlaneCommitID, ulNow };
+	}
 }
 
 void
@@ -9399,6 +9587,8 @@ steamcompmgr_main(int argc, char **argv)
 					}
 				}
 			}
+
+			UpdateMangoappInstances();
 
 			for ( auto &iter : g_VirtualConnectorFocuses )
 			{
@@ -9863,6 +10053,7 @@ steamcompmgr_main(int argc, char **argv)
 		}
 
 		publish_mangoapp_snapshot();
+		publish_mangoapp_connector_snapshots();
 
 		if ( bIsVBlankFromTimer )
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -9204,6 +9204,42 @@ static void publish_mangoapp_connector_snapshots()
 	}
 }
 
+// mangohudctl posts one control message for every instance to act on.
+static void relay_mangoapp_control()
+{
+	if ( !GetBackend()->UsesVirtualConnectors() || s_MangoappInstances.empty() )
+		return;
+
+	// An untagged mangoapp reads the control type itself, so leave the queue alone.
+	if ( has_legacy_mangoapp_reader() )
+		return;
+
+	// One tag is enough to know these instances read a control type at all.
+	bool bAnyTagged = false;
+	for ( auto &iter : g_VirtualConnectorFocuses )
+	{
+		if ( iter.second.externalOverlayWindow && iter.second.externalOverlayWindow->uMangoappMsgType )
+		{
+			bAnyTagged = true;
+			break;
+		}
+	}
+	if ( !bAnyTagged )
+		return;
+
+	// Every spawned instance, one still starting finds the message when it reads.
+	std::vector<uint32_t> msgTypes;
+	msgTypes.reserve( s_MangoappInstances.size() );
+	for ( const auto &iter : s_MangoappInstances )
+		msgTypes.push_back( iter.second.uMsgType );
+
+	uint32_t uHeldBack = mangoapp_relay_control( msgTypes );
+	static bool s_bLoggedHeldBack = false;
+	if ( uHeldBack && !s_bLoggedHeldBack )
+		xwm_log.warnf( "Holding back %u mangoapp control message(s), the queue is full", uHeldBack );
+	s_bLoggedHeldBack = uHeldBack != 0;
+}
+
 void
 steamcompmgr_main(int argc, char **argv)
 {
@@ -10054,6 +10090,7 @@ steamcompmgr_main(int argc, char **argv)
 
 		publish_mangoapp_snapshot();
 		publish_mangoapp_connector_snapshots();
+		relay_mangoapp_control();
 
 		if ( bIsVBlankFromTimer )
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -860,6 +860,10 @@ struct BaseLayerInfo_t
 	// back up. The layer filter above may have been downgraded from these.
 	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
+	// The output size the transform was computed for, so a replay after a mode
+	// change recomputes rather than applying a stale mapping.
+	uint32_t uOutputWidth = 0;
+	uint32_t uOutputHeight = 0;
 	AlphaBlendingMode_t eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
 };
 
@@ -2269,10 +2273,24 @@ paint_cached_base_layer(const gamescope::Rc<commit_t>& commit, const BaseLayerIn
 	layer->filter = base.filter;
 	if ( layer->tex == commit->vulkanTex )
 	{
-		layer->scale.x = base.windowScale[0];
-		layer->scale.y = base.windowScale[1];
-		layer->offset.x = base.windowOffset[0];
-		layer->offset.y = base.windowOffset[1];
+		if ( base.uOutputWidth == currentOutputWidth && base.uOutputHeight == currentOutputHeight )
+		{
+			layer->scale.x = base.windowScale[0];
+			layer->scale.y = base.windowScale[1];
+			layer->offset.x = base.windowOffset[0];
+			layer->offset.y = base.windowOffset[1];
+		}
+		else
+		{
+			// The output changed size since this transform was cached, so refit
+			// the texture to it rather than replaying the stale mapping.
+			float flScaleX = 1.0f, flScaleY = 1.0f;
+			calc_scale_factor( base.eUpscaleScaler, flScaleX, flScaleY, layer->tex->width(), layer->tex->height() );
+			layer->scale.x = 1.0f / flScaleX;
+			layer->scale.y = 1.0f / flScaleY;
+			layer->offset.x = -( ( (int)currentOutputWidth - (int)layer->tex->width() * flScaleX ) / 2.0f );
+			layer->offset.y = -( ( (int)currentOutputHeight - (int)layer->tex->height() * flScaleY ) / 2.0f );
+		}
 		frameInfo->focusedWindowScale = { layer->scale.x, layer->scale.y };
 		frameInfo->focusedWindowOffset = { layer->offset.x, layer->offset.y };
 	}
@@ -2560,6 +2578,8 @@ paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *
 		basePlane.filter = layer->filter;
 		basePlane.eUpscaleFilter = frameInfo->eUpscaleFilter;
 		basePlane.eUpscaleScaler = frameInfo->eUpscaleScaler;
+		basePlane.uOutputWidth = currentOutputWidth;
+		basePlane.uOutputHeight = currentOutputHeight;
 		basePlane.eAlphaBlendingMode = layer->eAlphaBlendingMode;
 
 		pFocus->CachedPlanes[ HELD_COMMIT_BASE ] = basePlane;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -852,6 +852,9 @@ struct BaseLayerInfo_t
 {
 	float scale[2];
 	float offset[2];
+	// The window's own transform, which the layer's does not track once upscaled.
+	float windowScale[2] = { 1.0f, 1.0f };
+	float windowOffset[2] = {};
 	float opacity;
 	GamescopeUpscaleFilter filter;
 	AlphaBlendingMode_t eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
@@ -2263,6 +2266,9 @@ paint_cached_base_layer(const gamescope::Rc<commit_t>& commit, const BaseLayerIn
 	layer->offset.y = base.offset[1];
 	layer->opacity = bOverrideOpacity ? flOpacityScale : base.opacity * flOpacityScale;
 
+	frameInfo->focusedWindowScale = { base.windowScale[0], base.windowScale[1] };
+	frameInfo->focusedWindowOffset = { base.windowOffset[0], base.windowOffset[1] };
+
 	layer->colorspace = commit->colorspace();
 	layer->hdr_metadata_blob = nullptr;
 	if (commit->feedback)
@@ -2347,8 +2353,8 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 
 	if ( flags & PaintWindowFlag::NoScale )
 	{
-		sourceWidth = currentOutputWidth;
-		sourceHeight = currentOutputHeight;
+		sourceWidth = baseWidth = currentOutputWidth;
+		sourceHeight = baseHeight = currentOutputHeight;
 	}
 	else
 	{
@@ -2403,6 +2409,29 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 
 	bool offset = ( ( winOffsetX || winOffsetY ) && w != scaleW );
 
+	// A pre-emptively upscaled commit draws from an output sized texture, so the
+	// window's own transform comes from the commit dimensions rather than those.
+	int baseXOffset = 0, baseYOffset = 0;
+	if (baseWidth != (int32_t)currentOutputWidth || baseHeight != (int32_t)currentOutputHeight || offset || globalScaleRatio != 1.0f)
+	{
+		calc_scale_factor(frameInfo->eUpscaleScaler, baseScaleRatio_x, baseScaleRatio_y, baseWidth, baseHeight);
+
+		baseXOffset = ((int)currentOutputWidth - (int)baseWidth * baseScaleRatio_x) / 2.0f;
+		baseYOffset = ((int)currentOutputHeight - (int)baseHeight * baseScaleRatio_y) / 2.0f;
+
+		if ( w != scaleW )
+		{
+			baseXOffset += winOffsetX * baseScaleRatio_x;
+			baseYOffset += winOffsetY * baseScaleRatio_y;
+		}
+
+		if ( zoomScaleRatio != 1.0 )
+		{
+			baseXOffset += (((int)baseWidth / 2) - (cursor ? cursor->x() : 0)) * baseScaleRatio_x;
+			baseYOffset += (((int)baseHeight / 2) - (cursor ? cursor->y() : 0)) * baseScaleRatio_y;
+		}
+	}
+
 	if (sourceWidth != (int32_t)currentOutputWidth || sourceHeight != (int32_t)currentOutputHeight || offset || globalScaleRatio != 1.0f)
 	{
 		calc_scale_factor(frameInfo->eUpscaleScaler, currentScaleRatio_x, currentScaleRatio_y, sourceWidth, sourceHeight);
@@ -2416,7 +2445,6 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 			drawYOffset += winOffsetY * currentScaleRatio_y;
 		}
 
-		calc_scale_factor(frameInfo->eUpscaleScaler, baseScaleRatio_x, baseScaleRatio_y, baseWidth, baseHeight);
 		if ( zoomScaleRatio != 1.0 )
 		{
 			drawXOffset += (((int)baseWidth / 2) - (cursor ? cursor->x() : 0)) * baseScaleRatio_x;
@@ -2431,6 +2459,9 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 
 	layer->offset.x = -drawXOffset;
 	layer->offset.y = -drawYOffset;
+
+	frameInfo->focusedWindowScale = { 1.0f / baseScaleRatio_x, 1.0f / baseScaleRatio_y };
+	frameInfo->focusedWindowOffset = { float( -baseXOffset ), float( -baseYOffset ) };
 
 	layer->blackBorder = flags & PaintWindowFlag::DrawBorders;
 
@@ -2511,6 +2542,10 @@ paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *
 		basePlane.scale[1] = layer->scale.y;
 		basePlane.offset[0] = layer->offset.x;
 		basePlane.offset[1] = layer->offset.y;
+		basePlane.windowScale[0] = frameInfo->focusedWindowScale.x;
+		basePlane.windowScale[1] = frameInfo->focusedWindowScale.y;
+		basePlane.windowOffset[0] = frameInfo->focusedWindowOffset.x;
+		basePlane.windowOffset[1] = frameInfo->focusedWindowOffset.y;
 		basePlane.opacity = layer->opacity;
 		basePlane.filter = layer->filter;
 		basePlane.eAlphaBlendingMode = layer->eAlphaBlendingMode;
@@ -2549,10 +2584,10 @@ static void update_touch_scaling( const struct FrameInfo_t *frameInfo )
 	if ( !frameInfo->layers.count() )
 		return;
 
-	focusedWindowScaleX = frameInfo->layers.get( frameInfo->layers.count() - 1 ).scale.x;
-	focusedWindowScaleY = frameInfo->layers.get( frameInfo->layers.count() - 1 ).scale.y;
-	focusedWindowOffsetX = frameInfo->layers.get( frameInfo->layers.count() - 1 ).offset.x;
-	focusedWindowOffsetY = frameInfo->layers.get( frameInfo->layers.count() - 1 ).offset.y;
+	focusedWindowScaleX = frameInfo->focusedWindowScale.x;
+	focusedWindowScaleY = frameInfo->focusedWindowScale.y;
+	focusedWindowOffsetX = frameInfo->focusedWindowOffset.x;
+	focusedWindowOffsetY = frameInfo->focusedWindowOffset.y;
 }
 
 #if HAVE_PIPEWIRE

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8094,7 +8094,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 
 	gpuvis_trace_printf( "pushing wait for commit %lu win %lx", newCommit->commitID, w->type == steamcompmgr_win_type_t::XWAYLAND ? w->xwayland().id : 0 );
 	{
-		newCommit->SetFence( fence, mango_nudge, doneCommits );
+		newCommit->SetFence( fence, mango_nudge, 0, doneCommits );
 		if ( bKnownReady )
 			newCommit->Signal();
 		else

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -871,6 +871,9 @@ struct global_focus_t : public focus_t
 	steamcompmgr_win_t		  	 		*fadeWindow;
 	MouseCursor		*cursor;
 
+	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
+	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
+
 	gamescope::VirtualConnectorKey_t ulVirtualFocusKey = 0;
 	std::shared_ptr<gamescope::IBackendConnector> pVirtualConnector;
 
@@ -1717,7 +1720,7 @@ window_is_fullscreen( steamcompmgr_win_t *w )
 	return w && ( window_is_steam( w ) || w->isFullscreen );
 }
 
-void calc_scale_factor_scaler(float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight)
+void calc_scale_factor_scaler(GamescopeUpscaleScaler eScaler, float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight)
 {
 	float XOutputRatio = currentOutputWidth / (float)g_nNestedWidth;
 	float YOutputRatio = currentOutputHeight / (float)g_nNestedHeight;
@@ -1726,14 +1729,14 @@ void calc_scale_factor_scaler(float &out_scale_x, float &out_scale_y, float sour
 	float XRatio = (float)g_nNestedWidth / sourceWidth;
 	float YRatio = (float)g_nNestedHeight / sourceHeight;
 
-	if (g_upscaleScaler == GamescopeUpscaleScaler::STRETCH)
+	if (eScaler == GamescopeUpscaleScaler::STRETCH)
 	{
 		out_scale_x = XRatio * XOutputRatio;
 		out_scale_y = YRatio * YOutputRatio;
 		return;
 	}
 
-	if (g_upscaleScaler != GamescopeUpscaleScaler::FILL)
+	if (eScaler != GamescopeUpscaleScaler::FILL)
 	{
 		out_scale_x = std::min(XRatio, YRatio);
 		out_scale_y = std::min(XRatio, YRatio);
@@ -1744,7 +1747,7 @@ void calc_scale_factor_scaler(float &out_scale_x, float &out_scale_y, float sour
 		out_scale_y = std::max(XRatio, YRatio);
 	}
 
-	if (g_upscaleScaler == GamescopeUpscaleScaler::AUTO)
+	if (eScaler == GamescopeUpscaleScaler::AUTO)
 	{
 		out_scale_x = std::min(g_flMaxWindowScale, out_scale_x);
 		out_scale_y = std::min(g_flMaxWindowScale, out_scale_y);
@@ -1753,7 +1756,7 @@ void calc_scale_factor_scaler(float &out_scale_x, float &out_scale_y, float sour
 	out_scale_x *= outputScaleRatio;
 	out_scale_y *= outputScaleRatio;
 
-	if (g_upscaleScaler == GamescopeUpscaleScaler::INTEGER)
+	if (eScaler == GamescopeUpscaleScaler::INTEGER)
 	{
 		if (out_scale_x > 1.0f)
 		{
@@ -1763,9 +1766,9 @@ void calc_scale_factor_scaler(float &out_scale_x, float &out_scale_y, float sour
 	}
 }
 
-void calc_scale_factor(float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight)
+void calc_scale_factor(GamescopeUpscaleScaler eScaler, float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight)
 {
-	calc_scale_factor_scaler(out_scale_x, out_scale_y, sourceWidth, sourceHeight);
+	calc_scale_factor_scaler(eScaler, out_scale_x, out_scale_y, sourceWidth, sourceHeight);
 
 	out_scale_x *= globalScaleRatio;
 	out_scale_y *= globalScaleRatio;
@@ -2151,7 +2154,7 @@ void MouseCursor::paint(steamcompmgr_win_t *window, steamcompmgr_win_t *fit, str
 	float currentScaleRatio_y = 1.0;
 	int cursorOffsetX, cursorOffsetY;
 
-	calc_scale_factor(currentScaleRatio_x, currentScaleRatio_y, sourceWidth, sourceHeight);
+	calc_scale_factor(frameInfo->eUpscaleScaler, currentScaleRatio_x, currentScaleRatio_y, sourceWidth, sourceHeight);
 
 	cursorOffsetX = (currentOutputWidth - sourceWidth * currentScaleRatio_x) / 2.0f;
 	cursorOffsetY = (currentOutputHeight - sourceHeight * currentScaleRatio_y) / 2.0f;
@@ -2310,9 +2313,9 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 	if ( !layer )
 		return nullptr;
 
-	layer->filter = ( flags & PaintWindowFlag::NoFilter ) ? GamescopeUpscaleFilter::LINEAR : g_upscaleFilter;
+	layer->filter = ( flags & PaintWindowFlag::NoFilter ) ? GamescopeUpscaleFilter::LINEAR : frameInfo->eUpscaleFilter;
 
-	layer->tex = lastCommit->GetTexture( layer->filter, g_upscaleScaler, layer->colorspace );
+	layer->tex = lastCommit->GetTexture( layer->filter, frameInfo->eUpscaleScaler, layer->colorspace );
 
 	if ( flags & PaintWindowFlag::NoScale )
 	{
@@ -2374,7 +2377,7 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 
 	if (sourceWidth != (int32_t)currentOutputWidth || sourceHeight != (int32_t)currentOutputHeight || offset || globalScaleRatio != 1.0f)
 	{
-		calc_scale_factor(currentScaleRatio_x, currentScaleRatio_y, sourceWidth, sourceHeight);
+		calc_scale_factor(frameInfo->eUpscaleScaler, currentScaleRatio_x, currentScaleRatio_y, sourceWidth, sourceHeight);
 
 		drawXOffset = ((int)currentOutputWidth - (int)sourceWidth * currentScaleRatio_x) / 2.0f;
 		drawYOffset = ((int)currentOutputHeight - (int)sourceHeight * currentScaleRatio_y) / 2.0f;
@@ -2385,7 +2388,7 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 			drawYOffset += winOffsetY * currentScaleRatio_y;
 		}
 
-		calc_scale_factor(baseScaleRatio_x, baseScaleRatio_y, baseWidth, baseHeight);
+		calc_scale_factor(frameInfo->eUpscaleScaler, baseScaleRatio_x, baseScaleRatio_y, baseWidth, baseHeight);
 		if ( zoomScaleRatio != 1.0 )
 		{
 			drawXOffset += (((int)baseWidth / 2) - (cursor ? cursor->x() : 0)) * baseScaleRatio_x;
@@ -2545,6 +2548,13 @@ static void paint_pipewire()
 	frameInfo.outputEncodingEOTF   = EOTF_Gamma22;
 	frameInfo.allowVRR             = false;
 	frameInfo.bFadingOut           = false;
+
+	const UpscaleSettings_t upscaleSettings = GetUpscaleSettings(
+		GetCurrentFocus() && window_is_steam( GetCurrentFocus()->focusWindow ),
+		g_wantedUpscaleFilter,
+		g_wantedUpscaleScaler );
+	frameInfo.eUpscaleFilter = upscaleSettings.eFilter;
+	frameInfo.eUpscaleScaler = upscaleSettings.eScaler;
 
 	// Apply screenshot-style color management.
 	for ( uint32_t nInputEOTF = 0; nInputEOTF < EOTF_Count; nInputEOTF++ )
@@ -2809,6 +2819,8 @@ paint_all( global_focus_t *pFocus, bool async )
 	frameInfo.outputEncodingEOTF = g_ColorMgmt.pending.outputEncodingEOTF;
 	frameInfo.allowVRR = cv_adaptive_sync;
 	frameInfo.bFadingOut = fadingOut;
+	frameInfo.eUpscaleFilter = pFocus->eUpscaleFilter;
+	frameInfo.eUpscaleScaler = pFocus->eUpscaleScaler;
 
 	// If the window we'd paint as the base layer is the streaming client,
 	// find the video underlay and put it up first in the scenegraph
@@ -2876,8 +2888,8 @@ paint_all( global_focus_t *pFocus, bool async )
 					paint_window(pFocus, w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders, 1.0f, fit);
 
 					bool needsScaling = frameInfo.layers.get( 0 ).scale.x < 0.999f && frameInfo.layers.get( 0 ).scale.y < 0.999f;
-					frameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR && needsScaling;
-					frameInfo.useNISLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::NIS && needsScaling;
+					frameInfo.useFSRLayer0 = frameInfo.eUpscaleFilter == GamescopeUpscaleFilter::FSR && needsScaling;
+					frameInfo.useNISLayer0 = frameInfo.eUpscaleFilter == GamescopeUpscaleFilter::NIS && needsScaling;
 				}
 				if ( pFocus == GetCurrentMouseFocus() )
 					update_touch_scaling( &frameInfo );
@@ -3239,6 +3251,8 @@ paint_all( global_focus_t *pFocus, bool async )
 			else if ( bRenderSizeScreenshot )
 			{
 				FrameInfo_t screenshotFrameInfo{};
+				screenshotFrameInfo.eUpscaleFilter = frameInfo.eUpscaleFilter;
+				screenshotFrameInfo.eUpscaleScaler = frameInfo.eUpscaleScaler;
 				screenshotFrameInfo.applyOutputColorMgmt = true;
 				screenshotFrameInfo.outputEncodingEOTF = bHDRScreenshot ? EOTF_PQ : EOTF_Gamma22;
 				for ( uint32_t nInputEOTF = 0; nInputEOTF < EOTF_Count; nInputEOTF++ )
@@ -6705,7 +6719,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 	if ( ev->atom == ctx->atoms.gamescopeFSRSharpness || ev->atom == ctx->atoms.gamescopeSharpness )
 	{
 		g_upscaleFilterSharpness = (int)clamp( get_prop( ctx, ctx->root, ev->atom, 2 ), 0u, 20u );
-		if ( g_upscaleFilter == GamescopeUpscaleFilter::FSR || g_upscaleFilter == GamescopeUpscaleFilter::NIS )
+		if ( g_wantedUpscaleFilter == GamescopeUpscaleFilter::FSR || g_wantedUpscaleFilter == GamescopeUpscaleFilter::NIS )
 			hasRepaint = true;
 	}
 	if ( ev->atom == ctx->atoms.gamescopeXWaylandModeControl )
@@ -7840,7 +7854,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 								&& !bMangoappSocketDisable;
 
 	bool bValidPreemptiveScale = reslistentry.pAcquirePoint && pCurrentFocus && w == pCurrentFocus->focusWindow && cv_upscale_preemptive;
-	bool bPreemptiveUpscale = bValidPreemptiveScale && newCommit->ShouldPreemptivelyUpscale();
+	bool bPreemptiveUpscale = bValidPreemptiveScale && newCommit->ShouldPreemptivelyUpscale( pCurrentFocus->eUpscaleFilter, pCurrentFocus->eUpscaleScaler );
 
 	bool bKnownReady = false;
 
@@ -7860,9 +7874,11 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		overscanScaleRatio = 1.0f;
 		zoomScaleRatio = 1.0f;
 		globalScaleRatio = 1.0f;
+		upscaledFrameInfo.eUpscaleFilter = pCurrentFocus->eUpscaleFilter;
+		upscaledFrameInfo.eUpscaleScaler = pCurrentFocus->eUpscaleScaler;
 		paint_window_commit( newCommit, w, w, &upscaledFrameInfo, nullptr );
-		upscaledFrameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR;
-		upscaledFrameInfo.useNISLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::NIS;
+		upscaledFrameInfo.useFSRLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::FSR;
+		upscaledFrameInfo.useNISLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::NIS;
 		globalScaleRatio = flOldGlobalScale;
 		zoomScaleRatio = flOldZoomScale;
 		overscanScaleRatio = flOldOverscanScale;
@@ -7896,8 +7912,8 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 			newCommit->upscaledTexture = std::optional<UpscaledTexture_t>
 			{
 				std::in_place_t{},
-				g_upscaleFilter,
-				g_upscaleScaler,
+				upscaledFrameInfo.eUpscaleFilter,
+				upscaledFrameInfo.eUpscaleScaler,
 				g_nOutputWidth,
 				g_nOutputHeight,
 				pTempImage->pTexture,
@@ -9503,20 +9519,7 @@ steamcompmgr_main(int argc, char **argv)
 		if ( g_bPendingFocusInfo.exchange( false ) )
 			DumpFocusInfo();
 
-		// XXX(misyl): This is bad! We shouldnt change the upscaler like this at all!!!
-		// We should move this to business logic in paint_window or something!
-		if ( GetCurrentFocus() && window_is_steam( GetCurrentFocus()->focusWindow ) )
-		{
-			g_bSteamIsActiveWindow = true;
-			g_upscaleScaler = GamescopeUpscaleScaler::FIT;
-			g_upscaleFilter = GamescopeUpscaleFilter::LINEAR;
-		}
-		else
-		{
-			g_bSteamIsActiveWindow = false;
-			g_upscaleScaler = g_wantedUpscaleScaler;
-			g_upscaleFilter = g_wantedUpscaleFilter;
-		}
+		g_bSteamIsActiveWindow = GetCurrentFocus() && window_is_steam( GetCurrentFocus()->focusWindow );
 
 		// If we're in the middle of a fade, then keep us
 		// as needing a repaint.
@@ -9536,6 +9539,13 @@ steamcompmgr_main(int argc, char **argv)
 		for ( auto &iter : g_VirtualConnectorFocuses )
 		{
 			global_focus_t *pPaintFocus = &iter.second;
+
+			const UpscaleSettings_t upscaleSettings = GetUpscaleSettings(
+				window_is_steam( pPaintFocus->focusWindow ),
+				g_wantedUpscaleFilter,
+				g_wantedUpscaleScaler );
+			pPaintFocus->eUpscaleFilter = upscaleSettings.eFilter;
+			pPaintFocus->eUpscaleScaler = upscaleSettings.eScaler;
 
 			if ( vblank )
 			{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -850,13 +850,16 @@ enum HeldCommitTypes_t
 
 struct BaseLayerInfo_t
 {
-	float scale[2];
-	float offset[2];
-	// The window's own transform, which the layer's does not track once upscaled.
+	// The window's own transform, which fits the commit's raw texture. The
+	// pre-emptively upscaled texture is output sized and needs no transform.
 	float windowScale[2] = { 1.0f, 1.0f };
 	float windowOffset[2] = {};
 	float opacity;
 	GamescopeUpscaleFilter filter;
+	// The requested upscale settings, to pick the commit's upscaled texture
+	// back up. The layer filter above may have been downgraded from these.
+	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
+	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
 	AlphaBlendingMode_t eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
 };
 
@@ -2260,16 +2263,29 @@ paint_cached_base_layer(const gamescope::Rc<commit_t>& commit, const BaseLayerIn
 	if ( !layer )
 		return;
 
-	layer->scale.x = base.scale[0];
-	layer->scale.y = base.scale[1];
-	layer->offset.x = base.offset[0];
-	layer->offset.y = base.offset[1];
 	layer->opacity = bOverrideOpacity ? flOpacityScale : base.opacity * flOpacityScale;
 
-	frameInfo->focusedWindowScale = { base.windowScale[0], base.windowScale[1] };
-	frameInfo->focusedWindowOffset = { base.windowOffset[0], base.windowOffset[1] };
+	layer->tex = commit->GetTexture( base.eUpscaleFilter, base.eUpscaleScaler, layer->colorspace );
+	layer->filter = base.filter;
+	if ( layer->tex == commit->vulkanTex )
+	{
+		layer->scale.x = base.windowScale[0];
+		layer->scale.y = base.windowScale[1];
+		layer->offset.x = base.windowOffset[0];
+		layer->offset.y = base.windowOffset[1];
+		frameInfo->focusedWindowScale = { layer->scale.x, layer->scale.y };
+		frameInfo->focusedWindowOffset = { layer->offset.x, layer->offset.y };
+	}
+	else
+	{
+		// The pre-emptively upscaled image covers the output and bakes the
+		// window transform into its pixels, so the pointer mapping keeps it.
+		layer->scale = { 1.0f, 1.0f };
+		layer->offset = { 0.0f, 0.0f };
+		frameInfo->focusedWindowScale = { base.windowScale[0], base.windowScale[1] };
+		frameInfo->focusedWindowOffset = { base.windowOffset[0], base.windowOffset[1] };
+	}
 
-	layer->colorspace = commit->colorspace();
 	layer->hdr_metadata_blob = nullptr;
 	if (commit->feedback)
 	{
@@ -2278,9 +2294,7 @@ paint_cached_base_layer(const gamescope::Rc<commit_t>& commit, const BaseLayerIn
 	layer->ctm = nullptr;
 	if (layer->colorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB)
 		layer->ctm = s_scRGB709To2020Matrix;
-	layer->tex = commit->vulkanTex;
 
-	layer->filter = base.filter;
 	layer->eAlphaBlendingMode = base.eAlphaBlendingMode;
 	layer->blackBorder = true;
 }
@@ -2538,16 +2552,14 @@ paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *
 	if ( layer && ( flags & PaintWindowFlag::BasePlane ) )
 	{
 		BaseLayerInfo_t basePlane = {};
-		basePlane.scale[0] = layer->scale.x;
-		basePlane.scale[1] = layer->scale.y;
-		basePlane.offset[0] = layer->offset.x;
-		basePlane.offset[1] = layer->offset.y;
 		basePlane.windowScale[0] = frameInfo->focusedWindowScale.x;
 		basePlane.windowScale[1] = frameInfo->focusedWindowScale.y;
 		basePlane.windowOffset[0] = frameInfo->focusedWindowOffset.x;
 		basePlane.windowOffset[1] = frameInfo->focusedWindowOffset.y;
 		basePlane.opacity = layer->opacity;
 		basePlane.filter = layer->filter;
+		basePlane.eUpscaleFilter = frameInfo->eUpscaleFilter;
+		basePlane.eUpscaleScaler = frameInfo->eUpscaleScaler;
 		basePlane.eAlphaBlendingMode = layer->eAlphaBlendingMode;
 
 		pFocus->CachedPlanes[ HELD_COMMIT_BASE ] = basePlane;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -295,6 +295,7 @@ gamescope::ConVar<int> cv_adaptive_sync_overlay_cycles( "adaptive_sync_overlay_c
 
 gamescope::ConVar<bool> cv_upscale_preemptive( "upscale_preemptive", true, "Allow pre-emptive upscaling" );
 gamescope::ConVar<bool> cv_upscale_preemptive_debug_force_sync( "upscale_preemptive_debug_force_sync", false, "Force synchronize pre-emptive upscaling" );
+gamescope::ConVar<bool> cv_hack_remap_sharp_to_fsr( "hack_remap_sharp_to_fsr", true, "HACK: treat unknown scaling filter 5 as FSR" );
 
 uint64_t g_SteamCompMgrLimitedAppRefreshCycle = 16'666'666;
 uint64_t g_SteamCompMgrAppRefreshCycle = 16'666'666;
@@ -6942,6 +6943,16 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 	if ( ev->atom == ctx->atoms.gamescopeNewScalingFilter )
 	{
 		uint32_t uScalingFilter = get_prop( ctx, ctx->root, ctx->atoms.gamescopeNewScalingFilter, 0 );
+
+		// HACK: Steam Frame's Sharp option sends 5, which no filter enum
+		// defines. Remap it so the option does something while the wire
+		// mismatch is sorted out with Steam.
+		if ( cv_hack_remap_sharp_to_fsr && uScalingFilter == 5 )
+		{
+			xwm_log.infof( "HACK: remapping scaling filter 5 to FSR" );
+			uScalingFilter = uint32_t( GamescopeUpscaleFilter::FSR );
+		}
+
 		if ( uScalingFilter > uint32_t( GamescopeUpscaleFilter::PIXEL ) )
 			xwm_log.errorf( "Unknown scaling filter %u, keeping %u", uScalingFilter, uint32_t( g_wantedUpscaleFilter ) );
 		else if ( g_wantedUpscaleFilter != GamescopeUpscaleFilter( uScalingFilter ) )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -873,6 +873,9 @@ struct global_focus_t : public focus_t
 
 	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
+	// Cleanup for the previous pre-emptive upscale, kept a frame behind.
+	std::optional<uint64_t> oLastPreemptiveUpscaleSeqNo;
+	std::vector<TempUpscaleImage_t> UpscaleImages;
 
 	std::array< gamescope::Rc<commit_t>, HELD_COMMIT_COUNT > HeldCommits;
 	std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > CachedPlanes = {};
@@ -924,6 +927,22 @@ global_focus_t *GetCurrentMouseFocus()
 		return &iter->second;
 
 	return GetCurrentFocus();
+}
+
+// The focus whose focusWindow is w, ignoring the other window roles.
+// Guards w because a null one would match any focus without a window.
+global_focus_t *GetFocusForWindow( steamcompmgr_win_t *w )
+{
+	if ( !w )
+		return nullptr;
+
+	for ( auto &iter : g_VirtualConnectorFocuses )
+	{
+		if ( iter.second.focusWindow == w )
+			return &iter.second;
+	}
+
+	return nullptr;
 }
 
 uint32_t		currentOutputWidth, currentOutputHeight;
@@ -7715,33 +7734,32 @@ void force_repaint( void )
 	nudge_steamcompmgr();
 }
 
-static std::vector<TempUpscaleImage_t> g_pUpscaleImages;
-void ClearUpscaleImages()
+static void ClearUpscaleImages( global_focus_t *pFocus )
 {
-	g_pUpscaleImages.clear();
+	pFocus->UpscaleImages.clear();
 }
 
-static TempUpscaleImage_t *GetTempUpscaleImage( uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat )
+static TempUpscaleImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat )
 {
-	if ( g_pUpscaleImages.size() )
+	if ( pFocus->UpscaleImages.size() )
 	{
 		// Mixing and matching sizes to only do the min required would be nice
 		// but massively complicates caching.
-		if ( g_pUpscaleImages[0].pTexture->width() != uWidth ||
-			 g_pUpscaleImages[0].pTexture->height() != uHeight ||
-			 g_pUpscaleImages[0].pTexture->drmFormat() != uDrmFormat )
+		if ( pFocus->UpscaleImages[0].pTexture->width() != uWidth ||
+			 pFocus->UpscaleImages[0].pTexture->height() != uHeight ||
+			 pFocus->UpscaleImages[0].pTexture->drmFormat() != uDrmFormat )
 		{
-			g_pUpscaleImages.clear();
+			pFocus->UpscaleImages.clear();
 		}
 	}
 
-	for ( TempUpscaleImage_t &image : g_pUpscaleImages )
+	for ( TempUpscaleImage_t &image : pFocus->UpscaleImages )
 	{
 		if ( !image.pTexture->IsInUse() )
 			return &image;
 	}
 
-	if ( g_pUpscaleImages.size() > 8 )
+	if ( pFocus->UpscaleImages.size() > 8 )
 	{
 		xwm_log.warnf( "No upscale images free!\n" );
 		return {};
@@ -7758,7 +7776,7 @@ static TempUpscaleImage_t *GetTempUpscaleImage( uint32_t uWidth, uint32_t uHeigh
 	imageFlags.bStorage = true;
 	imageFlags.bFlippable = true;
 	pTexture->BInit( g_nOutputWidth, g_nOutputHeight, 1, uDrmFormat, imageFlags );
-	TempUpscaleImage_t &image = g_pUpscaleImages.emplace_back( std::move( pTexture ), std::move( pTimeline ) );
+	TempUpscaleImage_t &image = pFocus->UpscaleImages.emplace_back( std::move( pTexture ), std::move( pTimeline ) );
 
 	return &image;
 }
@@ -7870,8 +7888,10 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 								( pCurrentFocus->focusWindow && pCurrentFocus->focusWindow->isSteamStreamingClient && w->isSteamStreamingClientVideo ) )
 								&& !bMangoappSocketDisable;
 
-	bool bValidPreemptiveScale = reslistentry.pAcquirePoint && pCurrentFocus && w == pCurrentFocus->focusWindow && cv_upscale_preemptive;
-	bool bPreemptiveUpscale = bValidPreemptiveScale && newCommit->ShouldPreemptivelyUpscale( pCurrentFocus->eUpscaleFilter, pCurrentFocus->eUpscaleScaler );
+	// The window's own connector, not whichever one is current.
+	global_focus_t *pUpscaleFocus = GetFocusForWindow( w );
+	bool bValidPreemptiveScale = reslistentry.pAcquirePoint && pUpscaleFocus && cv_upscale_preemptive;
+	bool bPreemptiveUpscale = bValidPreemptiveScale && newCommit->ShouldPreemptivelyUpscale( pUpscaleFocus->eUpscaleFilter, pUpscaleFocus->eUpscaleScaler );
 
 	bool bKnownReady = false;
 
@@ -7891,8 +7911,8 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		overscanScaleRatio = 1.0f;
 		zoomScaleRatio = 1.0f;
 		globalScaleRatio = 1.0f;
-		upscaledFrameInfo.eUpscaleFilter = pCurrentFocus->eUpscaleFilter;
-		upscaledFrameInfo.eUpscaleScaler = pCurrentFocus->eUpscaleScaler;
+		upscaledFrameInfo.eUpscaleFilter = pUpscaleFocus->eUpscaleFilter;
+		upscaledFrameInfo.eUpscaleScaler = pUpscaleFocus->eUpscaleScaler;
 		paint_window_commit( newCommit, w, w, &upscaledFrameInfo, nullptr );
 		upscaledFrameInfo.useFSRLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::FSR;
 		upscaledFrameInfo.useNISLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::NIS;
@@ -7900,7 +7920,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		zoomScaleRatio = flOldZoomScale;
 		overscanScaleRatio = flOldOverscanScale;
 
-		TempUpscaleImage_t *pTempImage = GetTempUpscaleImage( g_nOutputWidth, g_nOutputHeight, g_output.uOutputFormat );
+		TempUpscaleImage_t *pTempImage = GetTempUpscaleImage( pUpscaleFocus, g_nOutputWidth, g_nOutputHeight, g_output.uOutputFormat );
 		if ( pTempImage )
 		{
 			const uint64_t ulNextReleasePoint = ++pTempImage->ulLastPoint;
@@ -7910,11 +7930,9 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 			pCommandBuffer->AddDependency( reslistentry.pAcquirePoint->GetTimeline()->ToVkSemaphore(), reslistentry.pAcquirePoint->GetPoint() );
 			pCommandBuffer->AddSignal( pTempImage->pReleaseTimeline->ToVkSemaphore(), ulNextReleasePoint );
 
-			static std::optional<uint64_t> s_ulLastPreemptiveUpscaleSeqNo;
-
-			if ( s_ulLastPreemptiveUpscaleSeqNo )
+			if ( pUpscaleFocus->oLastPreemptiveUpscaleSeqNo )
 			{
-				vulkan_wait( *s_ulLastPreemptiveUpscaleSeqNo, true );
+				vulkan_wait( *pUpscaleFocus->oLastPreemptiveUpscaleSeqNo, true );
 			}
 
 			std::optional<uint64_t> seqNo = vulkan_composite( &upscaledFrameInfo, nullptr, false, pTempImage->pTexture, false, std::move( pCommandBuffer ) );
@@ -7924,7 +7942,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 				vulkan_wait( *seqNo, true );
 			}
 
-			s_ulLastPreemptiveUpscaleSeqNo = seqNo;
+			pUpscaleFocus->oLastPreemptiveUpscaleSeqNo = seqNo;
 
 			newCommit->upscaledTexture = std::optional<UpscaledTexture_t>
 			{
@@ -7952,7 +7970,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 	{
 		if ( bValidPreemptiveScale )
 		{
-			ClearUpscaleImages();
+			ClearUpscaleImages( pUpscaleFocus );
 		}
 
 		if ( reslistentry.pAcquirePoint )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -876,6 +876,7 @@ struct global_focus_t : public focus_t
 	// Cleanup for the previous pre-emptive upscale, kept a frame behind.
 	std::optional<uint64_t> oLastPreemptiveUpscaleSeqNo;
 	std::vector<TempUpscaleImage_t> UpscaleImages;
+	uint32_t uNextUpscaleImage = 0;
 
 	std::array< gamescope::Rc<commit_t>, HELD_COMMIT_COUNT > HeldCommits;
 	std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > CachedPlanes = {};
@@ -7737,6 +7738,7 @@ void force_repaint( void )
 static void ClearUpscaleImages( global_focus_t *pFocus )
 {
 	pFocus->UpscaleImages.clear();
+	pFocus->uNextUpscaleImage = 0;
 }
 
 static TempUpscaleImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat )
@@ -7750,13 +7752,20 @@ static TempUpscaleImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t
 			 pFocus->UpscaleImages[0].pTexture->drmFormat() != uDrmFormat )
 		{
 			pFocus->UpscaleImages.clear();
+			pFocus->uNextUpscaleImage = 0;
 		}
 	}
 
-	for ( TempUpscaleImage_t &image : pFocus->UpscaleImages )
+	// Round robin so a slot rests as long as possible, SteamVR can still be sampling a freed one.
+	for ( size_t i = 0; i < pFocus->UpscaleImages.size(); i++ )
 	{
+		size_t uIndex = ( pFocus->uNextUpscaleImage + i ) % pFocus->UpscaleImages.size();
+		TempUpscaleImage_t &image = pFocus->UpscaleImages[ uIndex ];
 		if ( !image.pTexture->IsInUse() )
+		{
+			pFocus->uNextUpscaleImage = ( uIndex + 1 ) % pFocus->UpscaleImages.size();
 			return &image;
+		}
 	}
 
 	if ( pFocus->UpscaleImages.size() > 8 )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1347,6 +1347,7 @@ bool steamcompmgr_window_should_refresh_switch( steamcompmgr_win_t *w )
 #define STEAM_PROP			"STEAM_BIGPICTURE"
 #define OVERLAY_PROP		"STEAM_OVERLAY"
 #define EXTERNAL_OVERLAY_PROP		"GAMESCOPE_EXTERNAL_OVERLAY"
+#define MANGOAPP_MSG_TYPE_PROP		"GAMESCOPE_MANGOAPP_MSG_TYPE"
 #define GAMES_RUNNING_PROP 	"STEAM_GAMES_RUNNING"
 #define SCREEN_SCALE_PROP	"STEAM_SCREEN_SCALE"
 #define SCREEN_MAGNIFICATION_PROP	"STEAM_SCREEN_MAGNIFICATION"
@@ -5485,6 +5486,7 @@ map_win(xwayland_ctx_t* ctx, Window id, unsigned long sequence)
 	
 	w->isOverlay = get_prop(ctx, w->xwayland().id, ctx->atoms.overlayAtom, 0);
 	w->isExternalOverlay = get_prop(ctx, w->xwayland().id, ctx->atoms.externalOverlayAtom, 0);
+	w->uMangoappMsgType = get_prop(ctx, w->xwayland().id, ctx->atoms.mangoappMsgTypeAtom, 0);
 
 	// misyl: Disable appID for overlay types, as parts of the code don't expect that focus-wise.
 	// Fixes mangoapp usage when nested, and not in SteamOS.
@@ -6666,6 +6668,15 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 			w->isExternalOverlay = get_prop(ctx, w->xwayland().id, ctx->atoms.externalOverlayAtom, 0);
 			if ( w->isExternalOverlay )
 				w->appID = 0;
+			MakeFocusDirty();
+		}
+	}
+	if (ev->atom == ctx->atoms.mangoappMsgTypeAtom)
+	{
+		steamcompmgr_win_t * w = find_win(ctx, ev->window);
+		if (w)
+		{
+			w->uMangoappMsgType = get_prop(ctx, w->xwayland().id, ctx->atoms.mangoappMsgTypeAtom, 0);
 			MakeFocusDirty();
 		}
 	}
@@ -8454,6 +8465,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 	ctx->atoms.gameAtom = XInternAtom(ctx->dpy, GAME_PROP, false);
 	ctx->atoms.overlayAtom = XInternAtom(ctx->dpy, OVERLAY_PROP, false);
 	ctx->atoms.externalOverlayAtom = XInternAtom(ctx->dpy, EXTERNAL_OVERLAY_PROP, false);
+	ctx->atoms.mangoappMsgTypeAtom = XInternAtom(ctx->dpy, MANGOAPP_MSG_TYPE_PROP, false);
 	ctx->atoms.opacityAtom = XInternAtom(ctx->dpy, OPACITY_PROP, false);
 	ctx->atoms.gamesRunningAtom = XInternAtom(ctx->dpy, GAMES_RUNNING_PROP, false);
 	ctx->atoms.screenScaleAtom = XInternAtom(ctx->dpy, SCREEN_SCALE_PROP, false);

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -874,6 +874,11 @@ struct global_focus_t : public focus_t
 	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
 
+	std::array< gamescope::Rc<commit_t>, HELD_COMMIT_COUNT > HeldCommits;
+	std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > CachedPlanes = {};
+	unsigned int uFadeOutStartTime = 0;
+	bool bPendingFade = false;
+
 	gamescope::VirtualConnectorKey_t ulVirtualFocusKey = 0;
 	std::shared_ptr<gamescope::IBackendConnector> pVirtualConnector;
 
@@ -965,8 +970,6 @@ unsigned long	damageSequence = 0;
 uint64_t		cursorHideTime = 10'000ul * 1'000'000ul;
 
 bool			gotXError = false;
-
-unsigned int	fadeOutStartTime = 0;
 
 unsigned int 	g_FadeOutDuration = 0;
 
@@ -1300,9 +1303,6 @@ bool steamcompmgr_window_should_refresh_switch( steamcompmgr_win_t *w )
 	return steamcompmgr_window_should_limit_fps( w );
 }
 
-
-std::array<gamescope::Rc<commit_t>, HELD_COMMIT_COUNT> g_HeldCommits;
-bool g_bPendingFade = false;
 
 /* opacity property name; sometime soon I'll write up an EWMH spec for it */
 #define OPACITY_PROP		"_NET_WM_WINDOW_OPACITY"
@@ -2224,8 +2224,6 @@ void MouseCursor::updateCursorFeedback( bool bForce )
 	m_needs_server_flush = true;
 }
 
-std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > g_CachedPlanes = {};
-
 static void
 paint_cached_base_layer(const gamescope::Rc<commit_t>& commit, const BaseLayerInfo_t& base, struct FrameInfo_t *frameInfo, float flOpacityScale, bool bOverrideOpacity )
 {
@@ -2270,13 +2268,17 @@ using PaintWindowFlags = uint32_t;
 
 wlserver_vk_swapchain_feedback* steamcompmgr_get_base_layer_swapchain_feedback()
 {
-	if ( g_HeldCommits[ HELD_COMMIT_BASE ] == nullptr )
+	global_focus_t *pFocus = GetCurrentFocus();
+	if ( !pFocus )
 		return nullptr;
 
-	if ( !g_HeldCommits[ HELD_COMMIT_BASE ]->feedback )
+	if ( pFocus->HeldCommits[ HELD_COMMIT_BASE ] == nullptr )
 		return nullptr;
 
-	return &(*g_HeldCommits[ HELD_COMMIT_BASE ]->feedback);
+	if ( !pFocus->HeldCommits[ HELD_COMMIT_BASE ]->feedback )
+		return nullptr;
+
+	return &(*pFocus->HeldCommits[ HELD_COMMIT_BASE ]->feedback);
 }
 
 gamescope::ConVar<bool> cv_paint_debug_pause_base_plane( "paint_debug_pause_base_plane", false, "Pause updates to the base plane." );
@@ -2458,18 +2460,18 @@ paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *
 		{
 			// If we're the base plane and have no valid contents
 			// pick up that buffer we've been holding onto if we have one.
-			if ( g_HeldCommits[ HELD_COMMIT_BASE ] != nullptr )
+			if ( pFocus->HeldCommits[ HELD_COMMIT_BASE ] != nullptr )
 			{
-				paint_cached_base_layer( g_HeldCommits[ HELD_COMMIT_BASE ], g_CachedPlanes[ HELD_COMMIT_BASE ], frameInfo, flOpacityScale, true );
+				paint_cached_base_layer( pFocus->HeldCommits[ HELD_COMMIT_BASE ], pFocus->CachedPlanes[ HELD_COMMIT_BASE ], frameInfo, flOpacityScale, true );
 				return;
 			}
 		}
 		else
 		{
-			if ( g_bPendingFade )
+			if ( pFocus->bPendingFade )
 			{
-				fadeOutStartTime = get_time_in_milliseconds();
-				g_bPendingFade = false;
+				pFocus->uFadeOutStartTime = get_time_in_milliseconds();
+				pFocus->bPendingFade = false;
 			}
 		}
 	}
@@ -2487,9 +2489,9 @@ paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *
 		basePlane.filter = layer->filter;
 		basePlane.eAlphaBlendingMode = layer->eAlphaBlendingMode;
 
-		g_CachedPlanes[ HELD_COMMIT_BASE ] = basePlane;
+		pFocus->CachedPlanes[ HELD_COMMIT_BASE ] = basePlane;
 		if ( !(flags & PaintWindowFlag::FadeTarget) )
-			g_CachedPlanes[ HELD_COMMIT_FADE ] = basePlane;
+			pFocus->CachedPlanes[ HELD_COMMIT_FADE ] = basePlane;
 
 		g_uCurrentBasePlaneCommitID = lastCommit->commitID;
 		g_uCurrentBasePlaneAppID = lastCommit->appID;
@@ -2499,9 +2501,20 @@ paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *
 
 bool g_bFirstFrame = true;
 
-static bool is_fading_out()
+static bool is_fading_out( const global_focus_t *pFocus )
 {
-	return fadeOutStartTime || g_bPendingFade;
+	return pFocus->uFadeOutStartTime || pFocus->bPendingFade;
+}
+
+static bool is_any_focus_fading_out()
+{
+	for ( const auto &iter : g_VirtualConnectorFocuses )
+	{
+		if ( is_fading_out( &iter.second ) )
+			return true;
+	}
+
+	return false;
 }
 
 // The laser reads these, so follow the pointer's connector.
@@ -2785,7 +2798,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	steamcompmgr_win_t *fit;
 
 	unsigned int currentTime = get_time_in_milliseconds();
-	bool fadingOut = ( currentTime - fadeOutStartTime < g_FadeOutDuration || g_bPendingFade ) && g_HeldCommits[HELD_COMMIT_FADE] != nullptr;
+	bool fadingOut = ( currentTime - pFocus->uFadeOutStartTime < g_FadeOutDuration || pFocus->bPendingFade ) && pFocus->HeldCommits[HELD_COMMIT_FADE] != nullptr;
 
 	w = pFocus->focusWindow;
 	overlay = pFocus->overlayWindow;
@@ -2866,21 +2879,21 @@ paint_all( global_focus_t *pFocus, bool async )
 			{
 				if ( fadingOut )
 				{
-					float opacityScale = g_bPendingFade
+					float opacityScale = pFocus->bPendingFade
 						? 0.0f
-						: ((currentTime - fadeOutStartTime) / (float)g_FadeOutDuration);
+						: ((currentTime - pFocus->uFadeOutStartTime) / (float)g_FadeOutDuration);
 			
-					paint_cached_base_layer(g_HeldCommits[HELD_COMMIT_FADE], g_CachedPlanes[HELD_COMMIT_FADE], &frameInfo, 1.0f - opacityScale, false);
+					paint_cached_base_layer(pFocus->HeldCommits[HELD_COMMIT_FADE], pFocus->CachedPlanes[HELD_COMMIT_FADE], &frameInfo, 1.0f - opacityScale, false);
 					paint_window(pFocus, w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::FadeTarget | PaintWindowFlag::DrawBorders, opacityScale, fit);
 				}
 				else
 				{
 					{
-						if ( g_HeldCommits[HELD_COMMIT_FADE] != nullptr )
+						if ( pFocus->HeldCommits[HELD_COMMIT_FADE] != nullptr )
 						{
-							g_HeldCommits[HELD_COMMIT_FADE] = nullptr;
-							g_bPendingFade = false;
-							fadeOutStartTime = 0;
+							pFocus->HeldCommits[HELD_COMMIT_FADE] = nullptr;
+							pFocus->bPendingFade = false;
+							pFocus->uFadeOutStartTime = 0;
 							pFocus->fadeWindow = None;
 						}
 					}
@@ -2897,17 +2910,17 @@ paint_all( global_focus_t *pFocus, bool async )
 		}
 		else
 		{
-			if ( g_HeldCommits[HELD_COMMIT_BASE] != nullptr )
+			if ( pFocus->HeldCommits[HELD_COMMIT_BASE] != nullptr )
 			{
 				float opacityScale = 1.0f;
 				if ( fadingOut )
 				{
-					opacityScale = g_bPendingFade
+					opacityScale = pFocus->bPendingFade
 						? 0.0f
-						: ((currentTime - fadeOutStartTime) / (float)g_FadeOutDuration);
+						: ((currentTime - pFocus->uFadeOutStartTime) / (float)g_FadeOutDuration);
 				}
 
-				paint_cached_base_layer( g_HeldCommits[HELD_COMMIT_BASE], g_CachedPlanes[HELD_COMMIT_BASE], &frameInfo, opacityScale, true );
+				paint_cached_base_layer( pFocus->HeldCommits[HELD_COMMIT_BASE], pFocus->CachedPlanes[HELD_COMMIT_BASE], &frameInfo, opacityScale, true );
 			}
 		}
 	}
@@ -3069,7 +3082,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	}
 
 	g_bFSRActive = frameInfo.useFSRLayer0;
-	if ( const auto& heldCommit = g_HeldCommits[HELD_COMMIT_BASE]; heldCommit && heldCommit->upscaledTexture ) {
+	if ( const auto& heldCommit = pFocus->HeldCommits[HELD_COMMIT_BASE]; heldCommit && heldCommit->upscaledTexture ) {
 		g_bFSRActive = ( heldCommit->upscaledTexture->eFilter == GamescopeUpscaleFilter::FSR );
 	}
 
@@ -5053,20 +5066,20 @@ determine_and_apply_focus( global_focus_t *pFocus )
 
 		if ( g_FadeOutDuration != 0 && !g_bFirstFrame && bDoFade )
 		{
-			if ( g_HeldCommits[ HELD_COMMIT_FADE ] == nullptr )
+			if ( pFocus->HeldCommits[ HELD_COMMIT_FADE ] == nullptr )
 			{
 				pFocus->fadeWindow = previousLocalFocus.focusWindow;
-				g_HeldCommits[ HELD_COMMIT_FADE ] = g_HeldCommits[ HELD_COMMIT_BASE ];
-				g_bPendingFade = true;
+				pFocus->HeldCommits[ HELD_COMMIT_FADE ] = pFocus->HeldCommits[ HELD_COMMIT_BASE ];
+				pFocus->bPendingFade = true;
 			}
 			else
 			{
 				// If we end up fading back to what we were going to fade to, cancel the fade.
 				if ( pFocus->fadeWindow != nullptr && pFocus->focusWindow == pFocus->fadeWindow )
 				{
-					g_HeldCommits[ HELD_COMMIT_FADE ] = nullptr;
-					g_bPendingFade = false;
-					fadeOutStartTime = 0;
+					pFocus->HeldCommits[ HELD_COMMIT_FADE ] = nullptr;
+					pFocus->bPendingFade = false;
+					pFocus->uFadeOutStartTime = 0;
 					pFocus->fadeWindow = nullptr;
 				}
 			}
@@ -5080,7 +5093,7 @@ determine_and_apply_focus( global_focus_t *pFocus )
 			previousLocalFocus.focusWindow != pFocus->focusWindow &&
 			!pFocus->focusWindow->isSteamStreamingClient )
 		{
-			get_window_last_done_commit( pFocus->focusWindow, g_HeldCommits[ HELD_COMMIT_BASE ] );
+			get_window_last_done_commit( pFocus->focusWindow, pFocus->HeldCommits[ HELD_COMMIT_BASE ] );
 		}
 	}
 
@@ -7242,8 +7255,6 @@ steamcompmgr_exit(void)
 		}
 	}
 	g_steamcompmgr_xdg_wins.clear();
-	g_HeldCommits[ HELD_COMMIT_BASE ] = nullptr;
-	g_HeldCommits[ HELD_COMMIT_FADE ] = nullptr;
 
 	for ( auto &lut : g_ColorMgmtLuts ) lut.shutdown();
 	for ( auto &lut : g_ColorMgmtLutsOverride ) lut.shutdown();
@@ -7433,7 +7444,7 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 				if ( w == pFocus->focusWindow && !w->isSteamStreamingClient )
 				{
 					if ( !cv_paint_debug_pause_base_plane )
-						g_HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
+						pFocus->HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
 					hasRepaint = true;
 
 					focusWindow_engine = w->engineName;
@@ -7449,7 +7460,7 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 				if ( w->isSteamStreamingClientVideo && pFocus->focusWindow && pFocus->focusWindow->isSteamStreamingClient )
 				{
 					if ( !cv_paint_debug_pause_base_plane )
-						g_HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
+						pFocus->HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
 					hasRepaint = true;
 				}
 			}
@@ -9461,11 +9472,12 @@ steamcompmgr_main(int argc, char **argv)
 		{
 			GamescopeAppTextureColorspace current_app_colorspace = GAMESCOPE_APP_TEXTURE_COLORSPACE_SRGB;
 			std::shared_ptr<gamescope::BackendBlob> app_hdr_metadata = nullptr;
-			if ( g_HeldCommits[HELD_COMMIT_BASE] != nullptr )
+			global_focus_t *pCurrentFocus = GetCurrentFocus();
+			if ( pCurrentFocus && pCurrentFocus->HeldCommits[HELD_COMMIT_BASE] != nullptr )
 			{
-				current_app_colorspace = g_HeldCommits[HELD_COMMIT_BASE]->colorspace();
-				if (g_HeldCommits[HELD_COMMIT_BASE]->feedback)
-					app_hdr_metadata = g_HeldCommits[HELD_COMMIT_BASE]->feedback->hdr_metadata_blob;
+				current_app_colorspace = pCurrentFocus->HeldCommits[HELD_COMMIT_BASE]->colorspace();
+				if (pCurrentFocus->HeldCommits[HELD_COMMIT_BASE]->feedback)
+					app_hdr_metadata = pCurrentFocus->HeldCommits[HELD_COMMIT_BASE]->feedback->hdr_metadata_blob;
 			}
 
 			bool app_wants_hdr = ColorspaceIsHDR( current_app_colorspace );
@@ -9523,7 +9535,7 @@ steamcompmgr_main(int argc, char **argv)
 
 		// If we're in the middle of a fade, then keep us
 		// as needing a repaint.
-		if ( is_fading_out() )
+		if ( is_any_focus_fading_out() )
 			hasRepaint = true;
 
 		bool bPainted = false;
@@ -9583,12 +9595,12 @@ steamcompmgr_main(int argc, char **argv)
 			// A false vblank value means bShouldPaint will resolve to false below, effectively ignoring this flag and losing any request
 			// to force a repaint. Don't clear g_bForceRepaint unless vblank is true.
 			const bool bForceRepaint = vblank && g_bForceRepaint.exchange(false);
-			const bool bForceSyncFlip = bForceRepaint || is_fading_out();
+			const bool bForceSyncFlip = bForceRepaint || is_fading_out( pPaintFocus );
 
 			// If we are compositing, always force sync flips because we currently wait
 			// for composition to finish before submitting.
 			// If we want to do async + composite, we should set up syncfile stuff and have DRM wait on it.
-			const bool bSurfaceWantsAsync = (g_HeldCommits[HELD_COMMIT_BASE] != nullptr && g_HeldCommits[HELD_COMMIT_BASE]->async);
+			const bool bSurfaceWantsAsync = (pPaintFocus->HeldCommits[HELD_COMMIT_BASE] != nullptr && pPaintFocus->HeldCommits[HELD_COMMIT_BASE]->async);
 			const bool bTearing = cv_tearing_enabled && GetBackend()->SupportsTearing() && bSurfaceWantsAsync;
 
 			enum class FlipType

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6812,19 +6812,23 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 	}
 	if ( ev->atom == ctx->atoms.gamescopeNewScalingFilter )
 	{
-		GamescopeUpscaleFilter nScalingFilter = ( GamescopeUpscaleFilter ) get_prop( ctx, ctx->root, ctx->atoms.gamescopeNewScalingFilter, 0 );
-		if (g_wantedUpscaleFilter != nScalingFilter)
+		uint32_t uScalingFilter = get_prop( ctx, ctx->root, ctx->atoms.gamescopeNewScalingFilter, 0 );
+		if ( uScalingFilter > uint32_t( GamescopeUpscaleFilter::PIXEL ) )
+			xwm_log.errorf( "Unknown scaling filter %u, keeping %u", uScalingFilter, uint32_t( g_wantedUpscaleFilter ) );
+		else if ( g_wantedUpscaleFilter != GamescopeUpscaleFilter( uScalingFilter ) )
 		{
-			g_wantedUpscaleFilter = nScalingFilter;
+			g_wantedUpscaleFilter = GamescopeUpscaleFilter( uScalingFilter );
 			hasRepaint = true;
 		}
 	}
 	if ( ev->atom == ctx->atoms.gamescopeNewScalingScaler )
 	{
-		GamescopeUpscaleScaler nScalingScaler = ( GamescopeUpscaleScaler ) get_prop( ctx, ctx->root, ctx->atoms.gamescopeNewScalingScaler, 0 );
-		if (g_wantedUpscaleScaler != nScalingScaler)
+		uint32_t uScalingScaler = get_prop( ctx, ctx->root, ctx->atoms.gamescopeNewScalingScaler, 0 );
+		if ( uScalingScaler > uint32_t( GamescopeUpscaleScaler::STRETCH ) )
+			xwm_log.errorf( "Unknown scaling scaler %u, keeping %u", uScalingScaler, uint32_t( g_wantedUpscaleScaler ) );
+		else if ( g_wantedUpscaleScaler != GamescopeUpscaleScaler( uScalingScaler ) )
 		{
-			g_wantedUpscaleScaler = nScalingScaler;
+			g_wantedUpscaleScaler = GamescopeUpscaleScaler( uScalingScaler );
 			hasRepaint = true;
 		}
 	}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -840,6 +840,31 @@ bool focus_t::IsDirty()
 	return ulCurrentFocusSerial != GetFocusSerial();
 }
 
+enum HeldCommitTypes_t
+{
+	HELD_COMMIT_BASE,
+	HELD_COMMIT_FADE,
+
+	HELD_COMMIT_COUNT,
+};
+
+struct BaseLayerInfo_t
+{
+	float scale[2];
+	float offset[2];
+	float opacity;
+	GamescopeUpscaleFilter filter;
+	AlphaBlendingMode_t eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
+};
+
+struct TempUpscaleImage_t
+{
+	gamescope::OwningRc<CVulkanTexture> pTexture;
+	// Timeline of upscale -> release, to be used as acquire for the commit.
+	std::shared_ptr<gamescope::CTimeline> pReleaseTimeline;
+	uint64_t ulLastPoint = 0ul;
+};
+
 struct global_focus_t : public focus_t
 {
 	steamcompmgr_win_t	  	 		*keyboardFocusWindow;
@@ -1272,14 +1297,6 @@ bool steamcompmgr_window_should_refresh_switch( steamcompmgr_win_t *w )
 	return steamcompmgr_window_should_limit_fps( w );
 }
 
-
-enum HeldCommitTypes_t
-{
-	HELD_COMMIT_BASE,
-	HELD_COMMIT_FADE,
-
-	HELD_COMMIT_COUNT,
-};
 
 std::array<gamescope::Rc<commit_t>, HELD_COMMIT_COUNT> g_HeldCommits;
 bool g_bPendingFade = false;
@@ -2203,15 +2220,6 @@ void MouseCursor::updateCursorFeedback( bool bForce )
 	m_bCursorVisibleFeedback = bVisible;
 	m_needs_server_flush = true;
 }
-
-struct BaseLayerInfo_t
-{
-	float scale[2];
-	float offset[2];
-	float opacity;
-	GamescopeUpscaleFilter filter;
-	AlphaBlendingMode_t eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
-};
 
 std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > g_CachedPlanes = {};
 
@@ -7674,14 +7682,6 @@ void force_repaint( void )
 	g_bForceRepaint = true;
 	nudge_steamcompmgr();
 }
-
-struct TempUpscaleImage_t
-{
-	gamescope::OwningRc<CVulkanTexture> pTexture;
-	// Timeline of upscale -> release, to be used as acquire for the commit.
-	std::shared_ptr<gamescope::CTimeline> pReleaseTimeline;
-	uint64_t ulLastPoint = 0ul;
-};
 
 static std::vector<TempUpscaleImage_t> g_pUpscaleImages;
 void ClearUpscaleImages()

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2442,7 +2442,7 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 }
 
 static void
-paint_window(steamcompmgr_win_t *w, steamcompmgr_win_t *scaleW, struct FrameInfo_t *frameInfo,
+paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *scaleW, struct FrameInfo_t *frameInfo,
 			  MouseCursor *cursor, PaintWindowFlags flags = 0, float flOpacityScale = 1.0f, steamcompmgr_win_t *fit = nullptr )
 {
 	gamescope::Rc<commit_t> lastCommit;
@@ -2518,7 +2518,8 @@ static void pick_decoration_windows( focus_t *pFocus );
 static void carry_override_underlay( focus_t *pFocus, steamcompmgr_win_t *pPreviousOverride, steamcompmgr_win_t *pPreviousUnderlay );
 
 // Swept on window destroy so the repick can carry its override pointers forward.
-static focus_t s_PipewireFocus{};
+// Synthetic focus for the capture stream, connector fields never populated.
+static global_focus_t s_PipewireFocus{};
 
 static void paint_pipewire()
 {
@@ -2554,7 +2555,7 @@ static void paint_pipewire()
 
 	const uint64_t ulFocusAppId = s_pPipewireBuffer->gamescope_info.focus_appid;
 
-	focus_t *pFocus = nullptr;
+	global_focus_t *pFocus = nullptr;
 	if ( ulFocusAppId )
 	{
 		static uint64_t s_ulLastFocusAppId = 0;
@@ -2632,13 +2633,13 @@ static void paint_pipewire()
 
 	// Paint the windows we have onto the Pipewire stream.
 	steamcompmgr_win_t *fit = pFocus->overrideWindow;
-	paint_window( pFocus->focusWindow, pFocus->focusWindow, &frameInfo, nullptr, 0, 1.0f, fit );
+	paint_window( pFocus, pFocus->focusWindow, pFocus->focusWindow, &frameInfo, nullptr, 0, 1.0f, fit );
 
 	if ( pFocus->overrideUnderlayWindow && !pFocus->focusWindow->isSteamStreamingClient )
-		paint_window( pFocus->overrideUnderlayWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
+		paint_window( pFocus, pFocus->overrideUnderlayWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 
 	if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
-		paint_window( pFocus->overrideWindow, pFocus->focusWindow, &frameInfo, nullptr,
+		paint_window( pFocus, pFocus->overrideWindow, pFocus->focusWindow, &frameInfo, nullptr,
 			PaintWindowFlag::NoFilter | PaintWindowFlag::ClampToOutput, 1.0f, fit );
 
 	if ( !pFocus->focusWindow->isSteamStreamingClient )
@@ -2652,13 +2653,13 @@ static void paint_pipewire()
 				break;
 
 			if ( decoration->opacity )
-				paint_window( decoration, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, decoration );
+				paint_window( pFocus, decoration, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, decoration );
 		}
 	}
 
 	if ( !ulFocusAppId && pFocus->overlayWindow && pFocus->overlayWindow->opacity )
 	{
-		paint_window( pFocus->overlayWindow, pFocus->overlayWindow, &frameInfo, nullptr, PaintWindowFlag::DrawBorders | PaintWindowFlag::NoFilter |
+		paint_window( pFocus, pFocus->overlayWindow, pFocus->overlayWindow, &frameInfo, nullptr, PaintWindowFlag::DrawBorders | PaintWindowFlag::NoFilter |
 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 )  );
 	}
 
@@ -2828,7 +2829,7 @@ paint_all( global_focus_t *pFocus, bool async )
 						if ( videow->isSteamStreamingClientVideo == true )
 						{
 							// TODO: also check matching AppID so we can have several pairs
-							paint_window(videow, videow, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders);
+							paint_window(pFocus, videow, videow, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders);
 							bHasVideoUnderlay = true;
 							break;
 						}
@@ -2840,7 +2841,7 @@ paint_all( global_focus_t *pFocus, bool async )
 				uint32_t flags = 0;
 				if ( !bHasVideoUnderlay )
 					flags |= PaintWindowFlag::BasePlane;
-				paint_window(w, w, &frameInfo, pFocus->cursor, flags);
+				paint_window(pFocus, w, w, &frameInfo, pFocus->cursor, flags);
 				if ( pFocus == GetCurrentMouseFocus() )
 					update_touch_scaling( &frameInfo );
 				
@@ -2858,7 +2859,7 @@ paint_all( global_focus_t *pFocus, bool async )
 						: ((currentTime - fadeOutStartTime) / (float)g_FadeOutDuration);
 			
 					paint_cached_base_layer(g_HeldCommits[HELD_COMMIT_FADE], g_CachedPlanes[HELD_COMMIT_FADE], &frameInfo, 1.0f - opacityScale, false);
-					paint_window(w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::FadeTarget | PaintWindowFlag::DrawBorders, opacityScale, fit);
+					paint_window(pFocus, w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::FadeTarget | PaintWindowFlag::DrawBorders, opacityScale, fit);
 				}
 				else
 				{
@@ -2872,7 +2873,7 @@ paint_all( global_focus_t *pFocus, bool async )
 						}
 					}
 					// Just draw focused window as normal, be it Steam or the game
-					paint_window(w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders, 1.0f, fit);
+					paint_window(pFocus, w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders, 1.0f, fit);
 
 					bool needsScaling = frameInfo.layers.get( 0 ).scale.x < 0.999f && frameInfo.layers.get( 0 ).scale.y < 0.999f;
 					frameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR && needsScaling;
@@ -2920,12 +2921,12 @@ paint_all( global_focus_t *pFocus, bool async )
 	if ( pFocus->overrideUnderlayWindow && w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane &&
 		 frameInfo.layers.count() + ( override ? 1 : 0 ) < k_nMaxLayers - nReservedLayers )
 	{
-		paint_window(pFocus->overrideUnderlayWindow, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, override);
+		paint_window(pFocus, pFocus->overrideUnderlayWindow, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, override);
 	}
 
 	if ( override && w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane )
 	{
-		paint_window(override, w, &frameInfo, pFocus->cursor,
+		paint_window(pFocus, override, w, &frameInfo, pFocus->cursor,
 			PaintWindowFlag::NoFilter | PaintWindowFlag::ClampToOutput, 1.0f, fit);
 		// Don't update touch scaling for frameInfo. We don't ever make it our
 		// wlserver_mousefocus window.
@@ -2944,7 +2945,7 @@ paint_all( global_focus_t *pFocus, bool async )
 			}
 
 			if ( decoration->opacity )
-				paint_window( decoration, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, decoration );
+				paint_window( pFocus, decoration, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, decoration );
 		}
 	}
 
@@ -2955,7 +2956,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	{
 		if (externalOverlay->opacity)
 		{
-			paint_window(externalOverlay, externalOverlay, &frameInfo, pFocus->cursor, PaintWindowFlag::NoScale | PaintWindowFlag::NoFilter |
+			paint_window(pFocus, externalOverlay, externalOverlay, &frameInfo, pFocus->cursor, PaintWindowFlag::NoScale | PaintWindowFlag::NoFilter |
 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 ) );
 
 			if ( externalOverlay == pFocus->inputFocusWindow && pFocus == GetCurrentMouseFocus() )
@@ -2967,7 +2968,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	{
 		if (overlay && overlay->opacity )
 		{
-			paint_window(overlay, overlay, &frameInfo, pFocus->cursor, PaintWindowFlag::DrawBorders | PaintWindowFlag::NoFilter |
+			paint_window(pFocus, overlay, overlay, &frameInfo, pFocus->cursor, PaintWindowFlag::DrawBorders | PaintWindowFlag::NoFilter |
 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 )  );
 
 			if ( overlay == pFocus->inputFocusWindow && pFocus == GetCurrentMouseFocus() )
@@ -3008,7 +3009,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	{
 		if (notification->opacity)
 		{
-			paint_window(notification, notification, &frameInfo, pFocus->cursor, PaintWindowFlag::NotificationMode | PaintWindowFlag::NoFilter);
+			paint_window(pFocus, notification, notification, &frameInfo, pFocus->cursor, PaintWindowFlag::NotificationMode | PaintWindowFlag::NoFilter);
 		}
 	}
 
@@ -3252,18 +3253,18 @@ paint_all( global_focus_t *pFocus, bool async )
 				currentOutputWidth = uScreenshotWidth;
 				currentOutputHeight = uScreenshotHeight;
 
-				paint_window( pFocus->focusWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, 0, 1.0f, pFocus->overrideWindow );
+				paint_window( pFocus, pFocus->focusWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, 0, 1.0f, pFocus->overrideWindow );
 				if ( pFocus->overrideUnderlayWindow && !pFocus->focusWindow->isSteamStreamingClient )
-					paint_window( pFocus->overrideUnderlayWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
+					paint_window( pFocus, pFocus->overrideUnderlayWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 				if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
-					paint_window( pFocus->overrideWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr,
+					paint_window( pFocus, pFocus->overrideWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr,
 						PaintWindowFlag::NoFilter | PaintWindowFlag::ClampToOutput, 1.0f, pFocus->overrideWindow );
 				if ( !pFocus->focusWindow->isSteamStreamingClient )
 				{
 					for ( steamcompmgr_win_t *decoration : pFocus->decorationWindows )
 					{
 						if ( decoration->opacity )
-							paint_window( decoration, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, decoration );
+							paint_window( pFocus, decoration, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, decoration );
 					}
 				}
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4634,11 +4634,11 @@ determine_and_apply_focus( global_focus_t *pFocus )
 	gamescope_xwayland_server_t *root_server = wlserver_get_xwayland_server(0);
 	xwayland_ctx_t *root_ctx = root_server->ctx.get();
 	global_focus_t previousLocalFocus = *pFocus;
-	*pFocus = global_focus_t{};
+	// Reset the pick, the rest of the focus belongs to the connector.
+	static_cast<focus_t &>( *pFocus ) = focus_t{};
+	pFocus->keyboardFocusWindow = nullptr;
 	pFocus->focusWindow = previousLocalFocus.focusWindow;
 	pFocus->cursor = root_ctx->cursor.get();
-	pFocus->ulVirtualFocusKey = previousLocalFocus.ulVirtualFocusKey;
-	pFocus->pVirtualConnector = previousLocalFocus.pVirtualConnector;
 	gameFocused = false;
 
 	focus_log.debugf( "Rerolling global focus..." );
@@ -5830,7 +5830,7 @@ destroy_win(xwayland_ctx_t *ctx, Window id, bool gone, bool fade)
 			pFocus->overrideWindow = nullptr;
 		if (x11_win(pFocus->overrideUnderlayWindow) == id)
 			pFocus->overrideUnderlayWindow = nullptr;
-		if (x11_win(pFocus->fadeWindow) == id && gone)
+		if (x11_win(pFocus->fadeWindow) == id)
 			pFocus->fadeWindow = nullptr;
 		std::erase_if(pFocus->decorationWindows, [id](steamcompmgr_win_t *w) { return x11_win(w) == id; });
 	}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -878,6 +878,12 @@ struct global_focus_t : public focus_t
 	std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > CachedPlanes = {};
 	unsigned int uFadeOutStartTime = 0;
 	bool bPendingFade = false;
+	bool bFSRActive = false;
+	uint64_t ulBasePlaneCommitID = 0;
+	uint32_t uBasePlaneAppID = 0;
+	bool bBasePlaneIsFifo = false;
+	pid_t nFocusWindowPid = 0;
+	std::shared_ptr<std::string> pFocusWindowEngine;
 
 	gamescope::VirtualConnectorKey_t ulVirtualFocusKey = 0;
 	std::shared_ptr<gamescope::IBackendConnector> pVirtualConnector;
@@ -2493,9 +2499,9 @@ paint_window(global_focus_t *pFocus, steamcompmgr_win_t *w, steamcompmgr_win_t *
 		if ( !(flags & PaintWindowFlag::FadeTarget) )
 			pFocus->CachedPlanes[ HELD_COMMIT_FADE ] = basePlane;
 
-		g_uCurrentBasePlaneCommitID = lastCommit->commitID;
-		g_uCurrentBasePlaneAppID = lastCommit->appID;
-		g_bCurrentBasePlaneIsFifo = lastCommit->IsPerfOverlayFIFO();
+		pFocus->ulBasePlaneCommitID = lastCommit->commitID;
+		pFocus->uBasePlaneAppID = lastCommit->appID;
+		pFocus->bBasePlaneIsFifo = lastCommit->IsPerfOverlayFIFO();
 	}
 }
 
@@ -3081,9 +3087,9 @@ paint_all( global_focus_t *pFocus, bool async )
 		frameInfo.useNISLayer0 = false;
 	}
 
-	g_bFSRActive = frameInfo.useFSRLayer0;
+	pFocus->bFSRActive = frameInfo.useFSRLayer0;
 	if ( const auto& heldCommit = pFocus->HeldCommits[HELD_COMMIT_BASE]; heldCommit && heldCommit->upscaledTexture ) {
-		g_bFSRActive = ( heldCommit->upscaledTexture->eFilter == GamescopeUpscaleFilter::FSR );
+		pFocus->bFSRActive = ( heldCommit->upscaledTexture->eFilter == GamescopeUpscaleFilter::FSR );
 	}
 
 	g_bFirstFrame = false;
@@ -7447,8 +7453,8 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 						pFocus->HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
 					hasRepaint = true;
 
-					focusWindow_engine = w->engineName;
-					focusWindow_pid = w->pid;
+					pFocus->pFocusWindowEngine = w->engineName;
+					pFocus->nFocusWindowPid = w->pid;
 				}
 
 				if ( w == pFocus->overrideWindow || w == pFocus->overrideUnderlayWindow ||
@@ -8877,6 +8883,22 @@ static gamescope::CTimerFunction g_FPSLimitVRRTimer{ []
 	g_FPSLimitVRRTimer.DisarmTimer();
 }};
 
+// mangoapp_update also runs on the image waiter thread, so publish plain
+// globals here rather than have it walk the focus.
+static void publish_mangoapp_snapshot()
+{
+	global_focus_t *pFocus = GetCurrentFocus();
+	if ( !pFocus )
+		return;
+
+	g_bFSRActive = pFocus->bFSRActive;
+	focusWindow_pid = pFocus->nFocusWindowPid;
+	focusWindow_engine = pFocus->pFocusWindowEngine;
+	g_uCurrentBasePlaneCommitID = pFocus->ulBasePlaneCommitID;
+	g_uCurrentBasePlaneAppID = pFocus->uBasePlaneAppID;
+	g_bCurrentBasePlaneIsFifo = pFocus->bBasePlaneIsFifo;
+}
+
 void
 steamcompmgr_main(int argc, char **argv)
 {
@@ -9722,6 +9744,8 @@ steamcompmgr_main(int argc, char **argv)
 				script.Manager().CallHook( "OnPostPaint" );
 			}
 		}
+
+		publish_mangoapp_snapshot();
 
 		if ( bIsVBlankFromTimer )
 		{

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -170,6 +170,7 @@ extern void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_
 extern void mangoapp_nudge_app_frame( uint32_t uMsgType, uint64_t ulNow );
 extern void mangoapp_set_connector_snapshots( std::unordered_map<uint32_t, MangoappSnapshot_t> snapshots );
 extern void mangoapp_drop_stream( uint32_t uMsgType );
+extern uint32_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes );
 struct wlr_surface *steamcompmgr_get_server_input_surface( size_t idx );
 wlserver_vk_swapchain_feedback* steamcompmgr_get_base_layer_swapchain_feedback();
 

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -23,6 +23,9 @@ void steamcompmgr_main(int argc, char **argv);
 
 #include <mutex>
 #include <vector>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 #include <X11/extensions/Xfixes.h>
 
@@ -136,7 +139,25 @@ extern uint64_t g_lastWinSeq;
 void nudge_steamcompmgr( void );
 void force_repaint( void );
 
-extern void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns );
+// Per-connector stat snapshot for typed mangoapp streams.
+struct MangoappSnapshot_t
+{
+	pid_t nPid = 0;
+	bool bFSRActive = false;
+	uint8_t uFSRSharpness = 0;
+	std::shared_ptr<std::string> pEngineName;
+	bool bSteamFocused = false;
+	bool bAppWantsHDR = false;
+	uint32_t uOutputWidth = 0;
+	uint32_t uOutputHeight = 0;
+	int nOutputRefreshmHz = 0;
+};
+
+static constexpr uint32_t k_uMangoappLegacyMsgType = 1;
+
+extern void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns, uint32_t uMsgType = k_uMangoappLegacyMsgType );
+extern void mangoapp_nudge_app_frame( uint32_t uMsgType, uint64_t ulNow );
+extern void mangoapp_set_connector_snapshots( std::unordered_map<uint32_t, MangoappSnapshot_t> snapshots );
 struct wlr_surface *steamcompmgr_get_server_input_surface( size_t idx );
 wlserver_vk_swapchain_feedback* steamcompmgr_get_base_layer_swapchain_feedback();
 

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -154,10 +154,22 @@ struct MangoappSnapshot_t
 };
 
 static constexpr uint32_t k_uMangoappLegacyMsgType = 1;
+// mangohudctl posts control messages here.
+static constexpr uint32_t k_uMangoappControlMsgType = 2;
+// Per-connector streams allocate upward from here, in stream/control pairs.
+static constexpr uint32_t k_uMangoappFirstConnectorMsgType = 100;
+
+// mangoapp derives the same type, so both sides must agree on it.
+static constexpr uint32_t MangoappControlMsgType( uint32_t uMsgType )
+{
+	return uMsgType + 1;
+}
+static_assert( MangoappControlMsgType( k_uMangoappLegacyMsgType ) == k_uMangoappControlMsgType );
 
 extern void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns, uint32_t uMsgType = k_uMangoappLegacyMsgType );
 extern void mangoapp_nudge_app_frame( uint32_t uMsgType, uint64_t ulNow );
 extern void mangoapp_set_connector_snapshots( std::unordered_map<uint32_t, MangoappSnapshot_t> snapshots );
+extern void mangoapp_drop_stream( uint32_t uMsgType );
 struct wlr_surface *steamcompmgr_get_server_input_surface( size_t idx );
 wlserver_vk_swapchain_feedback* steamcompmgr_get_base_layer_swapchain_feedback();
 

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -117,6 +117,8 @@ struct steamcompmgr_win_t {
 	uint32_t steamAppID = 0;
 	bool isOverlay = false;
 	bool isExternalOverlay = false;
+	// Set by per-connector mangoapp instances.
+	uint32_t uMangoappMsgType = 0;
 
 	bool bIsSteamPid = false;
 	bool bIsSteamWebHelperPid = false;

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -109,6 +109,7 @@ struct xwayland_ctx_t final : public gamescope::IWaitable
 		Atom gameAtom;
 		Atom overlayAtom;
 		Atom externalOverlayAtom;
+		Atom mangoappMsgTypeAtom;
 		Atom gamesRunningAtom;
 		Atom screenZoomAtom;
 		Atom screenScaleAtom;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ endforeach
 
 gamescope_tests = executable(
 	'gamescope_tests',
-	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_upscale.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
@@ -17,6 +17,7 @@ gamescope_tests = executable(
 reaper_test_helper = executable('reaper_test_helper', 'reaper_test_helper.cpp')
 
 test('convar', gamescope_tests, args: ['[convar]'])
+test('upscale', gamescope_tests, args: ['[upscale]'])
 test('utils/parsers', gamescope_tests, args: ['[parsers]'])
 test('utils/process', gamescope_tests, args: ['[process]'], depends: [reaper_test_helper])
 test('utils/string', gamescope_tests, args: ['[string]'])

--- a/tests/test_upscale.cpp
+++ b/tests/test_upscale.cpp
@@ -1,0 +1,29 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "main.hpp"
+
+TEST_CASE("GetUpscaleSettings", "[upscale]") {
+	SECTION("a Steam focus window forces linear and fit") {
+		const UpscaleSettings_t settings = GetUpscaleSettings(
+			true, GamescopeUpscaleFilter::FSR, GamescopeUpscaleScaler::INTEGER );
+
+		REQUIRE( settings.eFilter == GamescopeUpscaleFilter::LINEAR );
+		REQUIRE( settings.eScaler == GamescopeUpscaleScaler::FIT );
+	}
+
+	SECTION("a non-Steam focus window keeps the wanted settings") {
+		const UpscaleSettings_t settings = GetUpscaleSettings(
+			false, GamescopeUpscaleFilter::FSR, GamescopeUpscaleScaler::INTEGER );
+
+		REQUIRE( settings.eFilter == GamescopeUpscaleFilter::FSR );
+		REQUIRE( settings.eScaler == GamescopeUpscaleScaler::INTEGER );
+	}
+
+	SECTION("passes through a different wanted filter and scaler pair") {
+		const UpscaleSettings_t settings = GetUpscaleSettings(
+			false, GamescopeUpscaleFilter::NEAREST, GamescopeUpscaleScaler::AUTO );
+
+		REQUIRE( settings.eFilter == GamescopeUpscaleFilter::NEAREST );
+		REQUIRE( settings.eScaler == GamescopeUpscaleScaler::AUTO );
+	}
+}


### PR DESCRIPTION
Result of a couple weeks of work and testing, rebased onto master. This wires up everything we need for per-connector composition and upscaling. Per-connector mangoapp integration so multiple virtual connectors keep their own stats properly will be a follow-up.