### PR TITLE
Fix window dragging behavior

### DIFF
--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -1153,6 +1153,24 @@ namespace gamescope
             nudge_steamcompmgr();
         }
 
+        // SteamVR sends VREvent_MouseButtonUp to whichever overlay the laser is
+        // over at release, so a press that started on us can end somewhere else.
+        void ReleaseHeldMouse()
+        {
+            if ( !m_uHeldMouseButton )
+                return;
+
+            uint32_t uButton = m_uHeldMouseButton;
+            m_uHeldMouseButton = 0;
+
+            wlserver_lock();
+            if ( uButton == BTN_LEFT )
+                wlserver_touchup( 0, ++m_uFakeTimestamp );
+            else
+                wlserver_mousebutton( uButton, false, ++m_uFakeTimestamp );
+            wlserver_unlock();
+        }
+
         void ProcessVRInput()
         {
             std::scoped_lock lock{m_mutActiveConnectors};
@@ -1344,6 +1362,9 @@ namespace gamescope
                     {
                         if ( g_FocusedVROverlayMouse == hOverlay )
                         {
+                            // The laser leaving mid press means the release will go to some other overlay.
+                            ReleaseHeldMouse();
+
                             SetMouseFocus( vr::k_ulOverlayHandleInvalid );
                         }
                     }
@@ -1362,7 +1383,13 @@ namespace gamescope
                     break;
                 case vr::VREvent_MouseButtonUp:
                 case vr::VREvent_MouseButtonDown:
-                    if (pConnector)
+                    if (!pConnector)
+                    {
+                        // A release over an overlay that is not ours would be dropped and leave the press held forever.
+                        if (vrEvent.eventType == vr::VREvent_MouseButtonUp)
+                            ReleaseHeldMouse();
+                    }
+                    else
                     {
                         SetMouseFocus( hOverlay );
 
@@ -1430,6 +1457,7 @@ namespace gamescope
                                 wlserver_lock();
                                 if (vrEvent.data.mouse.button == vr::VRMouseButton_Left)
                                 {
+                                    m_uHeldMouseButton = bDown ? BTN_LEFT : 0;
                                     if (bDown)
                                         wlserver_touchdown(flX, flY, 0, ++m_uFakeTimestamp);
                                     else
@@ -1437,10 +1465,12 @@ namespace gamescope
                                 }
                                 else if (vrEvent.data.mouse.button == vr::VRMouseButton_Right)
                                 {
+                                    m_uHeldMouseButton = bDown ? BTN_RIGHT : 0;
                                     wlserver_mousebutton(BTN_RIGHT, bDown, ++m_uFakeTimestamp);
                                 }
                                 else if (vrEvent.data.mouse.button == vr::VRMouseButton_Middle)
                                 {
+                                    m_uHeldMouseButton = bDown ? BTN_MIDDLE : 0;
                                     wlserver_mousebutton(BTN_MIDDLE, bDown, ++m_uFakeTimestamp);
                                 }
                                 wlserver_unlock();
@@ -1536,6 +1566,7 @@ namespace gamescope
         std::atomic<uint32_t> m_uFakeTimestamp = { 0 };
 
         bool m_bMouseDown = false;
+        uint32_t m_uHeldMouseButton = 0;
         uint64_t m_ulMouseDownTime = 0;
         // Fake "trackpad" tracking for the whole overlay panel.
         glm::vec2 m_vScreenTrackpadPos{};

--- a/src/focus_placement.h
+++ b/src/focus_placement.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <algorithm>
+
+// Where a focus window belongs so the pointer, which X confines to the screen,
+// can reach all of it. An axis the window does not fit on is left alone,
+// clients center those to keep the middle reachable.
+struct focus_placement_t
+{
+	int x, y;
+};
+
+static inline focus_placement_t focus_placement( int x, int y, int w, int h, int screen_w, int screen_h )
+{
+	return {
+		w <= screen_w ? std::clamp( x, 0, screen_w - w ) : x,
+		h <= screen_h ? std::clamp( y, 0, screen_h - h ) : y,
+	};
+}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -81,6 +81,7 @@
 #include "wlserver.hpp"
 #include "rendervulkan.hpp"
 #include "steamcompmgr.hpp"
+#include "focus_placement.h"
 #include "vblankmanager.hpp"
 #include "log.hpp"
 #include "Utils/Defer.h"
@@ -4559,16 +4560,22 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	if ( bRaisedBase || ctx->list[0].xwayland().id != inputFocus->xwayland().id )
 		inputFocus->Raise();
 
-	// X confines the pointer to the screen, so a screen-sized focus window only
-	// sees all of it at the origin. Place it there once, a client that moves it
-	// afterwards keeps its position. Oversized windows stay put, clients centre
-	// those to keep the middle reachable.
+	// X confines the pointer to the screen, so clamp the focus window into it
+	// once, per axis. An axis the window does not fit on stays put, clients
+	// center those to keep the middle reachable. Override redirect windows
+	// sit exactly where the client wants them.
 	const Rect rect = w->GetGeometry();
 
-	if ( !w->placed && rect.nWidth == ctx->root_width && rect.nHeight == ctx->root_height )
+	if ( !w->placed && !win_is_override_redirect( w ) )
 	{
-		if ( rect.nX != 0 || rect.nY != 0 )
-			XMoveWindow(ctx->dpy, w->xwayland().id, 0, 0);
+		const focus_placement_t place = focus_placement( rect.nX, rect.nY, rect.nWidth, rect.nHeight, ctx->root_width, ctx->root_height );
+
+		xwm_log.debugf( "placement: win 0x%x at %d,%d %dx%d on %dx%d -> %d,%d",
+				w->id(), rect.nX, rect.nY, rect.nWidth, rect.nHeight,
+				ctx->root_width, ctx->root_height, place.x, place.y );
+
+		if ( place.x != rect.nX || place.y != rect.nY )
+			XMoveWindow(ctx->dpy, w->xwayland().id, place.x, place.y);
 
 		w->placed = true;
 	}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4560,21 +4560,26 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	if ( bRaisedBase || ctx->list[0].xwayland().id != inputFocus->xwayland().id )
 		inputFocus->Raise();
 
-	// X confines the pointer to the screen, so clamp the focus window into it
-	// once, per axis. An axis the window does not fit on stays put, clients
-	// center those to keep the middle reachable. Override redirect windows
-	// sit exactly where the client wants them.
-	const Rect rect = w->GetGeometry();
+	wlserver_lock();
+	bool bDragging = wlserver.drag_anchor.surface && wlserver.drag_anchor.surface == w->main_surface();
+	wlserver_unlock();
 
-	if ( !w->placed && !win_is_override_redirect( w ) )
+	// X confines the pointer to the screen, so clamp the focus window into it
+	// once, per axis, unless a client may still be dragging it. An axis the
+	// window does not fit on stays put, clients center those to keep the
+	// middle reachable. Override redirect windows sit where the client wants
+	// them, and the cached geometry can trail a granted move, so read live.
+	XWindowAttributes placeAttr;
+	if ( !w->placed && !bDragging && !win_is_override_redirect( w ) &&
+	     XGetWindowAttributes( ctx->dpy, w->xwayland().id, &placeAttr ) )
 	{
-		const focus_placement_t place = focus_placement( rect.nX, rect.nY, rect.nWidth, rect.nHeight, ctx->root_width, ctx->root_height );
+		const focus_placement_t place = focus_placement( placeAttr.x, placeAttr.y, placeAttr.width, placeAttr.height, ctx->root_width, ctx->root_height );
 
 		xwm_log.debugf( "placement: win 0x%x at %d,%d %dx%d on %dx%d -> %d,%d",
-				w->id(), rect.nX, rect.nY, rect.nWidth, rect.nHeight,
+				w->id(), placeAttr.x, placeAttr.y, placeAttr.width, placeAttr.height,
 				ctx->root_width, ctx->root_height, place.x, place.y );
 
-		if ( place.x != rect.nX || place.y != rect.nY )
+		if ( place.x != placeAttr.x || place.y != placeAttr.y )
 			XMoveWindow(ctx->dpy, w->xwayland().id, place.x, place.y);
 
 		w->placed = true;
@@ -5849,8 +5854,8 @@ configure_win(xwayland_ctx_t *ctx, XConfigureEvent *ce)
 		return;
 	}
 
-	// Resizing re-arms the placement. Moving does not, so we never fight a
-	// client that drags its window off.
+	// Resizing re-arms the placement. A move does not, configure_request
+	// handles a drag.
 	if ( ce->width != w->xwayland().a.width || ce->height != w->xwayland().a.height )
 		w->placed = false;
 
@@ -5899,6 +5904,40 @@ static void configure_request(xwayland_ctx_t *ctx, XConfigureRequestEvent *confi
 		.sibling = configureRequest->above,
 		.stack_mode = configureRequest->detail
 	};
+
+	// Take a client's own drag out of the pointer position so it does not chase itself.
+	steamcompmgr_win_t *w = find_win( ctx, configureRequest->window, false );
+	if ( w && ( configureRequest->value_mask & ( CWX | CWY ) ) && w->xwayland().a.map_state == IsViewable )
+	{
+		// Any window moved during a press may be the drag target, the anchor only applies under the pointer.
+		wlserver_lock();
+		struct wlr_surface *pSurface = w->main_surface();
+		if ( pSurface && wlserver_input_held() )
+		{
+			// An axis the request leaves out falls back to where the anchor last saw it.
+			bool bTracked = wlserver.drag_anchor.surface == pSurface;
+			int nGrantX = ( configureRequest->value_mask & CWX ) ? changes.x : ( bTracked ? wlserver.drag_anchor.last_x : w->xwayland().a.x );
+			int nGrantY = ( configureRequest->value_mask & CWY ) ? changes.y : ( bTracked ? wlserver.drag_anchor.last_y : w->xwayland().a.y );
+
+			xwm_log.debugf( "drag anchor: win 0x%x moved to %d,%d during a press", w->id(), nGrantX, nGrantY );
+			wlserver_drag_anchor_move( pSurface, nGrantX, nGrantY, w->xwayland().a.x, w->xwayland().a.y );
+			w->placed = false;
+		}
+		else if ( pSurface && pSurface == wlserver.drag_settle_surface )
+		{
+			// A client keeps moving until it sees the release, the budget bounds one that never stops.
+			if ( --wlserver.drag_settle_budget <= 0 )
+				wlserver.drag_settle_surface = nullptr;
+
+			int nGrantX = ( configureRequest->value_mask & CWX ) ? changes.x : w->xwayland().a.x;
+			int nGrantY = ( configureRequest->value_mask & CWY ) ? changes.y : w->xwayland().a.y;
+
+			xwm_log.debugf( "drag anchor: win 0x%x re-asserted %d,%d after its drag", w->id(), nGrantX, nGrantY );
+			w->placed = false;
+			MakeFocusDirty();
+		}
+		wlserver_unlock();
+	}
 
 	XConfigureWindow( ctx->dpy, configureRequest->window, configureRequest->value_mask, &changes );
 }

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -137,6 +137,7 @@ extern uint32_t inputCounter;
 extern uint64_t g_lastWinSeq;
 
 void nudge_steamcompmgr( void );
+void MakeFocusDirty();
 void force_repaint( void );
 
 // Per-connector stat snapshot for typed mangoapp streams.

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -365,12 +365,16 @@ void wlserver_open_steam_menu( bool qam )
 	XTestFakeKeyEvent(server->get_xdisplay(), XKeysymToKeycode( server->get_xdisplay(), XK_Control_L ), False, CurrentTime);
 }
 
+static void wlserver_drag_anchor_release();
+static void wlserver_drag_anchor_forget( struct wlr_surface *surface );
+
 static void wlserver_handle_pointer_button(struct wl_listener *listener, void *data)
 {
 	struct wlserver_pointer *pointer = wl_container_of( listener, pointer, button );
 	struct wlr_pointer_button_event *event = (struct wlr_pointer_button_event *) data;
 
 	wlr_seat_pointer_notify_button( wlserver.wlr.seat, event->time_msec, event->button, event->state );
+	wlserver_drag_anchor_release();
 }
 
 static void wlserver_handle_pointer_axis(struct wl_listener *listener, void *data)
@@ -616,6 +620,8 @@ static void handle_wl_surface_destroy( struct wl_listener *l, void *data )
 
 	if ( surf->wlr == wlserver.mouse_focus_surface )
 		wlserver.mouse_focus_surface = nullptr;
+
+	wlserver_drag_anchor_forget( surf->wlr );
 
 	if ( surf->wlr == wlserver.kb_focus_surface )
 		wlserver.kb_focus_surface = nullptr;
@@ -1930,6 +1936,7 @@ static void waylandy_surface_destroy(struct wl_listener *listener, void *data) {
 			wlserver.kb_focus_surface = nullptr;
 		if (wlserver.mouse_focus_surface == info->main_surface)
 			wlserver.mouse_focus_surface = nullptr;
+		wlserver_drag_anchor_forget( info->main_surface );
 		wlserver_surface = get_wl_surface_info(info->main_surface);
 	}
 
@@ -2565,6 +2572,87 @@ void wlserver_oncursorevent()
 	}
 }
 
+bool wlserver_input_held()
+{
+	assert( wlserver_is_lock_held() );
+
+	return wlserver.wlr.seat->pointer_state.button_count > 0 || !wlserver.touch_down_ids.empty();
+}
+
+// Xwayland adds the window origin to the pointer position, so a dragging
+// client reads its own moves back as motion. Subtract them until the press ends.
+void wlserver_drag_anchor_move( struct wlr_surface *surface, int x, int y, int base_x, int base_y )
+{
+	assert( wlserver_is_lock_held() );
+
+	if ( wlserver.drag_anchor.surface != surface )
+	{
+		wl_log.debugf( "drag anchor: now tracking surface %p", (void *)surface );
+		wlserver.drag_anchor = { .surface = surface, .last_x = base_x, .last_y = base_y };
+	}
+
+	// A new drag supersedes any pending settle.
+	wlserver.drag_settle_surface = nullptr;
+
+	wlserver.drag_anchor.dx += x - wlserver.drag_anchor.last_x;
+	wlserver.drag_anchor.dy += y - wlserver.drag_anchor.last_y;
+	wlserver.drag_anchor.last_x = x;
+	wlserver.drag_anchor.last_y = y;
+}
+
+static void wlserver_drag_anchor_apply( double &x, double &y )
+{
+	assert( wlserver_is_lock_held() );
+
+	if ( wlserver.drag_anchor.surface != wlserver.mouse_focus_surface )
+		return;
+
+	x -= wlserver.drag_anchor.dx;
+	y -= wlserver.drag_anchor.dy;
+}
+
+// The dragged surface is gone, drop the anchor and let the focus pass re-place.
+static void wlserver_drag_anchor_forget( struct wlr_surface *surface )
+{
+	assert( wlserver_is_lock_held() );
+
+	if ( wlserver.drag_settle_surface == surface )
+		wlserver.drag_settle_surface = nullptr;
+
+	if ( wlserver.drag_anchor.surface != surface )
+		return;
+
+	wlserver.drag_anchor = {};
+	MakeFocusDirty();
+	nudge_steamcompmgr();
+}
+
+// Covers the moves a client keeps sending before it sees the release.
+static constexpr int k_nDragSettleBudget = 32;
+
+// Nothing is pressed any more, let the focus pass put the window back on the screen.
+static void wlserver_drag_anchor_release()
+{
+	assert( wlserver_is_lock_held() );
+
+	if ( wlserver_input_held() )
+		return;
+
+	if ( !wlserver.drag_anchor.surface )
+	{
+		// A press without a drag ends any pending settle.
+		wlserver.drag_settle_surface = nullptr;
+		return;
+	}
+
+	wl_log.debugf( "drag anchor: released at %f,%f, placing the window again", wlserver.drag_anchor.dx, wlserver.drag_anchor.dy );
+	wlserver.drag_settle_surface = wlserver.drag_anchor.surface;
+	wlserver.drag_settle_budget = k_nDragSettleBudget;
+	wlserver.drag_anchor = {};
+	MakeFocusDirty();
+	nudge_steamcompmgr();
+}
+
 static std::pair<int, int> wlserver_get_cursor_bounds()
 {
 	auto [nWidth, nHeight] = wlserver_get_surface_extent( wlserver.mouse_focus_surface );
@@ -2864,7 +2952,11 @@ void wlserver_mousemotion( double dx, double dy, uint32_t time )
 
 	wlserver_oncursorevent();
 
-	wlr_seat_pointer_notify_motion( wlserver.wlr.seat, time, wlserver.mouse_surface_cursorx, wlserver.mouse_surface_cursory );
+	double sx = wlserver.mouse_surface_cursorx;
+	double sy = wlserver.mouse_surface_cursory;
+	wlserver_drag_anchor_apply( sx, sy );
+
+	wlr_seat_pointer_notify_motion( wlserver.wlr.seat, time, sx, sy );
 	wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
 }
 
@@ -2883,7 +2975,11 @@ void wlserver_mousewarp( double x, double y, uint32_t time, bool bSynthetic )
 
 	wlserver_oncursorevent();
 
-	wlr_seat_pointer_notify_motion( wlserver.wlr.seat, time, wlserver.mouse_surface_cursorx, wlserver.mouse_surface_cursory );
+	double sx = wlserver.mouse_surface_cursorx;
+	double sy = wlserver.mouse_surface_cursory;
+	wlserver_drag_anchor_apply( sx, sy );
+
+	wlr_seat_pointer_notify_motion( wlserver.wlr.seat, time, sx, sy );
 	wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
 }
 
@@ -2904,6 +3000,7 @@ void wlserver_mousebutton( int button, bool press, uint32_t time )
 
 	wlr_seat_pointer_notify_button( wlserver.wlr.seat, time, button, press ? WL_POINTER_BUTTON_STATE_PRESSED : WL_POINTER_BUTTON_STATE_RELEASED );
 	wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
+	wlserver_drag_anchor_release();
 }
 
 void wlserver_mousewheel( double flX, double flY, uint32_t time )
@@ -3038,7 +3135,9 @@ void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time, bool
 
 		if ( eMode == gamescope::TouchClickModes::Passthrough )
 		{
-			wlr_seat_touch_notify_motion( wlserver.wlr.seat, time, touch_id, tx, ty );
+			double sx = tx, sy = ty;
+			wlserver_drag_anchor_apply( sx, sy );
+			wlr_seat_touch_notify_motion( wlserver.wlr.seat, time, touch_id, sx, sy );
 
 			if ( bAlwaysWarpCursor )
 				wlserver_mousewarp( tx, ty, time, false );
@@ -3087,8 +3186,9 @@ void wlserver_touchdown( double x, double y, int touch_id, uint32_t time, gamesc
 
 		if ( eMode == gamescope::TouchClickModes::Passthrough )
 		{
-			wlr_seat_touch_notify_down( wlserver.wlr.seat, wlserver.mouse_focus_surface, time, touch_id,
-										tx, ty );
+			double sx = tx, sy = ty;
+			wlserver_drag_anchor_apply( sx, sy );
+			wlr_seat_touch_notify_down( wlserver.wlr.seat, wlserver.mouse_focus_surface, time, touch_id, sx, sy );
 
 			wlserver.touch_down_ids.insert( touch_id );
 		}
@@ -3153,6 +3253,7 @@ void wlserver_touchup( int touch_id, uint32_t time )
 		wlserver.touch_down_ids.erase( touch_id );
 	}
 
+	wlserver_drag_anchor_release();
 	bump_input_counter();
 }
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -3124,35 +3124,33 @@ void wlserver_touchup( int touch_id, uint32_t time )
 {
 	assert( wlserver_is_lock_held() );
 
-	if ( wlserver.mouse_focus_surface != NULL )
+	// Release whatever the touch pressed even if its surface is gone, or the seat keeps the button down.
+	bool bReleasedAny = false;
+	for ( int i = 0; i < WLSERVER_BUTTON_COUNT; i++ )
 	{
-		bool bReleasedAny = false;
-		for ( int i = 0; i < WLSERVER_BUTTON_COUNT; i++ )
+		if ( wlserver.button_held[ i ] == true )
 		{
-			if ( wlserver.button_held[ i ] == true )
+			uint32_t button = TouchClickModeToLinuxButton( (gamescope::TouchClickMode) i );
+
+			if ( button != 0 )
 			{
-				uint32_t button = TouchClickModeToLinuxButton( (gamescope::TouchClickMode) i );
-
-				if ( button != 0 )
-				{
-					wlr_seat_pointer_notify_button( wlserver.wlr.seat, time, button, WL_POINTER_BUTTON_STATE_RELEASED );
-					bReleasedAny = true;
-				}
-
-				wlserver.button_held[ i ] = false;
+				wlr_seat_pointer_notify_button( wlserver.wlr.seat, time, button, WL_POINTER_BUTTON_STATE_RELEASED );
+				bReleasedAny = true;
 			}
-		}
 
-		if ( bReleasedAny == true )
-		{
-			wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
+			wlserver.button_held[ i ] = false;
 		}
+	}
 
-		if ( wlserver.touch_down_ids.count( touch_id ) > 0 )
-		{
-			wlr_seat_touch_notify_up( wlserver.wlr.seat, time, touch_id );
-			wlserver.touch_down_ids.erase( touch_id );
-		}
+	if ( bReleasedAny == true )
+	{
+		wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
+	}
+
+	if ( wlserver.touch_down_ids.count( touch_id ) > 0 )
+	{
+		wlr_seat_touch_notify_up( wlserver.wlr.seat, time, touch_id );
+		wlserver.touch_down_ids.erase( touch_id );
 	}
 
 	bump_input_counter();

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -171,6 +171,21 @@ struct wlserver_t {
 	bool button_held[ WLSERVER_BUTTON_COUNT ];
 	std::set <uint32_t> touch_down_ids;
 
+	// Moves a client made to the surface under the pointer during the current
+	// press, taken back out of the pointer position so its root position holds.
+	struct {
+		struct wlr_surface *surface = nullptr;
+		double dx = 0.0;
+		double dy = 0.0;
+		int last_x = 0;
+		int last_y = 0;
+	} drag_anchor;
+
+	// The last dragged surface, and a bound on the moves it keeps sending
+	// after the release that re-arm the placement.
+	struct wlr_surface *drag_settle_surface = nullptr;
+	int drag_settle_budget = 0;
+
 	struct {
 		char *name;
 		char *description;
@@ -257,6 +272,8 @@ void wlserver_mousehide();
 void wlserver_mousewarp( double x, double y, uint32_t time, bool bSynthetic );
 void wlserver_mousebutton( int button, bool press, uint32_t time );
 void wlserver_mousewheel( double x, double y, uint32_t time );
+bool wlserver_input_held();
+void wlserver_drag_anchor_move( struct wlr_surface *surface, int x, int y, int base_x, int base_y );
 
 void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time, bool bAlwaysWarpCursor = false, gamescope::IBackendConnector* connector = nullptr );
 void wlserver_touchdown( double x, double y, int touch_id, uint32_t time, gamescope::IBackendConnector* connector = nullptr );

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ endforeach
 
 gamescope_tests = executable(
 	'gamescope_tests',
-	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_upscale.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_focus_placement.cpp', 'test_process.cpp', 'test_upscale.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
@@ -17,6 +17,7 @@ gamescope_tests = executable(
 reaper_test_helper = executable('reaper_test_helper', 'reaper_test_helper.cpp')
 
 test('convar', gamescope_tests, args: ['[convar]'])
+test('focus_placement', gamescope_tests, args: ['[focus_placement]'])
 test('upscale', gamescope_tests, args: ['[upscale]'])
 test('utils/parsers', gamescope_tests, args: ['[parsers]'])
 test('utils/process', gamescope_tests, args: ['[process]'], depends: [reaper_test_helper])

--- a/tests/test_focus_placement.cpp
+++ b/tests/test_focus_placement.cpp
@@ -1,0 +1,39 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "focus_placement.h"
+
+TEST_CASE("A screen-sized window belongs at the origin", "[focus_placement]") {
+	const auto place = focus_placement(1013, 1066, 1920, 1080, 1920, 1080);
+	REQUIRE(place.x == 0);
+	REQUIRE(place.y == 0);
+}
+
+TEST_CASE("A window that fits and hangs off is clamped onto the screen", "[focus_placement]") {
+	const auto place = focus_placement(1201, 878, 1127, 1064, 1920, 1080);
+	REQUIRE(place.x == 793);
+	REQUIRE(place.y == 16);
+}
+
+TEST_CASE("A window that fits at a negative origin is clamped to the near edge", "[focus_placement]") {
+	const auto place = focus_placement(-236, -50, 1762, 833, 1920, 1080);
+	REQUIRE(place.x == 0);
+	REQUIRE(place.y == 0);
+}
+
+TEST_CASE("A window inside the screen keeps its position", "[focus_placement]") {
+	const auto place = focus_placement(240, 90, 1440, 900, 1920, 1080);
+	REQUIRE(place.x == 240);
+	REQUIRE(place.y == 90);
+}
+
+TEST_CASE("An oversized window keeps its centering", "[focus_placement]") {
+	const auto place = focus_placement(-241, -16, 1762, 833, 1280, 800);
+	REQUIRE(place.x == -241);
+	REQUIRE(place.y == -16);
+}
+
+TEST_CASE("Each axis is decided on its own", "[focus_placement]") {
+	const auto place = focus_placement(200, -30, 2000, 700, 1920, 1080);
+	REQUIRE(place.x == 200);
+	REQUIRE(place.y == 0);
+}


### PR DESCRIPTION
Gamescope composites the focus window at the output origin regardless of its real X11 position, but Xwayland routes pointer input through that real position and X confines the pointer to the screen, so a window that ends up off-screen still looks fine while parts of it silently stop taking input, and a client that drags its own window (Wine caption drags, Qt/Electron drag regions) reads its own moves back as more pointer motion and runs away to a corner. 

This regressed in 3.16.25 when the unconditional snap-to-(0,0) was removed (a563226d), and bites launchers that persist or drag their windows. You can repro this by grabbing the title bar of a launcher such as Marvel Rivals and dragging it around the screen with the cursor on Steam Machine. RenderDoc has a similar issue if you pop-out one of the tabs like "Pipeline State" and do the same drag action in the OpenVR backend.

To try and avoid this issue, clamp a focus window that fits the screen back onto it (one-shot, per axis, never fighting a client), anchor the pointer's root position during client self-drags so the drag moves the window by exactly the finger motion, and fix two ways a press could leak held: a touch release with no focus surface, and a SteamVR button-up delivered to whichever overlay the laser ends on.