### PR TITLE
rendervulkan: allow render-only devices for nested backends

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -473,7 +473,7 @@ bool CVulkanDevice::createDevice()
 		};
 		vk.GetPhysicalDeviceProperties2( physDev(), &props2 );
 
-		if ( !GetBackend()->UsesVulkanSwapchain() && !drmProps.hasPrimary ) {
+		if ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() && !drmProps.hasPrimary ) {
 			vk_log.errorf( "physical device has no primary node" );
 			return false;
 		}


### PR DESCRIPTION
Nested Wayland and headless backends only need the DRM render node for Vulkan rendering and DMA-BUF exchange. The current check rejects those devices whenever `VkPhysicalDeviceDrmPropertiesEXT::hasPrimary` is false, even though the primary device ID is already optional later in `CVulkanDevice::createDevice`.

Require a primary node only for session-based backends such as DRM/KMS. Vulkan-swapchain backends retain their existing behavior.

This fixes nested Gamescope on a containerized RADV device exposing only `/dev/dri/renderD*`, without granting the container DRM/KMS ownership. It also addresses the same backend-independent rejection reported in #1966.

Validated downstream by applying this change to the pinned Gamescope source and exercising the queue checks; the DRM backend continues to reject devices without a primary node.