### PR TITLE
ime: keep one interpret in the generated keymap

### DIFF
--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -218,7 +218,11 @@ static struct xkb_keymap *generate_keymap(struct wlserver_input_method *ime)
 		"\n"
 		"xkb_types \"(unnamed)\" { include \"complete\" };\n"
 		"\n"
-		"xkb_compatibility \"(unnamed)\" { include \"complete\" };\n"
+		"xkb_compatibility \"(unnamed)\" {\n"
+		"	include \"complete\"\n"
+		// libxkbcommon 1.12+ serializes only matched interprets, Xwayland needs at least one
+		"	interpret Any+AnyOfOrNone(all) { action= NoAction(); };\n"
+		"};\n"
 		"\n"
 		"xkb_symbols \"(unnamed)\" {\n"
 	);


### PR DESCRIPTION
libxkbcommon 1.12 stops serializing interprets that no key matched. The IME keys match none, so the compat section comes out empty, xkbcomp writes no compat map into the XKM and Xwayland silently keeps its default keymap.

Add a catch-all NoAction interpret so the serialized keymap keeps a compat map.