### PR TITLE
More fixes for seamless virtual laser from one virtual connector to another

### DIFF
--- a/src/Backends/DeferredBackend.h
+++ b/src/Backends/DeferredBackend.h
@@ -192,6 +192,16 @@ namespace gamescope
 
             return nullptr;
 		}
+		virtual IBackendConnector *GetCurrentGamepadConnector() override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->GetCurrentGamepadConnector();
+            }
+
+            return nullptr;
+		}
 
 		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override
 		{

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -791,6 +791,11 @@ namespace gamescope
         {
             return m_pMouseFocusConnector;
         }
+        virtual IBackendConnector *GetCurrentGamepadConnector() override
+        {
+            COpenVRConnector *pConnector = m_pGamepadFocusConnector.load();
+            return pConnector ? pConnector : m_pKeyboardFocusConnector.load();
+        }
 		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override
 		{
 			if ( eScreenType == GAMESCOPE_SCREEN_TYPE_INTERNAL )
@@ -932,6 +937,11 @@ namespace gamescope
                     openvr_log.debugf( "Changed keyboard focus connector to %p ", pConnector.get() );
                     update_connector_display_info_wl( NULL );
                 }
+            }
+
+            {
+                COpenVRConnector *pExpected = nullptr;
+                m_pGamepadFocusConnector.compare_exchange_strong( pExpected, pConnector.get() );
             }
 
             std::scoped_lock lock{ m_mutActiveConnectors };
@@ -1121,30 +1131,49 @@ namespace gamescope
             UpdateLaserMouseFocusConnector( GetConnectorByOverlayHandle( ulFocusOverlay ) );
         }
 
-        void SetKeyboardFocus( uint64_t ulFocusOverlay )
+        static constexpr uint32_t k_uInputFocusFlagsAll =
+            vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForKeyboardInput |
+            vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForGamepadInput;
+
+        // SteamVR grants keyboard focus to whatever the laser rests on, so only a
+        // grant that asks for gamepad focus moves the controller.
+        void SetKeyboardFocus( uint64_t ulFocusOverlay, uint32_t uFlags = k_uInputFocusFlagsAll )
         {
-            uint64_t oldOverlayHandle = g_FocusedVROverlayKeyboard.exchange( ulFocusOverlay );
+            // A grant without either bit predates the flags, treat it as both.
+            if ( !( uFlags & k_uInputFocusFlagsAll ) )
+                uFlags = k_uInputFocusFlagsAll;
 
-            if ( oldOverlayHandle == ulFocusOverlay )
-                return;
-
-            openvr_log.debugf( "Changing keyboard focus from %lx to %lx", oldOverlayHandle, ulFocusOverlay );
-
-            COpenVRConnector *pInputConnector = nullptr;
-            if ( ulFocusOverlay != vr::k_ulOverlayHandleInvalid )
+            bool bChanged = false;
+            if ( uFlags & vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForKeyboardInput )
             {
-                COpenVRPlane *pInputPlane = GetPlaneByOverlayHandle( ulFocusOverlay );
-                if ( pInputPlane )
+                uint64_t oldOverlayHandle = g_FocusedVROverlayKeyboard.exchange( ulFocusOverlay );
+                if ( oldOverlayHandle != ulFocusOverlay )
                 {
-                    pInputConnector = pInputPlane->GetConnector();
+                    openvr_log.debugf( "Changing keyboard focus from %lx to %lx (flags 0x%x)", oldOverlayHandle, ulFocusOverlay, uFlags );
+                    bChanged = true;
                 }
             }
 
+            COpenVRConnector *pInputConnector = GetConnectorByOverlayHandle( ulFocusOverlay );
             if ( pInputConnector )
             {
-                openvr_log.debugf( "Changing keyboard focus connector to %p", pInputConnector );
-                m_pKeyboardFocusConnector.exchange( pInputConnector );
+                if ( ( uFlags & vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForKeyboardInput ) &&
+                     m_pKeyboardFocusConnector.exchange( pInputConnector ) != pInputConnector )
+                {
+                    openvr_log.debugf( "Changing keyboard focus connector to %p", pInputConnector );
+                    bChanged = true;
+                }
+
+                if ( ( uFlags & vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForGamepadInput ) &&
+                     m_pGamepadFocusConnector.exchange( pInputConnector ) != pInputConnector )
+                {
+                    openvr_log.debugf( "Changing gamepad focus connector to %p", pInputConnector );
+                    bChanged = true;
+                }
             }
+
+            if ( !bChanged )
+                return;
 
             // Switch cursor to be driven by the real/steaminput mouse, unless there's still a laser mouse pointing at us.
             UpdateLaserMouseFocusConnector( GetConnectorByOverlayHandle( g_FocusedVROverlayMouse ) );
@@ -1378,7 +1407,7 @@ namespace gamescope
                 case vr::VREvent_OverlayInputFocusChanged:
                     {
                         const vr::VREvent_Data_Gamescope_t &data = CastToGamescopeEventData( vrEvent.data );
-                        SetKeyboardFocus( data.overlayInputFocus.overlayHandle );
+                        SetKeyboardFocus( data.overlayInputFocus.overlayHandle, data.overlayInputFocus.flags );
                     }
                     break;
                 case vr::VREvent_MouseButtonUp:
@@ -1581,6 +1610,7 @@ namespace gamescope
         std::mutex m_mutActiveConnectors;
         std::atomic<COpenVRConnector *> m_pMouseFocusConnector;
         std::atomic<COpenVRConnector *> m_pKeyboardFocusConnector;
+        std::atomic<COpenVRConnector *> m_pGamepadFocusConnector;
 
         std::atomic<bool> m_bInitted = { false };
         std::atomic<bool> m_bRunning = { false };
@@ -1623,6 +1653,8 @@ namespace gamescope
         m_pBackend->m_pMouseFocusConnector.compare_exchange_strong( pThis, nullptr );
         pThis = this;
         m_pBackend->m_pKeyboardFocusConnector.compare_exchange_strong( pThis, nullptr );
+        pThis = this;
+        m_pBackend->m_pGamepadFocusConnector.compare_exchange_strong( pThis, nullptr );
     }
     GamescopeScreenType COpenVRConnector::GetScreenType() const
     {
@@ -2032,7 +2064,10 @@ namespace gamescope
 
                 bool bChanged = false;
                 if ( bTakeKeyboard )
+                {
                     bChanged |= m_pBackend->m_pKeyboardFocusConnector.exchange( this ) != this;
+                    bChanged |= m_pBackend->m_pGamepadFocusConnector.exchange( this ) != this;
+                }
                 if ( bTakeMouse )
                     bChanged |= m_pBackend->m_pMouseFocusConnector.exchange( this ) != this;
 

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -76,6 +76,7 @@ gamescope::ConVar<bool> cv_vr_debug_force_opaque( "vr_debug_force_opaque", false
 gamescope::ConVar<bool> cv_vr_nudge_to_visible( "vr_nudge_to_visible", false, "" );
 gamescope::ConVar<bool> cv_vr_nudge_to_visible_per_connector( "vr_nudge_to_visible_per_connector", false, "" );
 gamescope::ConVar<bool> cv_vr_click_focus( "vr_click_focus", true, "Move keyboard focus to the overlay a click lands on, without waiting for SteamVR to grant it." );
+gamescope::ConVar<uint64_t> cv_vr_click_focus_hold( "vr_click_focus_hold", 100'000'000ul, "Longest time to hold a laser press while a keyboard focus change lands in X. 0 sends it at once. In nanoseconds." );
 
 // Maximum interval between polling for VR events (normally paced by frame sync)
 gamescope::ConVar<uint32_t> cv_vr_poll_rate( "vr_poll_rate", 50ul, "Max time between input polls. In milliseconds." );
@@ -1144,6 +1145,7 @@ namespace gamescope
                 uFlags = k_uInputFocusFlagsAll;
 
             bool bChanged = false;
+            bool bKeyboardConnectorChanged = false;
             if ( uFlags & vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForKeyboardInput )
             {
                 uint64_t oldOverlayHandle = g_FocusedVROverlayKeyboard.exchange( ulFocusOverlay );
@@ -1162,6 +1164,7 @@ namespace gamescope
                 {
                     openvr_log.debugf( "Changing keyboard focus connector to %p", pInputConnector );
                     bChanged = true;
+                    bKeyboardConnectorChanged = true;
                 }
 
                 if ( ( uFlags & vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForGamepadInput ) &&
@@ -1179,30 +1182,144 @@ namespace gamescope
             UpdateLaserMouseFocusConnector( GetConnectorByOverlayHandle( g_FocusedVROverlayMouse ) );
 
             MakeFocusDirty();
+            if ( bKeyboardConnectorChanged )
+                ArmKeyboardFocusSettle();
             nudge_steamcompmgr();
+        }
+
+        // A keyboard connector move has to land in X, and the game losing it
+        // needs a moment to drop its pointer grab, before a press can go out.
+        void ArmKeyboardFocusSettle()
+        {
+            m_bKeyboardFocusPending = true;
+            m_ulKeyboardFocusSerial = GetFocusSerial();
+        }
+
+        // Once per poll, steamcompmgr applies focus between polls. The poll after
+        // the move lands still waits, so the old game has had a frame to let go.
+        void PollKeyboardFocusSettle()
+        {
+            if ( m_nKeyboardFocusGracePolls )
+                m_nKeyboardFocusGracePolls--;
+
+            if ( m_bKeyboardFocusPending && GetAppliedFocusSerial() >= m_ulKeyboardFocusSerial )
+            {
+                m_bKeyboardFocusPending = false;
+                m_nKeyboardFocusGracePolls = 1;
+            }
+        }
+
+        bool IsKeyboardFocusSettling()
+        {
+            return m_bKeyboardFocusPending || m_nKeyboardFocusGracePolls > 0;
+        }
+
+        // A press sent through the old game's grab lands there, so hold it until the move has settled.
+        void HoldPress( uint32_t uButton, float flX, float flY )
+        {
+            m_HeldPress = {
+                .bActive = true,
+                .uButton = uButton,
+                .flX = flX,
+                .flY = flY,
+                .ulDeadline = get_time_in_nanos() + cv_vr_click_focus_hold,
+            };
+        }
+
+        void SendHeldPress()
+        {
+            if ( !m_HeldPress.bActive )
+                return;
+
+            uint32_t uButton = m_HeldPress.uButton;
+            bool bReleased = m_HeldPress.bReleased;
+            float flX = m_HeldPress.flX;
+            float flY = m_HeldPress.flY;
+            m_HeldPress = {};
+
+            // A release in the same poll would make a click no frame sees.
+            m_uReleaseNextPoll = bReleased ? uButton : 0;
+            SendButton( uButton, true, flX, flY );
+        }
+
+        static uint32_t HeldButtonBit( uint32_t uButton )
+        {
+            return 1u << ( uButton - BTN_LEFT );
+        }
+
+        // Every laser button goes through here so the held set stays true to what went out.
+        void SendButton( uint32_t uButton, bool bDown, float flX = 0.0f, float flY = 0.0f )
+        {
+            if ( bDown )
+                m_uHeldMouseButtons |= HeldButtonBit( uButton );
+            else
+                m_uHeldMouseButtons &= ~HeldButtonBit( uButton );
+
+            wlserver_lock();
+            if ( uButton == BTN_LEFT )
+            {
+                if ( bDown )
+                    wlserver_touchdown( flX, flY, 0, ++m_uFakeTimestamp );
+                else
+                    wlserver_touchup( 0, ++m_uFakeTimestamp );
+            }
+            else
+            {
+                wlserver_mousebutton( uButton, bDown, ++m_uFakeTimestamp );
+            }
+            wlserver_unlock();
+        }
+
+        void FlushHeldPress()
+        {
+            if ( !m_HeldPress.bActive )
+                return;
+
+            if ( !IsKeyboardFocusSettling() || get_time_in_nanos() >= m_HeldPress.ulDeadline )
+                SendHeldPress();
         }
 
         // SteamVR sends VREvent_MouseButtonUp to whichever overlay the laser is
         // over at release, so a press that started on us can end somewhere else.
         void ReleaseHeldMouse()
         {
-            if ( !m_uHeldMouseButton )
+            // A completed click still held goes out now, its release follows next poll.
+            if ( m_HeldPress.bReleased )
+            {
+                SendHeldPress();
                 return;
+            }
 
-            uint32_t uButton = m_uHeldMouseButton;
-            m_uHeldMouseButton = 0;
+            // A press still held was never sent, so there is nothing to release.
+            m_HeldPress = {};
 
-            wlserver_lock();
-            if ( uButton == BTN_LEFT )
-                wlserver_touchup( 0, ++m_uFakeTimestamp );
-            else
-                wlserver_mousebutton( uButton, false, ++m_uFakeTimestamp );
-            wlserver_unlock();
+            // A release already queued for next poll stays there, sent now it would share the press's frame.
+            uint32_t uButtons = m_uHeldMouseButtons;
+            if ( m_uReleaseNextPoll )
+                uButtons &= ~HeldButtonBit( m_uReleaseNextPoll );
+
+            for ( uint32_t uButton = BTN_LEFT; uButtons; uButton++ )
+            {
+                if ( !( uButtons & HeldButtonBit( uButton ) ) )
+                    continue;
+
+                uButtons &= ~HeldButtonBit( uButton );
+                SendButton( uButton, false );
+            }
         }
 
         void ProcessVRInput()
         {
             std::scoped_lock lock{m_mutActiveConnectors};
+
+            PollKeyboardFocusSettle();
+            if ( m_uReleaseNextPoll )
+            {
+                uint32_t uButton = m_uReleaseNextPoll;
+                m_uReleaseNextPoll = 0;
+                SendButton( uButton, false );
+            }
+            FlushHeldPress();
 
             vr::VREvent_t vrEvent;
             bool bDidScrollThisFrame = false;
@@ -1483,26 +1600,31 @@ namespace gamescope
                             else
                             {
                                 bool bDown = vrEvent.eventType == vr::VREvent_MouseButtonDown;
-                                wlserver_lock();
+                                uint32_t uButton = 0;
                                 if (vrEvent.data.mouse.button == vr::VRMouseButton_Left)
-                                {
-                                    m_uHeldMouseButton = bDown ? BTN_LEFT : 0;
-                                    if (bDown)
-                                        wlserver_touchdown(flX, flY, 0, ++m_uFakeTimestamp);
-                                    else
-                                        wlserver_touchup(0, ++m_uFakeTimestamp);
-                                }
+                                    uButton = BTN_LEFT;
                                 else if (vrEvent.data.mouse.button == vr::VRMouseButton_Right)
-                                {
-                                    m_uHeldMouseButton = bDown ? BTN_RIGHT : 0;
-                                    wlserver_mousebutton(BTN_RIGHT, bDown, ++m_uFakeTimestamp);
-                                }
+                                    uButton = BTN_RIGHT;
                                 else if (vrEvent.data.mouse.button == vr::VRMouseButton_Middle)
+                                    uButton = BTN_MIDDLE;
+
+                                // Another button would go out ahead of the press still held, so send that first.
+                                if ( uButton && m_HeldPress.bActive && !( !bDown && uButton == m_HeldPress.uButton ) )
+                                    SendHeldPress();
+
+                                if ( uButton && bDown && cv_vr_click_focus_hold && !m_uHeldMouseButtons && !m_HeldPress.bActive && IsKeyboardFocusSettling() )
                                 {
-                                    m_uHeldMouseButton = bDown ? BTN_MIDDLE : 0;
-                                    wlserver_mousebutton(BTN_MIDDLE, bDown, ++m_uFakeTimestamp);
+                                    HoldPress( uButton, flX, flY );
                                 }
-                                wlserver_unlock();
+                                else if ( uButton && !bDown && m_HeldPress.bActive && uButton == m_HeldPress.uButton )
+                                {
+                                    // The press has not gone out yet, so the release rides along with it.
+                                    m_HeldPress.bReleased = true;
+                                }
+                                else if ( uButton )
+                                {
+                                    SendButton( uButton, bDown, flX, flY );
+                                }
                             }
                         }
                     }
@@ -1595,8 +1717,28 @@ namespace gamescope
         std::atomic<uint32_t> m_uFakeTimestamp = { 0 };
 
         bool m_bMouseDown = false;
-        uint32_t m_uHeldMouseButton = 0;
+        // Laser buttons currently down, one bit per button from BTN_LEFT.
+        uint32_t m_uHeldMouseButtons = 0;
         uint64_t m_ulMouseDownTime = 0;
+
+        // A keyboard connector move steamcompmgr has not applied yet, then the
+        // polls the game that lost it gets to drop its grab.
+        bool m_bKeyboardFocusPending = false;
+        uint64_t m_ulKeyboardFocusSerial = 0;
+        int m_nKeyboardFocusGracePolls = 0;
+        // The button of a held press that just went out, released a poll later.
+        uint32_t m_uReleaseNextPoll = 0;
+
+        // A laser press held back until the keyboard focus change has settled.
+        struct
+        {
+            bool bActive = false;
+            bool bReleased = false;
+            uint32_t uButton = 0;
+            float flX = 0.0f;
+            float flY = 0.0f;
+            uint64_t ulDeadline = 0;
+        } m_HeldPress;
         // Fake "trackpad" tracking for the whole overlay panel.
         glm::vec2 m_vScreenTrackpadPos{};
         glm::vec2 m_vScreenStartTrackpadPos{};
@@ -2063,9 +2205,11 @@ namespace gamescope
                     !pMouseConnector->GetPlaneByOverlayHandle( g_FocusedVROverlayMouse.load() );
 
                 bool bChanged = false;
+                bool bKeyboardChanged = false;
                 if ( bTakeKeyboard )
                 {
-                    bChanged |= m_pBackend->m_pKeyboardFocusConnector.exchange( this ) != this;
+                    bKeyboardChanged = m_pBackend->m_pKeyboardFocusConnector.exchange( this ) != this;
+                    bChanged |= bKeyboardChanged;
                     bChanged |= m_pBackend->m_pGamepadFocusConnector.exchange( this ) != this;
                 }
                 if ( bTakeMouse )
@@ -2077,6 +2221,8 @@ namespace gamescope
                     update_connector_display_info_wl( NULL );
 
                     MakeFocusDirty();
+                    if ( bKeyboardChanged )
+                        m_pBackend->ArmKeyboardFocusSettle();
                     nudge_steamcompmgr();
                 }
             }

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -77,6 +77,8 @@ gamescope::ConVar<bool> cv_vr_nudge_to_visible( "vr_nudge_to_visible", false, ""
 gamescope::ConVar<bool> cv_vr_nudge_to_visible_per_connector( "vr_nudge_to_visible_per_connector", false, "" );
 gamescope::ConVar<bool> cv_vr_click_focus( "vr_click_focus", true, "Move keyboard focus to the overlay a click lands on, without waiting for SteamVR to grant it." );
 gamescope::ConVar<uint64_t> cv_vr_click_focus_hold( "vr_click_focus_hold", 100'000'000ul, "Longest time to hold a laser press while a keyboard focus change lands in X. 0 sends it at once. In nanoseconds." );
+gamescope::ConVar<bool> cv_vr_hover_focus( "vr_hover_focus", true, "Move keyboard focus to a game overlay the laser stays on, so a game holding the X pointer grab lets go of it. The controller stays where it was." );
+gamescope::ConVar<uint64_t> cv_vr_hover_focus_dwell( "vr_hover_focus_dwell", 250'000'000ul, "Time the laser has to stay on another game before keyboard focus follows it. In nanoseconds." );
 
 // Maximum interval between polling for VR events (normally paced by frame sync)
 gamescope::ConVar<uint32_t> cv_vr_poll_rate( "vr_poll_rate", 50ul, "Max time between input polls. In milliseconds." );
@@ -1187,6 +1189,51 @@ namespace gamescope
             nudge_steamcompmgr();
         }
 
+        // Game to game only, Steam's overlays are left to clicks since the laser crosses them constantly.
+        bool IsHoverFocusCandidate( COpenVRConnector *pConnector )
+        {
+            COpenVRConnector *pKeyboardConnector = m_pKeyboardFocusConnector.load();
+            return cv_vr_hover_focus && pConnector && pKeyboardConnector && pKeyboardConnector != pConnector &&
+                VirtualConnectorKeyIsGame( pConnector->GetVirtualConnectorKey() ) &&
+                VirtualConnectorKeyIsGame( pKeyboardConnector->GetVirtualConnectorKey() );
+        }
+
+        // Arms the dwell. The laser can sit still without further move events, so the dwell is checked every poll.
+        void UpdateHoverFocus( uint64_t ulOverlay, COpenVRConnector *pConnector )
+        {
+            if ( !IsHoverFocusCandidate( pConnector ) )
+            {
+                m_ulHoverOverlay = vr::k_ulOverlayHandleInvalid;
+                return;
+            }
+
+            if ( m_ulHoverOverlay != ulOverlay )
+            {
+                m_ulHoverOverlay = ulOverlay;
+                m_ulHoverSince = get_time_in_nanos();
+            }
+        }
+
+        void CheckHoverFocus()
+        {
+            if ( m_ulHoverOverlay == vr::k_ulOverlayHandleInvalid )
+                return;
+
+            if ( !IsHoverFocusCandidate( GetConnectorByOverlayHandle( m_ulHoverOverlay ) ) )
+            {
+                m_ulHoverOverlay = vr::k_ulOverlayHandleInvalid;
+                return;
+            }
+
+            if ( get_time_in_nanos() - m_ulHoverSince < cv_vr_hover_focus_dwell )
+                return;
+
+            // Keyboard only, the controller stays with the game picked on purpose.
+            openvr_log.debugf( "Laser stayed on %lx, moving keyboard focus to it", m_ulHoverOverlay );
+            SetKeyboardFocus( m_ulHoverOverlay, vr::k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForKeyboardInput );
+            m_ulHoverOverlay = vr::k_ulOverlayHandleInvalid;
+        }
+
         // A keyboard connector move has to land in X, and the game losing it
         // needs a moment to drop its pointer grab, before a press can go out.
         void ArmKeyboardFocusSettle()
@@ -1465,6 +1512,10 @@ namespace gamescope
 
                         TouchClickMode eMode = GetTouchClickMode();
 
+                        // A trackpad sweep is a drag, not a hover.
+                        if ( eMode != TouchClickModes::Trackpad )
+                            UpdateHoverFocus( hOverlay, pConnector );
+
                         if (eMode == TouchClickModes::Trackpad)
                         {
                             glm::vec2 vOldTrackpadPos = m_vScreenTrackpadPos;
@@ -1513,6 +1564,9 @@ namespace gamescope
 
                             SetMouseFocus( vr::k_ulOverlayHandleInvalid );
                         }
+
+                        if ( m_ulHoverOverlay == hOverlay )
+                            m_ulHoverOverlay = vr::k_ulOverlayHandleInvalid;
                     }
                     break;
 
@@ -1663,6 +1717,8 @@ namespace gamescope
                 }
             }
 
+            CheckHoverFocus();
+
             if (bPendingTouchMove)
             {
                 // Always warp a cursor, even if it's invisible, so we get hover events.
@@ -1728,6 +1784,10 @@ namespace gamescope
         int m_nKeyboardFocusGracePolls = 0;
         // The button of a held press that just went out, released a poll later.
         uint32_t m_uReleaseNextPoll = 0;
+
+        // The game overlay the laser is on and when it got there.
+        uint64_t m_ulHoverOverlay = vr::k_ulOverlayHandleInvalid;
+        uint64_t m_ulHoverSince = 0;
 
         // A laser press held back until the keyboard focus change has settled.
         struct

--- a/src/backend.h
+++ b/src/backend.h
@@ -357,6 +357,11 @@ namespace gamescope
         {
             return this->GetCurrentConnector();
         }
+        // The connector Steam routes the controller to.
+        virtual IBackendConnector *GetCurrentGamepadConnector()
+        {
+            return this->GetCurrentConnector();
+        }
         virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) = 0;
 
         virtual bool SupportsPlaneHardwareCursor() const = 0;

--- a/src/backend.h
+++ b/src/backend.h
@@ -79,6 +79,13 @@ namespace gamescope
         return VirtualConnectorInSteamPerAppState() && ( ulKey & k_ulNonSteamWindowBit ) == k_ulNonSteamWindowBit;
     }
 
+    // A game or non-Steam window on its own connector, not Steam or its bootstrapper.
+    static inline bool VirtualConnectorKeyIsGame( VirtualConnectorKey_t ulKey )
+    {
+        return VirtualConnectorInSteamPerAppState() && ulKey != 0 &&
+            ulKey != k_ulSteamBootstrapperKey && !VirtualConnectorKeyIsSteam( ulKey );
+    }
+
     static inline std::string_view VirtualConnectorStrategyToString( VirtualConnectorStrategy eStrategy )
     {
         switch ( eStrategy )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4317,6 +4317,8 @@ static void set_wm_state( xwayland_ctx_t *ctx, Window win, uint32_t state )
 
 void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win_t* > &vecPossibleFocusWindows )
 {
+	// A bump during the pass has to leave the focus dirty.
+	uint64_t ulFocusSerial = GetFocusSerial();
 	xwayland_ctx_t *ctx = this;
 
 	steamcompmgr_win_t *inputFocus = NULL;
@@ -4632,7 +4634,7 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 
 	XFree(children);
 
-	ctx->focus.ulCurrentFocusSerial = GetFocusSerial();
+	ctx->focus.ulCurrentFocusSerial = ulFocusSerial;
 }
 
 wlr_surface *win_surface(steamcompmgr_win_t *window)
@@ -4776,6 +4778,8 @@ DumpFocusInfo()
 static void
 determine_and_apply_focus( global_focus_t *pFocus )
 {
+	// A bump during the pass has to leave the focus dirty.
+	uint64_t ulFocusSerial = GetFocusSerial();
 	gamescope_xwayland_server_t *root_server = wlserver_get_xwayland_server(0);
 	xwayland_ctx_t *root_ctx = root_server->ctx.get();
 	global_focus_t previousLocalFocus = *pFocus;
@@ -5250,7 +5254,7 @@ determine_and_apply_focus( global_focus_t *pFocus )
 		wlserver_unlock();
 	}
 
-	pFocus->ulCurrentFocusSerial = GetFocusSerial();
+	pFocus->ulCurrentFocusSerial = ulFocusSerial;
 }
 
 static void

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -833,9 +833,15 @@ void MakeFocusDirty()
 	s_ulFocusSerial++;
 }
 
-static inline uint64_t GetFocusSerial()
+uint64_t GetFocusSerial()
 {
 	return s_ulFocusSerial;
+}
+
+static std::atomic<uint64_t> s_ulAppliedFocusSerial = 0ul;
+uint64_t GetAppliedFocusSerial()
+{
+	return s_ulAppliedFocusSerial;
 }
 
 bool focus_t::IsDirty()
@@ -952,6 +958,23 @@ global_focus_t *GetCurrentGamepadFocus()
 		return &iter->second;
 
 	return GetCurrentFocus();
+}
+
+// A held laser press waits on this, so flush the X focus before publishing it.
+// The focuses record what they applied, a serial bumped mid-pass is not claimed.
+static void publish_applied_focus_serial()
+{
+	uint64_t ulApplied = GetFocusSerial();
+	for ( auto &iter : g_VirtualConnectorFocuses )
+		ulApplied = std::min( ulApplied, iter.second.ulCurrentFocusSerial );
+
+	if ( ulApplied == s_ulAppliedFocusSerial )
+		return;
+
+	gamescope_xwayland_server_t *server = NULL;
+	for ( size_t i = 0; ( server = wlserver_get_xwayland_server( i ) ); i++ )
+		XFlush( server->ctx->dpy );
+	s_ulAppliedFocusSerial = ulApplied;
 }
 
 // The focus whose focusWindow is w, ignoring the other window roles.
@@ -9956,6 +9979,8 @@ steamcompmgr_main(int argc, char **argv)
 				hasRepaint = true;
 			}
 		}
+
+		publish_applied_focus_serial();
 
 		if ( g_bPendingFocusInfo.exchange( false ) )
 			DumpFocusInfo();

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4568,6 +4568,15 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 			ctx->cursor->hide();
 		}
 
+		// Both sides of an X focus move get a repaint from Wine.
+		if ( ctx->currentKeyboardFocusWindow != keyboardFocusWindow )
+		{
+			uint64_t ulNow = get_time_in_nanos();
+			if ( steamcompmgr_win_t *pOld = find_win( ctx, ctx->currentKeyboardFocusWindow ) )
+				pOld->last_focus_change_time = ulNow;
+			keyboardFocusWin->last_focus_change_time = ulNow;
+		}
+
 		ctx->focus.inputFocusWindow = inputFocus;
 		ctx->focus.inputFocusMode = inputFocus->inputFocusMode;
 		ctx->currentKeyboardFocusWindow = keyboardFocusWindow;
@@ -7991,6 +8000,7 @@ static TempUpscaleImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t
 }
 
 gamescope::ConVar<bool> cv_surface_update_force_only_current_surface( "surface_update_force_only_current_surface", false, "Force updates to apply only to the current surface, ignoring commits for other surfaces." );
+gamescope::ConVar<uint64_t> cv_surface_update_focus_repaint_time( "surface_update_focus_repaint_time", 500'000'000ul, "Ignore commits for a window's other surfaces this long after its X focus changes, Wine repaints the window then. 0 disables. In nanoseconds." );
 
 void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, ResListEntry_t& reslistentry)
 {
@@ -8028,15 +8038,22 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 	bool bHasDamage = ( reslistentry.surf->buffer_damage.extents.x2 - reslistentry.surf->buffer_damage.extents.x1 ) > 2 &&
 					  ( reslistentry.surf->buffer_damage.extents.y2 - reslistentry.surf->buffer_damage.extents.y1 ) > 2;
 
+	// Wine repaints the X window when its foreground state changes, so for a while
+	// after a focus move an X commit beside the override surface is that, not content.
+	uint64_t ulNow = get_time_in_nanos();
+	bool bFocusRepaint = w->override_surface() && cv_surface_update_focus_repaint_time &&
+		ulNow - w->last_focus_change_time < cv_surface_update_focus_repaint_time;
+
 	// If we have an override surface, make sure this commit is for the current surface
 	// or if the commit is probably bogus.
-	bool bOnlyCurrentSurface = w->bHasHadNonSRGBColorSpace || bPossiblyBogus || !bHasDamage || cv_surface_update_force_only_current_surface;
+	bool bOnlyCurrentSurface = w->bHasHadNonSRGBColorSpace || bPossiblyBogus || !bHasDamage || bFocusRepaint || cv_surface_update_force_only_current_surface;
 
 	bool for_current_surface = !w->override_surface() || w->current_surface() == reslistentry.surf;
 
 	if ( !for_current_surface )
 	{
-		xwm_log.debugf( "Got commit not for current surface." );
+		xwm_log.debugf( "Got commit not for current surface, %s it, focus changed %.1f ms ago.",
+			bOnlyCurrentSurface ? "dropping" : "showing", ( ulNow - w->last_focus_change_time ) / 1'000'000.0 );
 	}
 
 	if ( bOnlyCurrentSurface && !for_current_surface )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -943,6 +943,17 @@ global_focus_t *GetCurrentMouseFocus()
 	return GetCurrentFocus();
 }
 
+global_focus_t *GetCurrentGamepadFocus()
+{
+	uint64_t ulKey = GetBackend()->GetCurrentGamepadConnector() ? GetBackend()->GetCurrentGamepadConnector()->GetVirtualConnectorKey() : 0;
+
+	auto iter = g_VirtualConnectorFocuses.find( ulKey );
+	if ( iter != g_VirtualConnectorFocuses.end() )
+		return &iter->second;
+
+	return GetCurrentFocus();
+}
+
 // The focus whose focusWindow is w, ignoring the other window roles.
 // Guards w because a null one would match any focus without a window.
 global_focus_t *GetFocusForWindow( steamcompmgr_win_t *w )
@@ -5159,17 +5170,20 @@ determine_and_apply_focus( global_focus_t *pFocus )
 		focused_keyboard_display = get_win_display_name(pFocus->keyboardFocusWindow);
 	}
 
+	// Steam routes the controller by the focused app, so it follows the gamepad focus.
+	if ( steamMode && pFocus == GetCurrentGamepadFocus() )
+	{
+		XChangeProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeFocusedAppAtom, XA_CARDINAL, 32, PropModeReplace,
+						(unsigned char *)&focusedAppId, focusedAppId != 0 ? 1 : 0 );
+
+		XChangeProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeFocusedAppGfxAtom, XA_CARDINAL, 32, PropModeReplace,
+						(unsigned char *)&focusedBaseAppId, focusedBaseAppId != 0 ? 1 : 0 );
+
+		XFlush( root_ctx->dpy );
+	}
+
 	if ( pFocus == GetCurrentFocus() )
 	{
-		if ( steamMode )
-		{
-			XChangeProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeFocusedAppAtom, XA_CARDINAL, 32, PropModeReplace,
-							(unsigned char *)&focusedAppId, focusedAppId != 0 ? 1 : 0 );
-
-			XChangeProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeFocusedAppGfxAtom, XA_CARDINAL, 32, PropModeReplace,
-							(unsigned char *)&focusedBaseAppId, focusedBaseAppId != 0 ? 1 : 0 );
-		}
-
 		XChangeProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeFocusedWindowAtom, XA_CARDINAL, 32, PropModeReplace,
 						(unsigned char *)&focusedWindow, focusedWindow != 0 ? 1 : 0 );
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6258,6 +6258,8 @@ handle_system_tray_opcode(xwayland_ctx_t *ctx, XClientMessageEvent *ev)
 	}
 }
 
+gamescope::ConVar<bool> cv_virtual_connector_refuse_iconify( "virtual_connector_refuse_iconify", true, "Put a window shown on its own virtual connector straight back to normal state when it asks to be iconified." );
+
 /* See http://tronche.com/gui/x/icccm/sec-4.html#s-4.1.4 */
 static void
 handle_wm_change_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessageEvent *ev)
@@ -6265,6 +6267,15 @@ handle_wm_change_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessag
 	long state = ev->data.l[0];
 
 	if (state == ICCCM_ICONIC_STATE) {
+		// FIXME: Wine minimizes an exclusive-fullscreen game that loses foreground, and on its own
+		// virtual connector it stays on screen regardless. A game per Xwayland is the real fix, this flashes black once.
+		if ( cv_virtual_connector_refuse_iconify && !gamescope::VirtualConnectorIsSingleOutput() && GetFocusForWindow( w ) )
+		{
+			xwm_log.debugf("Refusing WM_CHANGE_STATE to ICONIC for window 0x%lx on its own virtual connector", w->xwayland().id);
+			set_wm_state( ctx, w->xwayland().id, ICCCM_NORMAL_STATE );
+			return;
+		}
+
 		xwm_log.debugf("Faking WM_CHANGE_STATE to ICONIC for window 0x%lx", w->xwayland().id);
 		set_wm_state( ctx, w->xwayland().id, ICCCM_ICONIC_STATE );
 	} else {

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -138,6 +138,9 @@ extern uint64_t g_lastWinSeq;
 
 void nudge_steamcompmgr( void );
 void MakeFocusDirty();
+uint64_t GetFocusSerial();
+// The newest focus serial steamcompmgr has applied and flushed to X.
+uint64_t GetAppliedFocusSerial();
 void force_repaint( void );
 
 // Per-connector stat snapshot for typed mangoapp streams.

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -145,6 +145,7 @@ struct steamcompmgr_win_t {
 
 	uint64_t last_commit_first_latch_time = 0;
 	uint64_t last_commit_present_time = 0;
+	uint64_t last_focus_change_time = 0;
 
 	bool hasHwndStyle = false;
 	uint32_t hwndStyle = 0;


### PR DESCRIPTION
This lets multiple virtual connectors running on the same Xwayland instance switch the laser mouse between one connector and another without needing to click to focus the new window the laser is pointing at. My test for this has been launching Balatro and Hollow Knight: Silksong side-by-side, with Balatro in borderless and Silksong in exclusive fullscreen, calling up the laser mouse, then moving it from one to the other.