### PR TITLE
WaylandBackend: Ignore more libdecor pointer events

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -3060,6 +3060,7 @@ namespace gamescope
 	}
 	void CWaylandInputThread::Wayland_Pointer_Motion( wl_pointer *pPointer, uint32_t uTime, wl_fixed_t fSurfaceX, wl_fixed_t fSurfaceY )
 	{
+		// Ignore any pointer events for which the `enter` event surface didn't pass `IsGamescopeToplevel` (libdecor frame)
 		if ( !m_bMouseEntered )
 			return;
 
@@ -3094,6 +3095,9 @@ namespace gamescope
     }
     void CWaylandInputThread::Wayland_Pointer_Button( wl_pointer *pPointer, uint32_t uSerial, uint32_t uTime, uint32_t uButton, uint32_t uState )
     {
+        // Ignore any pointer events for which the `enter` event surface didn't pass `IsGamescopeToplevel` (libdecor frame)
+        if ( !m_bMouseEntered )
+            return;
         // Don't do any motion/movement stuff if we don't have kb focus
         if ( !cv_wayland_mouse_warp_without_keyboard_focus && !m_bKeyboardEntered )
             return;
@@ -3104,19 +3108,35 @@ namespace gamescope
     }
     void CWaylandInputThread::Wayland_Pointer_Axis( wl_pointer *pPointer, uint32_t uTime, uint32_t uAxis, wl_fixed_t fValue )
     {
+        // Ignore any pointer events for which the `enter` event surface didn't pass `IsGamescopeToplevel` (libdecor frame)
+        if ( !m_bMouseEntered )
+            return;
     }
     void CWaylandInputThread::Wayland_Pointer_Axis_Source( wl_pointer *pPointer, uint32_t uAxisSource )
     {
+        // Ignore any pointer events for which the `enter` event surface didn't pass `IsGamescopeToplevel` (libdecor frame)
+        if ( !m_bMouseEntered )
+            return;
+
         m_uAxisSource = uAxisSource;
     }
     void CWaylandInputThread::Wayland_Pointer_Axis_Stop( wl_pointer *pPointer, uint32_t uTime, uint32_t uAxis )
     {
+        // Ignore any pointer events for which the `enter` event surface didn't pass `IsGamescopeToplevel` (libdecor frame)
+        if ( !m_bMouseEntered )
+            return;
     }
     void CWaylandInputThread::Wayland_Pointer_Axis_Discrete( wl_pointer *pPointer, uint32_t uAxis, int32_t nDiscrete )
     {
+        // Ignore any pointer events for which the `enter` event surface didn't pass `IsGamescopeToplevel` (libdecor frame)
+        if ( !m_bMouseEntered )
+            return;
     }
     void CWaylandInputThread::Wayland_Pointer_Axis_Value120( wl_pointer *pPointer, uint32_t uAxis, int32_t nValue120 )
     {
+        // Ignore any pointer events for which the `enter` event surface didn't pass `IsGamescopeToplevel` (libdecor frame)
+        if ( !m_bMouseEntered )
+            return;
         if ( !cv_wayland_mouse_warp_without_keyboard_focus && !m_bKeyboardEntered )
             return;
 


### PR DESCRIPTION
We reject pointer enter and leave events for surfaces not tagged as `gamescope` planes such as surfaces owned by the `libdecor` frame. However we didn't gate any of other pointer events on whether it related to a `gamescope` surface.

This resulted in pointer events being ignored after they were received by a `libdecor` surface in certain software. This is likely to happen after moving or resizing the window.

I suspect this is the cause of https://github.com/ValveSoftware/gamescope/issues/2299

Bellow you can see another issue caused by this. The video shows the gtk3-demo app under gamescope. After the gamescope window is resized, as the pointer moves over the gamescope plane the gtk3-demo window gets resized to be smaller in the axis in which the gamescope window was resized.
I think this is from gamescope sending the mouse down event from the resize but not a mouse up.
Clicks after this happens don't seem to be registered.

```bash
flatpak run --device=dri --socket=wayland --filesystem=host --command=sh org.freedesktop.Platform//25.08 -c "env PATH=\"\${PATH}:/usr/lib/extensions/vulkan/gamescope/bin\" gamescope -- env GDK_BACKEND=x11  /run/host/bin/gtk3-demo"
```

### gamescope 3.16.28

[Screencast From 2026-09-02 22-46-00_short.webm](https://github.com/user-attachments/assets/9e908e7d-cc8c-4d96-9163-34f65db6b90a)

### This branch

[Screencast From 2026-09-02 22-45-07_short.webm](https://github.com/user-attachments/assets/64db8e69-e8d3-4c36-9265-62ccdd5e8237) 
