### PR TITLE
Reduce memory usage + add mangoapp tests

### DIFF
--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -2,6 +2,8 @@
 #include <unistd.h>
 #include <sys/msg.h>
 #include <algorithm>
+#include <cstddef>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -58,6 +60,9 @@ struct MangoappRawMsg_t
     long mtype;
     uint8_t data[1016];
 };
+// The control layout is folded straight out of one of these.
+static_assert(offsetof(MangoappRawMsg_t, data) == sizeof(long));
+static_assert(sizeof(MangoappRawMsg_t) >= sizeof(mangoapp_ctrl_msgid1_v1));
 
 // The queue outlives gamescope and types start over every run, so leave nothing behind.
 void mangoapp_drop_stream( uint32_t uMsgType )
@@ -96,16 +101,13 @@ struct MangoappPendingControl_t
 static std::vector<MangoappPendingControl_t> s_PendingControl;
 
 // System V hands each message to one reader, so fan it out to every instance.
-// Returns how many sends are still waiting for room.
-uint32_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes )
+// Drains even with no instance, so the caller still sees what was asked.
+// Sends still waiting for room, in order. Returns how many remain.
+uint32_t mangoapp_flush_control( const std::vector<uint32_t> &msgTypes )
 {
-    if (msgTypes.empty())
-        return 0;
-
     if (!inited)
         init_mangoapp();
 
-    // Finish the last fan-out first, so no instance sees commands out of order.
     while (!s_PendingControl.empty())
     {
         const MangoappPendingControl_t &pending = s_PendingControl.front();
@@ -114,6 +116,17 @@ uint32_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes )
             return (uint32_t) s_PendingControl.size();
         s_PendingControl.erase(s_PendingControl.begin());
     }
+    return 0;
+}
+
+MangoappControlRelay_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes )
+{
+    MangoappControlRelay_t relay;
+
+    // Finish the last fan-out first, so no instance sees commands out of order.
+    relay.uHeldBack = mangoapp_flush_control( msgTypes );
+    if (relay.uHeldBack)
+        return relay;
 
     uint32_t uDeferred = 0;
     MangoappRawMsg_t rawMsg;
@@ -126,6 +139,8 @@ uint32_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes )
         // Truncated, so fanning it out would hand every instance a corrupt message.
         if (size == ssize_t(sizeof(rawMsg.data)))
             continue;
+
+        mangoapp_fold_control(&rawMsg, sizeof(long) + size, relay);
 
         // A type nobody reads yet holds the message until that instance starts.
         for (uint32_t uMsgType : msgTypes)
@@ -142,7 +157,34 @@ uint32_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes )
         if (uDeferred)
             break;
     }
-    return uDeferred;
+    relay.uHeldBack = uDeferred;
+    return relay;
+}
+
+// A fresh instance starts on the file alone, so what mangohudctl asked goes over its own control type.
+void mangoapp_post_control( uint32_t uMsgType, uint8_t uNoDisplay, bool bStartLogging )
+{
+    if (!inited)
+        init_mangoapp();
+
+    mangoapp_ctrl_msgid1_v1 ctrl = {};
+    ctrl.hdr.msg_type = MangoappControlMsgType(uMsgType);
+    ctrl.hdr.ctrl_msg_type = 1;
+    ctrl.hdr.version = 1;
+    ctrl.no_display = uNoDisplay;
+    ctrl.log_session = bStartLogging ? 1 : 0;
+
+    MangoappPendingControl_t pending = { .uMsgType = uMsgType, .size = sizeof(ctrl) - sizeof(long) };
+    memcpy(&pending.msg, &ctrl, sizeof(ctrl));
+    // Behind anything still held back, so no instance sees commands out of order.
+    if (!s_PendingControl.empty() || msgsnd(msgid, &pending.msg, pending.size, IPC_NOWAIT) < 0)
+        s_PendingControl.push_back(pending);
+
+    // An untagged mangoapp reads the shared type instead. A tagged one never does, so the relay
+    // hands this copy back to it, and both commands are sets, so the repeat changes nothing.
+    pending.msg.mtype = k_uMangoappControlMsgType;
+    if (!s_PendingControl.empty() || msgsnd(msgid, &pending.msg, pending.size, IPC_NOWAIT) < 0)
+        s_PendingControl.push_back(pending);
 }
 
 void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uint64_t latency_ns, uint32_t uMsgType ) {

--- a/src/mangoapp_config.h
+++ b/src/mangoapp_config.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+// Whether mangoapp would show its overlay, read the way mangoapp reads its config file
+// and MANGOHUD_CONFIG, which replaces the file unless it sets read_cfg.
+using mangoapp_options_t = std::unordered_map<std::string, std::string>;
+
+static inline std::string_view mangoapp_config_trim( std::string_view s )
+{
+	const size_t start = s.find_first_not_of( " \t\r" );
+	if ( start == std::string_view::npos )
+		return {};
+	const size_t end = s.find_last_not_of( " \t\r" );
+	return s.substr( start, end - start + 1 );
+}
+
+static inline void mangoapp_config_parse( std::string_view sConfig, char cSeparator, mangoapp_options_t &options )
+{
+	while ( !sConfig.empty() )
+	{
+		size_t end = sConfig.find( cSeparator );
+		std::string_view sLine = sConfig.substr( 0, end );
+		sConfig = end == std::string_view::npos ? std::string_view{} : sConfig.substr( end + 1 );
+
+		if ( size_t comment = sLine.find( '#' ); comment != std::string_view::npos )
+			sLine = sLine.substr( 0, comment );
+
+		size_t equal = sLine.find( '=' );
+		std::string_view sParam = mangoapp_config_trim( sLine.substr( 0, equal ) );
+		std::string_view sValue = equal == std::string_view::npos ? std::string_view{ "1" } : mangoapp_config_trim( sLine.substr( equal + 1 ) );
+		if ( !sParam.empty() )
+			options[ std::string{ sParam } ] = std::string{ sValue };
+	}
+}
+
+static inline bool mangoapp_config_visible( std::string_view sFile, std::string_view sEnv = {} )
+{
+	mangoapp_options_t envOptions;
+	mangoapp_config_parse( sEnv, ',', envOptions );
+
+	mangoapp_options_t options;
+	auto readCfg = envOptions.find( "read_cfg" );
+	if ( sEnv.empty() || ( readCfg != envOptions.end() && readCfg->second != "0" ) )
+		mangoapp_config_parse( sFile, '\n', options );
+	for ( auto &iter : envOptions )
+		options[ iter.first ] = iter.second;
+
+	if ( auto iter = options.find( "no_display" ); iter != options.end() )
+		return strtol( iter->second.c_str(), nullptr, 0 ) == 0;
+
+	if ( auto iter = options.find( "preset" ); iter != options.end() )
+	{
+		// Only the first preset is live, the rest are the toggle_preset cycle.
+		char *pEnd = nullptr;
+		long nPreset = strtol( iter->second.c_str(), &pEnd, 10 );
+		if ( pEnd != iter->second.c_str() && nPreset == 0 )
+			return false;
+	}
+
+	return true;
+}

--- a/src/mangoapp_control.h
+++ b/src/mangoapp_control.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+// mangohudctl's message, as mangoapp_proto.h lays it out.
+struct mangoapp_ctrl_header {
+	long msg_type;
+	uint32_t ctrl_msg_type;
+	uint32_t version;
+} __attribute__((packed));
+
+struct mangoapp_ctrl_msgid1_v1 {
+	struct mangoapp_ctrl_header hdr;
+
+	uint8_t no_display;      // 0 = ignore, 1 = hide, 2 = show, 3 = toggle
+	uint8_t log_session;
+	char log_session_name[64];
+	uint8_t reload_config;   // 0 = ignore, 1 or 3 = reload
+} __attribute__((packed));
+
+// What one drain of the shared control type asked of the overlay, folded in order.
+struct MangoappControlRelay_t
+{
+	uint32_t uHeldBack = 0;
+	// The last explicit no_display set since the last reload, true hides.
+	std::optional<bool> obHide;
+	// A toggle left over after the last set, or with no set at all.
+	bool bToggle = false;
+	bool bReloadConfig = false;
+	// The same for log_session, a reload stops logging in mangoapp.
+	std::optional<bool> obLogging;
+	bool bToggleLogging = false;
+};
+
+// Folds a whole queue message the way mangoapp's control thread applies it, log_session, reload, then no_display.
+static inline void mangoapp_fold_control( const void *pMsg, size_t size, MangoappControlRelay_t &relay )
+{
+	if ( size < sizeof( mangoapp_ctrl_msgid1_v1 ) )
+		return;
+
+	const auto *pCtrl = static_cast<const mangoapp_ctrl_msgid1_v1 *>( pMsg );
+	if ( pCtrl->hdr.ctrl_msg_type != 1 )
+		return;
+
+	switch ( pCtrl->log_session )
+	{
+		case 1: relay.obLogging = true;  relay.bToggleLogging = false; break;
+		case 2: relay.obLogging = false; relay.bToggleLogging = false; break;
+		case 3:
+			if ( relay.obLogging )
+				relay.obLogging = !*relay.obLogging;
+			else
+				relay.bToggleLogging = !relay.bToggleLogging;
+			break;
+		default: break;
+	}
+
+	if ( pCtrl->reload_config == 1 || pCtrl->reload_config == 3 )
+	{
+		relay.bReloadConfig = true;
+		relay.obHide.reset();
+		relay.bToggle = false;
+		relay.obLogging = false;
+		relay.bToggleLogging = false;
+	}
+
+	switch ( pCtrl->no_display )
+	{
+		case 1: relay.obHide = true;  relay.bToggle = false; break;
+		case 2: relay.obHide = false; relay.bToggle = false; break;
+		case 3:
+			if ( relay.obHide )
+				relay.obHide = !*relay.obHide;
+			else
+				relay.bToggle = !relay.bToggle;
+			break;
+		default: break;
+	}
+}

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3399,6 +3399,31 @@ static bool vulkan_make_output_images( VulkanOutput_t *pOutput )
 	return true;
 }
 
+// Without a swapchain the shared images are ours to make, so they wait for their first use.
+static bool vulkan_defer_output_images()
+{
+	return !GetBackend()->UsesVulkanSwapchain();
+}
+
+static bool vulkan_ensure_output_images()
+{
+	if ( !vulkan_defer_output_images() )
+		return true;
+
+	VulkanOutput_t *pOutput = &g_output;
+	if ( !pOutput->outputImages.empty() && pOutput->outputImages[0] )
+		return true;
+
+	vk_log.debugf( "Making the shared output images on first use" );
+	if ( vulkan_make_output_images( pOutput ) )
+		return true;
+
+	// A half-made set would pass the check above, so the next use tries again from nothing.
+	pOutput->outputImages.clear();
+	pOutput->outputImagesPartialOverlay.clear();
+	return false;
+}
+
 bool vulkan_remake_output_images()
 {
 	VulkanOutput_t *pOutput = &g_output;
@@ -3411,6 +3436,14 @@ bool vulkan_remake_output_images()
 		pScreenshotTexture = nullptr;
 	for (auto& pCaptureTexture : pOutput->pCaptureTextures)
 		pCaptureTexture = nullptr;
+
+	if ( vulkan_defer_output_images() )
+	{
+		pOutput->outputImages.clear();
+		pOutput->outputImagesPartialOverlay.clear();
+		pOutput->temporaryHackyBlankImage = vulkan_create_debug_blank_texture();
+		return true;
+	}
 
 	bool bRet = vulkan_make_output_images( pOutput );
 	assert( bRet );
@@ -3490,7 +3523,9 @@ bool vulkan_make_output()
 			return false;
 		}
 
-		if ( !vulkan_make_output_images( pOutput ) )
+		if ( vulkan_defer_output_images() )
+			pOutput->temporaryHackyBlankImage = vulkan_create_debug_blank_texture();
+		else if ( !vulkan_make_output_images( pOutput ) )
 			return false;
 	}
 
@@ -4091,6 +4126,9 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 	{
 		g_reshadeManager.clear();
 	}
+
+	if ( !pOutputOverride && !vulkan_ensure_output_images() )
+		return std::nullopt;
 
 	gamescope::Rc<CVulkanTexture> compositeImage;
 	if ( pOutputOverride )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -9260,14 +9260,18 @@ static void relay_mangoapp_control()
 	if ( has_legacy_mangoapp_reader() )
 		return;
 
-	// One tag is enough to know these instances read a control type at all.
+	// One tag is enough to know these instances read a control type at all. A hidden one is unmapped, so look at every window.
 	bool bAnyTagged = false;
-	for ( auto &iter : g_VirtualConnectorFocuses )
+	gamescope_xwayland_server_t *server = NULL;
+	for (size_t i = 0; !bAnyTagged && (server = wlserver_get_xwayland_server(i)); i++)
 	{
-		if ( iter.second.externalOverlayWindow && iter.second.externalOverlayWindow->uMangoappMsgType )
+		for ( steamcompmgr_win_t *w = server->ctx->list; w; w = w->xwayland().next )
 		{
-			bAnyTagged = true;
-			break;
+			if ( w->uMangoappMsgType )
+			{
+				bAnyTagged = true;
+				break;
+			}
 		}
 	}
 	if ( !bAnyTagged )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -9131,6 +9131,10 @@ static void UpdateMangoappInstances()
 		if ( gamescope::VirtualConnectorKeyIsSteam( iter.first ) )
 			continue;
 
+		// Nothing to overlay yet. Key 0 under PerAppId never gets a window at all.
+		if ( !iter.second.focusWindow )
+			continue;
+
 		if ( s_MangoappInstances.contains( iter.first ) )
 			continue;
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <array>
 #include <fstream>
+#include <iterator>
 #include <string>
 #include <filesystem>
 #include <unordered_map>
@@ -57,6 +58,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/poll.h>
+#include <sys/inotify.h>
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <sys/types.h>
@@ -82,6 +84,7 @@
 #include "rendervulkan.hpp"
 #include "steamcompmgr.hpp"
 #include "focus_placement.h"
+#include "mangoapp_config.h"
 #include "vblankmanager.hpp"
 #include "log.hpp"
 #include "Utils/Defer.h"
@@ -9105,7 +9108,10 @@ struct MangoappInstance_t
 {
 	uint32_t uMsgType = 0;
 	pid_t nReaperPid = -1;
+	uint64_t ulUnwantedSinceNs = 0;
 };
+
+gamescope::ConVar<int> cv_mangoapp_teardown_grace_ms{ "mangoapp_teardown_grace_ms", 10000, "Keep a per-connector mangoapp this long after it stops being wanted" };
 
 // Key -> spawned mangoapp. Steamcompmgr thread only.
 static std::unordered_map<gamescope::VirtualConnectorKey_t, MangoappInstance_t> s_MangoappInstances;
@@ -9119,10 +9125,116 @@ static uint32_t mangoapp_msg_type_for_key( gamescope::VirtualConnectorKey_t ulKe
 	return iter != s_MangoappInstances.end() ? iter->second.uMsgType : 0;
 }
 
+// Steam toggles the overlay by rewriting MANGOHUD_CONFIGFILE, a hidden instance still costs a GL context and a swapchain.
+static std::filesystem::path s_MangoappConfigPath;
+static bool s_bMangoappConfigVisible = true;
+// mangohudctl can show or hide without touching the file, until the next reload.
+static std::optional<bool> s_obMangoappControlVisible;
+// A mangohudctl logging session, mangoapp logs hidden and a reload stops it.
+static bool s_bMangoappLogging = false;
+static std::unique_ptr<gamescope::CFunctionWaitable> s_pMangoappConfigWaitable;
+
+static void ReadMangoappConfig()
+{
+	std::string sConfig;
+	if ( !s_MangoappConfigPath.empty() )
+	{
+		std::ifstream file( s_MangoappConfigPath );
+		// Steam may be between a delete and a rewrite, keep what we had.
+		if ( !file )
+			return;
+		sConfig.assign( std::istreambuf_iterator<char>( file ), std::istreambuf_iterator<char>() );
+	}
+
+	const char *pszEnvConfig = getenv( "MANGOHUD_CONFIG" );
+	bool bVisible = mangoapp_config_visible( sConfig, pszEnvConfig ? pszEnvConfig : "" );
+	if ( bVisible != s_bMangoappConfigVisible )
+		xwm_log.infof( "mangoapp config now %s the overlay", bVisible ? "shows" : "hides" );
+	s_bMangoappConfigVisible = bVisible;
+	// A reload puts every instance back on the file's state and stops its logging.
+	s_obMangoappControlVisible.reset();
+	s_bMangoappLogging = false;
+}
+
+static void WatchMangoappConfig()
+{
+	// Not the convar, the watch has to outlive a runtime flip of it.
+	if ( !g_bLaunchMangoapp || !GetBackend()->UsesVirtualConnectors() || !steamMode )
+		return;
+
+	const char *pszConfigPath = getenv( "MANGOHUD_CONFIGFILE" );
+	if ( pszConfigPath && *pszConfigPath )
+		s_MangoappConfigPath = pszConfigPath;
+	ReadMangoappConfig();
+
+	if ( s_MangoappConfigPath.empty() )
+		return;
+
+	int nFD = inotify_init1( IN_NONBLOCK | IN_CLOEXEC );
+	if ( nFD < 0 )
+	{
+		xwm_log.errorf_errno( "inotify_init1 failed, mangoapp visibility will not follow the config" );
+		return;
+	}
+
+	// The directory, so a rewrite by rename is seen, without IN_MODIFY so a half-written file is not.
+	std::filesystem::path dir = s_MangoappConfigPath.parent_path();
+	if ( dir.empty() )
+		dir = ".";
+	if ( inotify_add_watch( nFD, dir.c_str(), IN_CLOSE_WRITE | IN_MOVED_TO | IN_MOVED_FROM | IN_DELETE ) < 0 )
+	{
+		xwm_log.errorf_errno( "Failed to watch %s", dir.c_str() );
+		close( nFD );
+		return;
+	}
+
+	s_pMangoappConfigWaitable = std::make_unique<gamescope::CFunctionWaitable>( nFD, [ nFD ]()
+	{
+		alignas( struct inotify_event ) char buf[ 4096 ];
+		bool bChanged = false;
+		for (;;)
+		{
+			ssize_t nRead = read( nFD, buf, sizeof( buf ) );
+			if ( nRead <= 0 )
+				break;
+			for ( ssize_t nOffset = 0; nOffset < nRead; )
+			{
+				const struct inotify_event *pEvent = reinterpret_cast<const struct inotify_event *>( buf + nOffset );
+				// An overflow may have eaten ours, a re-read is cheap.
+				if ( pEvent->mask & IN_Q_OVERFLOW )
+					bChanged = true;
+				else if ( pEvent->len && s_MangoappConfigPath.filename().native() == pEvent->name )
+					bChanged = true;
+				nOffset += sizeof( *pEvent ) + pEvent->len;
+			}
+		}
+		if ( bChanged )
+			ReadMangoappConfig();
+	});
+	g_SteamCompMgrWaiter.AddWaitable( s_pMangoappConfigWaitable.get() );
+}
+
+static bool mangoapp_overlay_visible()
+{
+	return s_obMangoappControlVisible.value_or( s_bMangoappConfigVisible );
+}
+
+// Only where Steam drives the overlay. Elsewhere mangoapp's own keybinds are how it comes back, and they need it running.
+static bool mangoapp_instances_wanted()
+{
+	if ( !steamMode )
+		return true;
+
+	// Hidden, a logging instance still has work to do.
+	return mangoapp_overlay_visible() || s_bMangoappLogging;
+}
+
 static void UpdateMangoappInstances()
 {
 	if ( !mangoapp_per_connector() )
 		return;
+
+	const bool bWanted = mangoapp_instances_wanted();
 
 	static bool s_bLoggedSpawnFail = false;
 	for ( const auto &iter : g_VirtualConnectorFocuses )
@@ -9135,7 +9247,7 @@ static void UpdateMangoappInstances()
 		if ( !iter.second.focusWindow )
 			continue;
 
-		if ( s_MangoappInstances.contains( iter.first ) )
+		if ( !bWanted || s_MangoappInstances.contains( iter.first ) )
 			continue;
 
 		// The control type is the stream type plus one, so types go in pairs.
@@ -9164,11 +9276,31 @@ static void UpdateMangoappInstances()
 
 		s_uNextMangoappMsgType += 2;
 		s_MangoappInstances[ iter.first ] = MangoappInstance_t{ .uMsgType = uMsgType, .nReaperPid = nPid };
+
+		// The new instance starts on the file, so hand it what mangohudctl asked since.
+		uint8_t uNoDisplay = 0;
+		if ( mangoapp_overlay_visible() != s_bMangoappConfigVisible )
+			uNoDisplay = mangoapp_overlay_visible() ? 2 : 1;
+		if ( uNoDisplay || s_bMangoappLogging )
+			mangoapp_post_control( uMsgType, uNoDisplay, s_bMangoappLogging );
 	}
 
+	const uint64_t ulNow = get_time_in_nanos();
 	for ( auto iter = s_MangoappInstances.begin(); iter != s_MangoappInstances.end(); )
 	{
-		if ( !g_VirtualConnectorFocuses.contains( iter->first ) )
+		const bool bGone = !g_VirtualConnectorFocuses.contains( iter->first );
+		if ( !bGone )
+		{
+			// A stopped logging session is still writing its files, and a quick flip back is free.
+			if ( bWanted )
+				iter->second.ulUnwantedSinceNs = 0;
+			else if ( !iter->second.ulUnwantedSinceNs )
+				iter->second.ulUnwantedSinceNs = ulNow;
+		}
+		const uint64_t ulGraceNs = uint64_t( std::max( 0, int( cv_mangoapp_teardown_grace_ms ) ) ) * 1'000'000ul;
+		const bool bExpired = iter->second.ulUnwantedSinceNs && ulNow - iter->second.ulUnwantedSinceNs >= ulGraceNs;
+
+		if ( bGone || bExpired )
 		{
 			pid_t nReaperPid = iter->second.nReaperPid;
 			gamescope::Process::KillProcess( nReaperPid, SIGTERM );
@@ -9241,7 +9373,8 @@ static void publish_mangoapp_connector_snapshots()
 	for ( auto &iter : g_VirtualConnectorFocuses )
 	{
 		uint32_t uMsgType = iter.second.externalOverlayWindow ? iter.second.externalOverlayWindow->uMangoappMsgType : 0;
-		if ( !uMsgType )
+		// The window of a torn-down instance lingers a few frames, its type is gone.
+		if ( !uMsgType || uMsgType != mangoapp_msg_type_for_key( iter.first ) )
 			continue;
 
 		auto &lastBasePlane = s_LastBasePlanes[ uMsgType ];
@@ -9257,7 +9390,22 @@ static void publish_mangoapp_connector_snapshots()
 // mangohudctl posts one control message for every instance to act on.
 static void relay_mangoapp_control()
 {
-	if ( !GetBackend()->UsesVirtualConnectors() || s_MangoappInstances.empty() )
+	if ( !mangoapp_per_connector() )
+		return;
+
+	// Every spawned instance, one still starting finds the message when it reads.
+	std::vector<uint32_t> msgTypes;
+	msgTypes.reserve( s_MangoappInstances.size() );
+	for ( const auto &iter : s_MangoappInstances )
+		msgTypes.push_back( iter.second.uMsgType );
+
+	// Sends that did not fit go out whether or not the drain below runs, an untagged reader waits on them too.
+	static bool s_bLoggedHeldBack = false;
+	uint32_t uHeldBack = mangoapp_flush_control( msgTypes );
+	if ( uHeldBack && !s_bLoggedHeldBack )
+		xwm_log.warnf( "Holding back %u mangoapp control message(s), the queue is full", uHeldBack );
+	s_bLoggedHeldBack = uHeldBack != 0;
+	if ( uHeldBack )
 		return;
 
 	// An untagged mangoapp reads the control type itself, so leave the queue alone.
@@ -9278,20 +9426,27 @@ static void relay_mangoapp_control()
 			}
 		}
 	}
-	if ( !bAnyTagged )
+	// With no instance there is nothing to mistake, and a show has to be seen to spawn one.
+	if ( !bAnyTagged && !s_MangoappInstances.empty() )
 		return;
 
-	// Every spawned instance, one still starting finds the message when it reads.
-	std::vector<uint32_t> msgTypes;
-	msgTypes.reserve( s_MangoappInstances.size() );
-	for ( const auto &iter : s_MangoappInstances )
-		msgTypes.push_back( iter.second.uMsgType );
+	// Drained messages are folded even when their fan-out is held back, they are off the shared type now.
+	MangoappControlRelay_t relay = mangoapp_relay_control( msgTypes );
+	if ( relay.uHeldBack && !s_bLoggedHeldBack )
+		xwm_log.warnf( "Holding back %u mangoapp control message(s), the queue is full", relay.uHeldBack );
+	s_bLoggedHeldBack = relay.uHeldBack != 0;
 
-	uint32_t uHeldBack = mangoapp_relay_control( msgTypes );
-	static bool s_bLoggedHeldBack = false;
-	if ( uHeldBack && !s_bLoggedHeldBack )
-		xwm_log.warnf( "Holding back %u mangoapp control message(s), the queue is full", uHeldBack );
-	s_bLoggedHeldBack = uHeldBack != 0;
+	// Same order mangoapp applies them, the reload first and then no_display on top.
+	if ( relay.bReloadConfig )
+		ReadMangoappConfig();
+	if ( relay.obHide )
+		s_obMangoappControlVisible = !*relay.obHide;
+	else if ( relay.bToggle )
+		s_obMangoappControlVisible = !mangoapp_overlay_visible();
+	if ( relay.obLogging )
+		s_bMangoappLogging = *relay.obLogging;
+	else if ( relay.bToggleLogging )
+		s_bMangoappLogging = !s_bMangoappLogging;
 }
 
 void
@@ -9441,6 +9596,7 @@ steamcompmgr_main(int argc, char **argv)
 	g_SteamCompMgrWaiter.AddWaitable( &GetVBlankTimer() );
 	g_SteamCompMgrWaiter.AddWaitable( &g_FPSLimitVRRTimer );
 	GetVBlankTimer().ArmNextVBlank( true );
+	WatchMangoappConfig();
 
 	{
 		gamescope_xwayland_server_t *pServer = NULL;

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -20,6 +20,7 @@ void steamcompmgr_main(int argc, char **argv);
 #include "rendervulkan.hpp"
 #include "wlserver.hpp"
 #include "vblankmanager.hpp"
+#include "mangoapp_control.h"
 
 #include <mutex>
 #include <vector>
@@ -171,7 +172,10 @@ extern void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_
 extern void mangoapp_nudge_app_frame( uint32_t uMsgType, uint64_t ulNow );
 extern void mangoapp_set_connector_snapshots( std::unordered_map<uint32_t, MangoappSnapshot_t> snapshots );
 extern void mangoapp_drop_stream( uint32_t uMsgType );
-extern uint32_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes );
+extern uint32_t mangoapp_flush_control( const std::vector<uint32_t> &msgTypes );
+extern MangoappControlRelay_t mangoapp_relay_control( const std::vector<uint32_t> &msgTypes );
+// uNoDisplay in mangohudctl terms, 0 leaves it, 1 hides, 2 shows.
+extern void mangoapp_post_control( uint32_t uMsgType, uint8_t uNoDisplay, bool bStartLogging );
 struct wlr_surface *steamcompmgr_get_server_input_surface( size_t idx );
 wlserver_vk_swapchain_feedback* steamcompmgr_get_base_layer_swapchain_feedback();
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ endforeach
 
 gamescope_tests = executable(
 	'gamescope_tests',
-	unittest_src + ['test_convar.cpp', 'test_focus_placement.cpp', 'test_process.cpp', 'test_upscale.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_focus_placement.cpp', 'test_mangoapp_config.cpp', 'test_mangoapp_control.cpp', 'test_process.cpp', 'test_upscale.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
@@ -18,6 +18,8 @@ reaper_test_helper = executable('reaper_test_helper', 'reaper_test_helper.cpp')
 
 test('convar', gamescope_tests, args: ['[convar]'])
 test('focus_placement', gamescope_tests, args: ['[focus_placement]'])
+test('mangoapp_config', gamescope_tests, args: ['[mangoapp_config]'])
+test('mangoapp_control', gamescope_tests, args: ['[mangoapp_control]'])
 test('upscale', gamescope_tests, args: ['[upscale]'])
 test('utils/parsers', gamescope_tests, args: ['[parsers]'])
 test('utils/process', gamescope_tests, args: ['[process]'], depends: [reaper_test_helper])

--- a/tests/test_mangoapp_config.cpp
+++ b/tests/test_mangoapp_config.cpp
@@ -1,0 +1,49 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "mangoapp_config.h"
+
+TEST_CASE("An empty config shows the overlay", "[mangoapp_config]") {
+	REQUIRE(mangoapp_config_visible(""));
+}
+
+TEST_CASE("The session's boot config hides it", "[mangoapp_config]") {
+	REQUIRE_FALSE(mangoapp_config_visible("no_display"));
+	REQUIRE_FALSE(mangoapp_config_visible("no_display\n"));
+	REQUIRE_FALSE(mangoapp_config_visible("  no_display  \r\n"));
+}
+
+TEST_CASE("Steam's overlay-off config hides it", "[mangoapp_config]") {
+	REQUIRE_FALSE(mangoapp_config_visible("control=mangohud\nfsr_steam_sharpness=5\nnis_steam_sharpness=10\nno_display\n"));
+}
+
+TEST_CASE("Steam's overlay-on config shows it", "[mangoapp_config]") {
+	REQUIRE(mangoapp_config_visible("control=mangohud\nfsr_steam_sharpness=5\nnis_steam_sharpness=10\npreset=2\n"));
+}
+
+TEST_CASE("no_display takes a value", "[mangoapp_config]") {
+	REQUIRE(mangoapp_config_visible("no_display=0"));
+	REQUIRE_FALSE(mangoapp_config_visible("no_display=1"));
+	REQUIRE_FALSE(mangoapp_config_visible("no_display = 1"));
+}
+
+TEST_CASE("Preset 0 hides, only the first preset counts", "[mangoapp_config]") {
+	REQUIRE_FALSE(mangoapp_config_visible("preset=0"));
+	REQUIRE_FALSE(mangoapp_config_visible("preset=0,2,3"));
+	REQUIRE(mangoapp_config_visible("preset=2,0"));
+	REQUIRE(mangoapp_config_visible("preset=4"));
+}
+
+TEST_CASE("An explicit no_display beats the preset", "[mangoapp_config]") {
+	REQUIRE(mangoapp_config_visible("preset=0\nno_display=0"));
+	REQUIRE_FALSE(mangoapp_config_visible("preset=2\nno_display"));
+}
+
+TEST_CASE("Comments are ignored", "[mangoapp_config]") {
+	REQUIRE(mangoapp_config_visible("# no_display\npreset=2"));
+	REQUIRE_FALSE(mangoapp_config_visible("no_display # hidden for now"));
+}
+
+TEST_CASE("MANGOHUD_CONFIG replaces the file unless it sets read_cfg", "[mangoapp_config]") {
+	REQUIRE(mangoapp_config_visible("no_display", "fps_limit=60"));
+	REQUIRE_FALSE(mangoapp_config_visible("no_display", "read_cfg,fps_limit=60"));
+}

--- a/tests/test_mangoapp_control.cpp
+++ b/tests/test_mangoapp_control.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "mangoapp_control.h"
+
+static mangoapp_ctrl_msgid1_v1 ctrl(uint8_t no_display, uint8_t reload_config = 0, uint8_t log_session = 0) {
+	mangoapp_ctrl_msgid1_v1 msg = {};
+	msg.hdr.msg_type = 2;
+	msg.hdr.ctrl_msg_type = 1;
+	msg.hdr.version = 1;
+	msg.no_display = no_display;
+	msg.reload_config = reload_config;
+	msg.log_session = log_session;
+	return msg;
+}
+
+static void fold(MangoappControlRelay_t &relay, const mangoapp_ctrl_msgid1_v1 &msg) {
+	mangoapp_fold_control(&msg, sizeof(msg), relay);
+}
+
+TEST_CASE("Sets are kept, the last one wins", "[mangoapp_control]") {
+	MangoappControlRelay_t relay;
+	fold(relay, ctrl(1));
+	REQUIRE(relay.obHide == true);
+	fold(relay, ctrl(2));
+	REQUIRE(relay.obHide == false);
+	REQUIRE_FALSE(relay.bToggle);
+}
+
+TEST_CASE("Toggles cancel in pairs and flip a set", "[mangoapp_control]") {
+	MangoappControlRelay_t relay;
+	fold(relay, ctrl(3));
+	REQUIRE(relay.bToggle);
+	fold(relay, ctrl(3));
+	REQUIRE_FALSE(relay.bToggle);
+
+	fold(relay, ctrl(1));
+	fold(relay, ctrl(3));
+	REQUIRE(relay.obHide == false);
+	REQUIRE_FALSE(relay.bToggle);
+}
+
+TEST_CASE("A reload drops what came before it", "[mangoapp_control]") {
+	MangoappControlRelay_t relay;
+	fold(relay, ctrl(1));
+	fold(relay, ctrl(0, 3));
+	REQUIRE(relay.bReloadConfig);
+	REQUIRE_FALSE(relay.obHide.has_value());
+	REQUIRE_FALSE(relay.bToggle);
+
+	// Within one message the reload lands first, then no_display on top.
+	fold(relay, ctrl(1, 1));
+	REQUIRE(relay.obHide == true);
+}
+
+TEST_CASE("Logging folds like visibility and a reload stops it", "[mangoapp_control]") {
+	MangoappControlRelay_t relay;
+	fold(relay, ctrl(0, 0, 3));
+	REQUIRE(relay.bToggleLogging);
+	fold(relay, ctrl(0, 0, 1));
+	REQUIRE(relay.obLogging == true);
+	REQUIRE_FALSE(relay.bToggleLogging);
+	fold(relay, ctrl(0, 0, 3));
+	REQUIRE(relay.obLogging == false);
+
+	// Within one message the start lands first, then the reload stops it.
+	fold(relay, ctrl(0, 3, 1));
+	REQUIRE(relay.bReloadConfig);
+	REQUIRE(relay.obLogging == false);
+	fold(relay, ctrl(0, 0, 1));
+	REQUIRE(relay.obLogging == true);
+}
+
+TEST_CASE("Other control types and short messages are ignored", "[mangoapp_control]") {
+	MangoappControlRelay_t relay;
+	mangoapp_ctrl_msgid1_v1 other = ctrl(1);
+	other.hdr.ctrl_msg_type = 2;
+	fold(relay, other);
+	REQUIRE_FALSE(relay.obHide.has_value());
+
+	mangoapp_ctrl_msgid1_v1 hide = ctrl(1);
+	mangoapp_fold_control(&hide, sizeof(hide) - 1, relay);
+	REQUIRE_FALSE(relay.obHide.has_value());
+}


### PR DESCRIPTION
Trims memory around the per-connector mangoapp work in a couple ways:

- Stop spawning a mangoapp for connector 0, which never gets a window under PerAppId, ~100 MB idle all session
- In Steam mode, spawn per-connector mangoapps only while the perf overlay shows or a logging session runs, following the config file and mangohudctl the way mangoapp does. Zero instances with the overlay off

and one more general improvement by making the shared output images on first use instead of at init, which saves us around ~25 MB that OpenVR only reaches on pool exhaustion.

Also adds some basic tests for mangoapp control and configuration.