### PR TITLE
Support streaming a disconnected display after booting headless

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -1075,6 +1075,89 @@ static bool get_saved_mode(const char *description, saved_mode &mode_info)
 	return false;
 }
 
+/* Same identity extraction as CDRMConnector::ParseEDID. */
+static void parse_edid_identity(const di_edid *pEdid, char (&szMakePNP)[4], char (&szModel)[16])
+{
+	memset(szMakePNP, 0, sizeof(szMakePNP));
+	memset(szModel, 0, sizeof(szModel));
+
+	const di_edid_vendor_product *pProduct = di_edid_get_vendor_product(pEdid);
+	memcpy(szMakePNP, pProduct->manufacturer, 3);
+
+	const di_edid_display_descriptor *const *pDescriptors = di_edid_get_display_descriptors(pEdid);
+	for (size_t i = 0; pDescriptors[i] != nullptr; i++)
+	{
+		if (di_edid_display_descriptor_get_tag(pDescriptors[i]) == DI_EDID_DISPLAY_DESCRIPTOR_PRODUCT_NAME)
+			strncpy(szModel, di_edid_display_descriptor_get_string(pDescriptors[i]), sizeof(szModel) - 1);
+	}
+}
+
+/* Resolve a mode from the display we last drove, identified by the persisted EDID. */
+static bool get_last_display_mode(saved_mode &mode_info)
+{
+	const char *pszPath = gamescope::GetPatchedEdidPath();
+	if (!pszPath)
+		return false;
+
+	FILE *pFile = fopen(pszPath, "rb");
+	if (!pFile)
+		return false;
+
+	uint8_t edid[4096];
+	size_t ulSize = fread(edid, 1, sizeof(edid), pFile);
+	fclose(pFile);
+	if (!ulSize)
+		return false;
+
+	di_info *pInfo = di_info_parse_edid(edid, ulSize);
+	if (!pInfo)
+		return false;
+	defer( di_info_destroy( pInfo ) );
+
+	const di_edid *pEdid = di_info_get_edid(pInfo);
+
+	char szMakePNP[4];
+	char szModel[16];
+	parse_edid_identity(pEdid, szMakePNP, szModel);
+
+	const char *pszMake = szMakePNP;
+	auto pnpIter = pnps.find(szMakePNP);
+	if (pnpIter != pnps.end())
+		pszMake = pnpIter->second.c_str();
+
+	// Matches the description format setup_best_connector saves modes under.
+	char description[256];
+	snprintf(description, sizeof(description), "%s %s", pszMake, szModel);
+
+	if (get_saved_mode(description, mode_info) && mode_info.width > 0 && mode_info.height > 0 && mode_info.refresh > 0)
+	{
+		drm_log.infof("using saved mode %dx%d@%d of last connected display '%s'",
+			mode_info.width, mode_info.height, mode_info.refresh, description);
+		return true;
+	}
+
+	const di_edid_detailed_timing_def *const *pTimings = di_edid_get_detailed_timing_defs(pEdid);
+	if (pTimings[0] && !pTimings[0]->interlaced)
+	{
+		const di_edid_detailed_timing_def *pDef = pTimings[0];
+		int64_t lTotalPixels = (int64_t)(pDef->horiz_video + pDef->horiz_blank) * (pDef->vert_video + pDef->vert_blank);
+		if (pDef->horiz_video > 0 && pDef->vert_video > 0 && lTotalPixels > 0 && pDef->pixel_clock_hz > 0)
+		{
+			mode_info.width = pDef->horiz_video;
+			mode_info.height = pDef->vert_video;
+			mode_info.refresh = (int)((pDef->pixel_clock_hz + lTotalPixels / 2) / lTotalPixels);
+			if (mode_info.refresh > 0)
+			{
+				drm_log.infof("using preferred mode %dx%d@%d of last connected display '%s'",
+					mode_info.width, mode_info.height, mode_info.refresh, description);
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 static GamescopeBroadcastRGBMode_t s_ExternalBroadcastRGBMode = GAMESCOPE_BROADCAST_RGB_MODE_AUTOMATIC;
 
 static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
@@ -3358,14 +3441,29 @@ static void drm_unset_mode( struct drm_t *drm )
 	drm->pending.mode_id = 0;
 	drm->needs_modeset = true;
 
-	g_nOutputWidth = drm->preferred_width;
-	g_nOutputHeight = drm->preferred_height;
+	if ( drm->preferred_width != 0 || drm->preferred_height != 0 || drm->preferred_refresh != 0 )
+	{
+		g_nOutputWidth = drm->preferred_width;
+		g_nOutputHeight = drm->preferred_height;
+		g_nOutputRefresh = drm->preferred_refresh;
+	}
+	else if ( g_nOutputWidth == 0 || g_nOutputHeight == 0 )
+	{
+		// Cold headless start, size the virtual screen off the display we last drove.
+		saved_mode mode_info{};
+		if ( get_last_display_mode( mode_info ) )
+		{
+			g_nOutputWidth = mode_info.width;
+			g_nOutputHeight = mode_info.height;
+			g_nOutputRefresh = gamescope::ConvertHztomHz( mode_info.refresh );
+		}
+	}
+	// else keep the mode of a display that went away mid-session.
+
 	if (g_nOutputHeight == 0)
 		g_nOutputHeight = 720;
 	if (g_nOutputWidth == 0)
 		g_nOutputWidth = g_nOutputHeight * 16 / 9;
-
-	g_nOutputRefresh = drm->preferred_refresh;
 	if (g_nOutputRefresh == 0)
 		g_nOutputRefresh = gamescope::ConvertHztomHz( 60 );
 	g_nDynamicRefreshHz = 0;

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -774,7 +774,8 @@ static void page_flip_handler(int fd, unsigned int frame, unsigned int sec, unsi
 	DRMPresentCtx *pCtx = reinterpret_cast<DRMPresentCtx *>( data );
 
 	// Make this const when we move into CDRMBackend.
-	GetBackend()->GetCurrentConnector()->PresentationFeedback().m_uCompletedPresents = pCtx->ulPendingFlipCount;
+	if ( g_DRM.pConnector )
+		g_DRM.pConnector->PresentationFeedback().m_uCompletedPresents = pCtx->ulPendingFlipCount;
 
 	if ( !g_DRM.pCRTC )
 		return;

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -738,6 +738,18 @@ static gamescope::CDRMPlane *find_primary_plane(struct drm_t *drm)
 	return nullptr;
 }
 
+/* Pick any primary plane, ignoring CRTC routing, to bootstrap a headless start. */
+static gamescope::CDRMPlane *find_any_primary_plane(struct drm_t *drm)
+{
+	for ( std::unique_ptr< gamescope::CDRMPlane > &pPlane : drm->planes )
+	{
+		if ( pPlane->GetProperties().type->GetCurrentValue() == DRM_PLANE_TYPE_PRIMARY )
+			return pPlane.get();
+	}
+
+	return nullptr;
+}
+
 static bool have_overlay_planes(struct drm_t *drm)
 {
 	if ( !drm->pCRTC )
@@ -1372,6 +1384,10 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
 	if ( !drm->pPrimaryPlane )
 		drm->pPrimaryPlane = find_primary_plane( drm );
 
+	// Headless start, there is no CRTC to route through yet.
+	if ( !drm->pPrimaryPlane )
+		drm->pPrimaryPlane = find_any_primary_plane( drm );
+
 	if ( !drm->pPrimaryPlane )
 	{
 		drm_log.errorf("Failed to find a primary plane");
@@ -1420,12 +1436,15 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
 	} else {
 		switch (g_nDRMFormat) {
 		case DRM_FORMAT_XRGB2101010:
+		case DRM_FORMAT_ARGB2101010:
 			g_nDRMFormatOverlay = DRM_FORMAT_ARGB2101010;
 			break;
+		case DRM_FORMAT_XBGR2101010:
 		case DRM_FORMAT_ABGR2101010:
 			g_nDRMFormatOverlay = DRM_FORMAT_ABGR2101010;
 			break;
 		case DRM_FORMAT_XRGB8888:
+		case DRM_FORMAT_ARGB8888:
 			g_nDRMFormatOverlay = DRM_FORMAT_ARGB8888;
 			break;
 		default:

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -39,6 +39,7 @@
 #include "gpuvis_trace_utils.h"
 #include "log.hpp"
 #include "main.hpp"
+#include "mode_list_file.h"
 #include "modegen.hpp"
 #include "rendervulkan.hpp"
 #include "steamcompmgr.hpp"
@@ -1275,7 +1276,10 @@ static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
 	wlserver_unlock();
 
 	if (!initial)
+	{
 		WritePatchedEdid( best->GetRawEDID(), best->GetHDRInfo(), g_bRotated );
+		WriteModeListFile( best->GetModes() );
+	}
 
 	update_connector_display_info_wl( drm );
 
@@ -3725,7 +3729,10 @@ namespace gamescope
 		virtual bool PostInit() override
 		{
 			if ( g_DRM.pConnector )
+			{
 				WritePatchedEdid( g_DRM.pConnector->GetRawEDID(), g_DRM.pConnector->GetHDRInfo(), g_bRotated );
+				WriteModeListFile( g_DRM.pConnector->GetModes() );
+			}
 			return true;
 		}
 
@@ -4190,6 +4197,7 @@ namespace gamescope
 				return;
 
 			WritePatchedEdid( GetCurrentConnector()->GetRawEDID(), GetCurrentConnector()->GetHDRInfo(), g_bRotated );
+			WriteModeListFile( GetCurrentConnector()->GetModes() );
 		}
 
 	protected:

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -597,7 +597,7 @@ static LogScope liftoff_log_scope( "liftoff" );
 
 static std::unordered_map< std::string, std::string > pnps = {};
 
-static void drm_unset_mode( struct drm_t *drm );
+static void drm_unset_mode( struct drm_t *drm, bool force );
 static void drm_unset_connector( struct drm_t *drm );
 
 static constexpr uint32_t s_kSteamDeckLCDRates[] =
@@ -1094,9 +1094,19 @@ static void parse_edid_identity(const di_edid *pEdid, char (&szMakePNP)[4], char
 	}
 }
 
+static constexpr const char *k_pszVirtualScreenName = "Virtual screen";
+
 /* Resolve a mode from the display we last drove, identified by the persisted EDID. */
 static bool get_last_display_mode(saved_mode &mode_info)
 {
+	// A mode picked while headless is saved under the virtual screen's own name.
+	if (get_saved_mode(k_pszVirtualScreenName, mode_info) && mode_info.width > 0 && mode_info.height > 0 && mode_info.refresh > 0)
+	{
+		drm_log.infof("using saved mode %dx%d@%d of the virtual screen",
+			mode_info.width, mode_info.height, mode_info.refresh);
+		return true;
+	}
+
 	const char *pszPath = gamescope::GetPatchedEdidPath();
 	if (!pszPath)
 		return false;
@@ -1160,6 +1170,109 @@ static bool get_last_display_mode(saved_mode &mode_info)
 	return false;
 }
 
+namespace gamescope
+{
+	// Stands in for a null current connector while headless.
+	class CDRMHeadlessConnector final : public CBaseBackendConnector
+	{
+	public:
+		virtual bool IsHeadless() const override
+		{
+			return true;
+		}
+		// The null-connector path this replaces reports id 0, so keep that instead of an auto-assigned id.
+		virtual uint64_t GetConnectorID() const override
+		{
+			return 0;
+		}
+
+		virtual GamescopeScreenType GetScreenType() const override
+		{
+			return GAMESCOPE_SCREEN_TYPE_EXTERNAL;
+		}
+		virtual GamescopePanelOrientation GetCurrentOrientation() const override
+		{
+			return GAMESCOPE_PANEL_ORIENTATION_0;
+		}
+		virtual bool SupportsHDR() const override
+		{
+			return false;
+		}
+		virtual bool IsHDRActive() const override
+		{
+			return false;
+		}
+		virtual const BackendConnectorHDRInfo &GetHDRInfo() const override
+		{
+			return m_HDRInfo;
+		}
+		virtual bool IsVRRActive() const override
+		{
+			return false;
+		}
+		virtual std::span<const BackendMode> GetModes() const override
+		{
+			return m_Modes;
+		}
+
+		virtual bool SupportsVRR() const override
+		{
+			return false;
+		}
+
+		virtual std::span<const uint8_t> GetRawEDID() const override
+		{
+			return std::span<const uint8_t>{};
+		}
+		virtual std::span<const uint32_t> GetValidDynamicRefreshRates() const override
+		{
+			return std::span<const uint32_t>{};
+		}
+
+		virtual void GetNativeColorimetry(
+			bool bHDR10,
+			displaycolorimetry_t *displayColorimetry, EOTF *displayEOTF,
+			displaycolorimetry_t *outputEncodingColorimetry, EOTF *outputEncodingEOTF ) const override
+		{
+			*displayColorimetry = displaycolorimetry_709;
+			*displayEOTF = EOTF_Gamma22;
+			*outputEncodingColorimetry = displaycolorimetry_709;
+			*outputEncodingEOTF = EOTF_Gamma22;
+		}
+
+		virtual const char *GetName() const override
+		{
+			return "Headless";
+		}
+		virtual const char *GetMake() const override
+		{
+			return "Gamescope";
+		}
+		virtual const char *GetModel() const override
+		{
+			return k_pszVirtualScreenName;
+		}
+
+		virtual int Present( const FrameInfo_t *pFrameInfo, bool bAsync ) override
+		{
+			return 0;
+		}
+
+		void RebuildModes()
+		{
+			m_Modes = LoadModeListFile();
+			if ( m_Modes.empty() )
+				m_Modes.push_back( BackendMode{ (uint32_t)g_nOutputWidth, (uint32_t)g_nOutputHeight, (uint32_t)ConvertmHzToHz( g_nOutputRefresh ) } );
+		}
+
+	private:
+		BackendConnectorHDRInfo m_HDRInfo{};
+		std::vector<BackendMode> m_Modes;
+	};
+}
+
+static gamescope::CDRMHeadlessConnector s_HeadlessConnector;
+
 static GamescopeBroadcastRGBMode_t s_ExternalBroadcastRGBMode = GAMESCOPE_BROADCAST_RGB_MODE_AUTOMATIC;
 
 static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
@@ -1209,13 +1322,17 @@ static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
 	if (best == nullptr) {
 		drm_log.infof("cannot find any connected connector!");
 		drm_unset_connector(drm);
-		drm_unset_mode(drm);
+		drm_unset_mode(drm, force);
+		s_HeadlessConnector.RebuildModes();
+
+		// Steam keys saved modes by the description, so get_last_display_mode reads this name back.
 		const struct wlserver_output_info wlserver_output_info = {
-			.description = "Virtual screen",
+			.description = k_pszVirtualScreenName,
 		};
 		wlserver_lock();
 		wlserver_set_output_info(&wlserver_output_info);
 		wlserver_unlock();
+		update_connector_display_info_wl( drm );
 		return true;
 	}
 
@@ -3441,7 +3558,7 @@ bool drm_update_color_mgmt(struct drm_t *drm)
 
 int g_nDynamicRefreshHz = 0;
 
-static void drm_unset_mode( struct drm_t *drm )
+static void drm_unset_mode( struct drm_t *drm, bool force )
 {
 	drm->pending.mode_id = 0;
 	drm->needs_modeset = true;
@@ -3452,9 +3569,9 @@ static void drm_unset_mode( struct drm_t *drm )
 		g_nOutputHeight = drm->preferred_height;
 		g_nOutputRefresh = drm->preferred_refresh;
 	}
-	else if ( g_nOutputWidth == 0 || g_nOutputHeight == 0 )
+	else if ( force )
 	{
-		// Cold headless start, size the virtual screen off the display we last drove.
+		// Cold start, or Steam picked a mode while headless.
 		saved_mode mode_info{};
 		if ( get_last_display_mode( mode_info ) )
 		{
@@ -4109,13 +4226,16 @@ namespace gamescope
 
 		virtual IBackendConnector *GetCurrentConnector() override
 		{
-			return g_DRM.pConnector;
+			if ( g_DRM.pConnector )
+				return g_DRM.pConnector;
+
+			return &s_HeadlessConnector;
 		}
 
 		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override
 		{
-			if ( GetCurrentConnector() && GetCurrentConnector()->GetScreenType() == eScreenType )
-				return GetCurrentConnector();
+			if ( g_DRM.pConnector && g_DRM.pConnector->GetScreenType() == eScreenType )
+				return g_DRM.pConnector;
 
 			if ( eScreenType == GAMESCOPE_SCREEN_TYPE_INTERNAL )
 			{
@@ -4194,11 +4314,11 @@ namespace gamescope
 
 		virtual void HackUpdatePatchedEdid() override
 		{
-			if ( !GetCurrentConnector() )
+			if ( !g_DRM.pConnector )
 				return;
 
-			WritePatchedEdid( GetCurrentConnector()->GetRawEDID(), GetCurrentConnector()->GetHDRInfo(), g_bRotated );
-			WriteModeListFile( GetCurrentConnector()->GetModes() );
+			WritePatchedEdid( g_DRM.pConnector->GetRawEDID(), g_DRM.pConnector->GetHDRInfo(), g_bRotated );
+			WriteModeListFile( g_DRM.pConnector->GetModes() );
 		}
 
 	protected:
@@ -4246,14 +4366,14 @@ namespace gamescope
 				drm->m_QueuedFbIds.swap( drm->m_FbIdsInRequest );
 			}
 
-			GetCurrentConnector()->PresentationFeedback().m_uQueuedPresents++;
+			g_DRM.pConnector->PresentationFeedback().m_uQueuedPresents++;
 
 			uint32_t uCurrentPresentCtx = m_uNextPresentCtx;
 			m_uNextPresentCtx = ( m_uNextPresentCtx + 1 ) % 3;
-			m_PresentCtxs[uCurrentPresentCtx].ulPendingFlipCount = GetCurrentConnector()->PresentationFeedback().m_uQueuedPresents;
+			m_PresentCtxs[uCurrentPresentCtx].ulPendingFlipCount = g_DRM.pConnector->PresentationFeedback().m_uQueuedPresents;
 
-			drm_log.debugf("flip commit %" PRIu64, (uint64_t)GetCurrentConnector()->PresentationFeedback().m_uQueuedPresents);
-			gpuvis_trace_printf( "flip commit %" PRIu64, (uint64_t)GetCurrentConnector()->PresentationFeedback().m_uQueuedPresents );
+			drm_log.debugf("flip commit %" PRIu64, (uint64_t)g_DRM.pConnector->PresentationFeedback().m_uQueuedPresents);
+			gpuvis_trace_printf( "flip commit %" PRIu64, (uint64_t)g_DRM.pConnector->PresentationFeedback().m_uQueuedPresents );
 
 			ret = drmModeAtomicCommit(drm->fd, drm->req, drm->flags, &m_PresentCtxs[uCurrentPresentCtx] );
 			if ( ret != 0 )
@@ -4279,7 +4399,7 @@ namespace gamescope
 				// Clear our refs.
 				drm->m_FbIdsInRequest.clear();
 
-				GetCurrentConnector()->PresentationFeedback().m_uQueuedPresents--;
+				g_DRM.pConnector->PresentationFeedback().m_uQueuedPresents--;
 
 				if ( isPageFlip )
 					drm->uPendingFlipCount--;

--- a/src/backend.h
+++ b/src/backend.h
@@ -205,6 +205,9 @@ namespace gamescope
 
         virtual uint64_t GetVirtualConnectorKey() const = 0;
 
+        // A stand-in connector with no display behind it, e.g. the DRM headless virtual screen.
+        virtual bool IsHeadless() const { return false; }
+
         virtual INestedHints *GetNestedHints() = 0;
 
         virtual void SetProperty( ConnectorProperty eProperty, std::any value ) = 0;

--- a/src/backend.h
+++ b/src/backend.h
@@ -152,13 +152,6 @@ namespace gamescope
         }
     };
 
-    struct BackendMode
-    {
-        uint32_t uWidth;
-        uint32_t uHeight;
-        uint32_t uRefresh; // Hz
-    };
-
     struct BackendPresentFeedback
     {
     public:

--- a/src/edid.cpp
+++ b/src/edid.cpp
@@ -355,4 +355,55 @@ namespace gamescope
 
         return edid;
     }
+
+    const char *EnsureVirtualEdid()
+    {
+        const char *pszPatchedEdidPath = GetPatchedEdidPath();
+        if ( !pszPatchedEdidPath )
+            return nullptr;
+
+        FILE *pFile = fopen( pszPatchedEdidPath, "rb" );
+        if ( !pFile )
+            return nullptr;
+
+        uint8_t edid[4096];
+        size_t ulSize = fread( edid, 1, sizeof( edid ), pFile );
+        fclose( pFile );
+        if ( ulSize < 128 || ulSize % 128 != 0 )
+            return nullptr;
+
+        // Gamescope's own vendor, product and serial identity, the last display's timings and HDR block stay.
+        memcpy( &edid[8], &s_GamescopeBaseEdid[8], 8 );
+
+        for ( uint32_t i = 0; i < EDID_BYTE_DESCRIPTOR_COUNT; i++ )
+        {
+            uint8_t *pDesc = &edid[0x36 + i * EDID_BYTE_DESCRIPTOR_SIZE];
+            if ( pDesc[0] == 0 && pDesc[1] == 0 && pDesc[3] == 0xfc )
+                memcpy( &pDesc[5], "VirtualScreen", 13 );
+        }
+
+        patch_edid_checksum( &edid[0] );
+
+        // Truncation would collapse both names onto the published path, losing the atomic rename.
+        static char szPath[PATH_MAX];
+        if ( snprintf( szPath, sizeof( szPath ), "%s.virtual", pszPatchedEdidPath ) >= (int)sizeof( szPath ) )
+            return nullptr;
+
+        char szTmpPath[PATH_MAX];
+        if ( snprintf( szTmpPath, sizeof( szTmpPath ), "%s.virtual.tmp", pszPatchedEdidPath ) >= (int)sizeof( szTmpPath ) )
+            return nullptr;
+
+        pFile = fopen( szTmpPath, "wb" );
+        if ( !pFile )
+            return nullptr;
+
+        // Fail closed, the returned path gets published.
+        bool bWritten = fwrite( edid, 1, ulSize, pFile ) == ulSize;
+        bWritten &= fflush( pFile ) == 0;
+        bWritten &= fclose( pFile ) == 0;
+        if ( !bWritten || rename( szTmpPath, szPath ) != 0 )
+            return nullptr;
+
+        return szPath;
+    }
 }

--- a/src/edid.h
+++ b/src/edid.h
@@ -12,6 +12,7 @@ namespace gamescope
     const char *GetPatchedEdidPath();
     void WritePatchedEdid( std::span<const uint8_t> pEdid, const BackendConnectorHDRInfo &hdrInfo, bool bRotate );
     std::vector<uint8_t> GenerateSimpleEdid( uint32_t uWidth, uint32_t uHeight );
+    const char *EnsureVirtualEdid();
 
     std::optional<std::vector<uint8_t>> PatchEdid( std::span<const uint8_t> pEdid, const BackendConnectorHDRInfo &hdrInfo, bool bRotate );
 }

--- a/src/gamescope_shared.h
+++ b/src/gamescope_shared.h
@@ -19,6 +19,13 @@ namespace gamescope
 
 		GAMESCOPE_SCREEN_TYPE_COUNT
 	};
+
+	struct BackendMode
+	{
+		uint32_t uWidth;
+		uint32_t uHeight;
+		uint32_t uRefresh; // Hz
+	};
 }
 
 enum GamescopeAppTextureColorspace

--- a/src/meson.build
+++ b/src/meson.build
@@ -109,6 +109,7 @@ src = [
   'color_helpers.cpp',
   'main.cpp',
   'edid.cpp',
+  'mode_list_file.cpp',
   'wlserver.cpp',
   'vblankmanager.cpp',
   'rendervulkan.cpp',

--- a/src/mode_list_file.cpp
+++ b/src/mode_list_file.cpp
@@ -1,0 +1,68 @@
+#include "mode_list_file.h"
+#include "edid.h"
+#include "log.hpp"
+
+#include <cstdio>
+
+namespace gamescope
+{
+    static LogScope modelist_log("modelist");
+
+    static std::string GetModeListPath()
+    {
+        const char *pszPatchedEdidPath = GetPatchedEdidPath();
+        if ( !pszPatchedEdidPath )
+            return "";
+
+        return std::string{ pszPatchedEdidPath } + ".modes";
+    }
+
+    void WriteModeListFile( std::span<const BackendMode> modes )
+    {
+        std::string sPath = GetModeListPath();
+        if ( sPath.empty() )
+            return;
+
+        std::string sTmpPath = sPath + ".tmp";
+
+        FILE *pFile = fopen( sTmpPath.c_str(), "wb" );
+        if ( !pFile )
+        {
+            modelist_log.errorf( "Couldn't open file: %s", sTmpPath.c_str() );
+            return;
+        }
+
+        std::string sText = EncodeModeList( modes );
+        fwrite( sText.data(), 1, sText.size(), pFile );
+        fflush( pFile );
+        fclose( pFile );
+
+        // Flip it over, same as WritePatchedEdid.
+        rename( sTmpPath.c_str(), sPath.c_str() );
+        modelist_log.infof( "Wrote %zu modes to: %s", modes.size(), sPath.c_str() );
+    }
+
+    std::vector<BackendMode> LoadModeListFile()
+    {
+        std::string sPath = GetModeListPath();
+        if ( sPath.empty() )
+            return {};
+
+        FILE *pFile = fopen( sPath.c_str(), "rb" );
+        if ( !pFile )
+            return {};
+
+        char szText[16384];
+        size_t ulSize = fread( szText, 1, sizeof( szText ), pFile );
+        fclose( pFile );
+
+        // A read that fills the buffer may cut the last line, trim it so it can't parse as a bogus mode.
+        if ( ulSize == sizeof( szText ) )
+        {
+            while ( ulSize > 0 && szText[ ulSize - 1 ] != '\n' )
+                ulSize--;
+        }
+
+        return ParseModeList( std::string_view{ szText, ulSize } );
+    }
+}

--- a/src/mode_list_file.h
+++ b/src/mode_list_file.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "gamescope_shared.h"
+
+#include <cstdio>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace gamescope
+{
+    // Sidecar text format: one "WxH@R" per line, connector preference order.
+    inline std::string EncodeModeList( std::span<const BackendMode> modes )
+    {
+        std::string sText;
+        for ( const BackendMode &mode : modes )
+        {
+            char szLine[64];
+            snprintf( szLine, sizeof( szLine ), "%ux%u@%u\n", mode.uWidth, mode.uHeight, mode.uRefresh );
+            sText += szLine;
+        }
+        return sText;
+    }
+
+    inline std::vector<BackendMode> ParseModeList( std::string_view text )
+    {
+        std::vector<BackendMode> modes;
+        size_t ulPos = 0;
+        while ( ulPos < text.size() )
+        {
+            size_t ulEnd = text.find( '\n', ulPos );
+            if ( ulEnd == std::string_view::npos )
+                ulEnd = text.size();
+
+            std::string line{ text.substr( ulPos, ulEnd - ulPos ) };
+            ulPos = ulEnd + 1;
+
+            BackendMode mode{};
+            if ( sscanf( line.c_str(), "%ux%u@%u", &mode.uWidth, &mode.uHeight, &mode.uRefresh ) != 3 )
+                continue;
+            if ( !mode.uWidth || !mode.uHeight || !mode.uRefresh )
+                continue;
+            // Catches "%u" swallowing negatives as huge values, and other garbage.
+            if ( mode.uWidth > 16384 || mode.uHeight > 16384 || mode.uRefresh > 1000 )
+                continue;
+
+            modes.push_back( mode );
+        }
+        return modes;
+    }
+
+    void WriteModeListFile( std::span<const BackendMode> modes );
+    std::vector<BackendMode> LoadModeListFile();
+}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4506,7 +4506,7 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 		eStrategy = gamescope::VirtualConnectorStrategies::SteamControlled;
 		ulKey = 0;
 	}
-	else if ( GetBackend() && GetBackend()->GetCurrentConnector() )
+	else if ( GetBackend() && GetBackend()->GetCurrentConnector() && !GetBackend()->GetCurrentConnector()->IsHeadless() )
 	{
 		eStrategy = gamescope::cv_backend_virtual_connector_strategy;
 		ulKey = GetBackend()->GetCurrentConnector()->GetVirtualConnectorKey();
@@ -7744,7 +7744,7 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 				// TODO: fix this properly for all overlays, including Steam notifications and QAM
 				// HACK: If VRR is active, prevent external overlays, i.e. mangoapp, from repainting the base plane
 				if ( ( w == pFocus->externalOverlayWindow && w->opacity != TRANSLUCENT ) &&
-				     ( GetBackend()->GetCurrentConnector() && !GetBackend()->GetCurrentConnector()->IsVRRActive() ) )
+				     ( GetBackend()->GetCurrentConnector() && !GetBackend()->GetCurrentConnector()->IsVRRActive() && !GetBackend()->GetCurrentConnector()->IsHeadless() ) )
 				{
 					hasRepaintNonBasePlane = true;
 				}
@@ -9112,6 +9112,14 @@ void update_edid_prop()
 	if (!filename)
 		return;
 
+	// Headless: present the virtual screen's identity, not the last display's.
+	if (!GetBackend()->GetCurrentConnector() || GetBackend()->GetCurrentConnector()->IsHeadless())
+	{
+		const char *pszVirtualEdid = gamescope::EnsureVirtualEdid();
+		if (pszVirtualEdid)
+			filename = pszVirtualEdid;
+	}
+
 	gamescope_xwayland_server_t *server = NULL;
 	for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
 	{
@@ -9994,6 +10002,7 @@ steamcompmgr_main(int argc, char **argv)
 			hasRepaint = true;
 
 			update_mode_atoms(root_ctx, &flush_root);
+			update_edid_prop();
 		}
 
 		g_uCompositeDebug = cv_composite_debug;

--- a/src/vblankmanager.cpp
+++ b/src/vblankmanager.cpp
@@ -89,8 +89,9 @@ namespace gamescope
 
 		uint64_t ulTargetPoint = GetLastVBlank() + ulIntervalNSecs - ulOffset;
 
-		while ( ulTargetPoint < ulNow )
-			ulTargetPoint += ulIntervalNSecs;
+		// Step in one go, a headless session never marks a vblank so the gap grows with uptime.
+		if ( ulTargetPoint < ulNow )
+			ulTargetPoint += ( ( ulNow - ulTargetPoint - 1 ) / ulIntervalNSecs + 1 ) * ulIntervalNSecs;
 
 		return ulTargetPoint;
 	}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ endforeach
 
 gamescope_tests = executable(
 	'gamescope_tests',
-	unittest_src + ['test_convar.cpp', 'test_focus_placement.cpp', 'test_mangoapp_config.cpp', 'test_mangoapp_control.cpp', 'test_process.cpp', 'test_upscale.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_focus_placement.cpp', 'test_mangoapp_config.cpp', 'test_mangoapp_control.cpp', 'test_mode_list.cpp', 'test_process.cpp', 'test_upscale.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp', 'test_vrclient_detect.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
@@ -20,6 +20,7 @@ test('convar', gamescope_tests, args: ['[convar]'])
 test('focus_placement', gamescope_tests, args: ['[focus_placement]'])
 test('mangoapp_config', gamescope_tests, args: ['[mangoapp_config]'])
 test('mangoapp_control', gamescope_tests, args: ['[mangoapp_control]'])
+test('mode_list', gamescope_tests, args: ['[mode_list]'])
 test('upscale', gamescope_tests, args: ['[upscale]'])
 test('utils/parsers', gamescope_tests, args: ['[parsers]'])
 test('utils/process', gamescope_tests, args: ['[process]'], depends: [reaper_test_helper])

--- a/tests/test_mode_list.cpp
+++ b/tests/test_mode_list.cpp
@@ -1,0 +1,56 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "mode_list_file.h"
+
+using namespace gamescope;
+
+TEST_CASE("Mode list round-trip", "[mode_list]") {
+	std::vector<BackendMode> modes = {
+		{ 3840, 2160, 120 },
+		{ 3840, 2160, 60 },
+		{ 1920, 1080, 60 },
+	};
+
+	std::string text = EncodeModeList( modes );
+	REQUIRE( text == "3840x2160@120\n3840x2160@60\n1920x1080@60\n" );
+
+	std::vector<BackendMode> parsed = ParseModeList( text );
+	REQUIRE( parsed.size() == 3 );
+	for ( size_t i = 0; i < parsed.size(); i++ )
+	{
+		REQUIRE( parsed[i].uWidth == modes[i].uWidth );
+		REQUIRE( parsed[i].uHeight == modes[i].uHeight );
+		REQUIRE( parsed[i].uRefresh == modes[i].uRefresh );
+	}
+}
+
+TEST_CASE("Mode list parse skips malformed lines", "[mode_list]") {
+	std::string text = "1920x1080@60\ngarbage\n0x0@0\n1280x720@\n\n2560x1440@165\n";
+	std::vector<BackendMode> parsed = ParseModeList( text );
+	REQUIRE( parsed.size() == 2 );
+	REQUIRE( parsed[0].uWidth == 1920 );
+	REQUIRE( parsed[0].uHeight == 1080 );
+	REQUIRE( parsed[0].uRefresh == 60 );
+	REQUIRE( parsed[1].uWidth == 2560 );
+	REQUIRE( parsed[1].uRefresh == 165 );
+}
+
+TEST_CASE("Mode list parse handles missing trailing newline", "[mode_list]") {
+	std::vector<BackendMode> parsed = ParseModeList( "1920x1080@60" );
+	REQUIRE( parsed.size() == 1 );
+	REQUIRE( parsed[0].uRefresh == 60 );
+}
+
+TEST_CASE("Empty mode list encodes to empty text", "[mode_list]") {
+	REQUIRE( EncodeModeList( {} ) == "" );
+	REQUIRE( ParseModeList( "" ).empty() );
+}
+
+TEST_CASE("Mode list parse rejects out-of-range values", "[mode_list]") {
+	std::string text = "-1x-1@-1\n20000x20000@60\n1920x1080@2000\n1920x1080@60\n";
+	std::vector<BackendMode> parsed = ParseModeList( text );
+	REQUIRE( parsed.size() == 1 );
+	REQUIRE( parsed[0].uWidth == 1920 );
+	REQUIRE( parsed[0].uHeight == 1080 );
+	REQUIRE( parsed[0].uRefresh == 60 );
+}


### PR DESCRIPTION
Gamescope currently fails to start on a Steam Machine that boots with no display connected, aborting in init_drm because finding a primary plane requires a CRTC and a CRTC requires a connected connector. That leaves the session in a login loop until something is plugged in.

This makes the DRM backend serve a stand-in connector while nothing is connected, so a headless machine comes up and can be streamed through Remote Play. The virtual screen keeps the resolution of the display that was last driven rather than falling back to 720p, and it offers that display's real mode list, so if you were on an ultrawide you can stay at 5120x2160 or drop to 1920x1080 from Steam's display settings even though the machine booted with the monitor disconnected or off. The mode list and the last display's identity come from a small sidecar file written next to the patched EDID whenever a real display is driven.

Deliberately not included are synthetic streaming resolutions beyond what the display really offered, and inheriting the last display's HDR support. Both need the Steam client side worked out first. I could see how a virtual-connector-based approach would fit a per-app streaming model better, but it pulls in focus and composite changes across steamcompmgr plus Steam-side work, so this tries to match how Remote Play streams a whole session today.