### PR TITLE
wlserver: follow the keyboard layout Steam gives us

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -7273,6 +7273,14 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 			g_flHDRItmTargetNits = 10000.f;
 		hasRepaint = true;
 	}
+	if ( ev->atom == ctx->atoms.gamescopeKeyboardLayout )
+	{
+		std::string sLayout = get_string_prop( ctx, ctx->root, ctx->atoms.gamescopeKeyboardLayout );
+
+		wlserver_lock();
+		wlserver_set_keyboard_layout( sLayout.c_str() );
+		wlserver_unlock();
+	}
 	if ( ev->atom == ctx->atoms.gamescopeColorLookPQ )
 	{
 		std::string path = get_string_prop( ctx, ctx->root, ctx->atoms.gamescopeColorLookPQ );
@@ -8754,6 +8762,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 
 	ctx->atoms.gamescopeXWaylandModeControl = XInternAtom( ctx->dpy, "GAMESCOPE_XWAYLAND_MODE_CONTROL", false );
 	ctx->atoms.gamescopeFPSLimit = XInternAtom( ctx->dpy, "GAMESCOPE_FPS_LIMIT", false );
+	ctx->atoms.gamescopeKeyboardLayout = XInternAtom( ctx->dpy, "GAMESCOPE_KEYBOARD_LAYOUT", false );
 	ctx->atoms.gamescopeLimiterFeedback = XInternAtom( ctx->dpy, "GAMESCOPE_LIMITER_FEEDBACK", false );
 	ctx->atoms.gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_INTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH", false );
 	ctx->atoms.gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_EXTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH_EXTERNAL", false );

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -472,6 +472,25 @@ static void wlserver_handle_touch_motion(struct wl_listener *listener, void *dat
 	wlserver_touchmotion( event->x, event->y, event->touch_id, event->time_msec, false, touch->connector );
 }
 
+struct wlserver_keyboard {
+	struct wlr_keyboard *wlr;
+
+	struct wl_listener destroy;
+};
+
+// The keyboards in wlserver.keyboard_group, kept so a layout change can reach them.
+// wlroots keeps keyboard_group_device private, so we cannot iterate group->devices.
+static std::vector<struct wlserver_keyboard *> s_Keyboards;
+
+static void wlserver_handle_keyboard_destroy(struct wl_listener *listener, void *data)
+{
+	struct wlserver_keyboard *keyboard = wl_container_of( listener, keyboard, destroy );
+
+	std::erase( s_Keyboards, keyboard );
+	wl_list_remove( &keyboard->destroy.link );
+	free( keyboard );
+}
+
 static void wlserver_handle_pointer_destroy(struct wl_listener *listener, void *data)
 {
 	struct wlserver_pointer *pointer = wl_container_of( listener, pointer, destroy );
@@ -509,6 +528,12 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 				wl_log.errorf("failed to add physical keyboard %s", device->name);
 				break;
 			}
+
+			struct wlserver_keyboard *pKeyboard = (struct wlserver_keyboard *) calloc( 1, sizeof( struct wlserver_keyboard ) );
+			pKeyboard->wlr = keyboard;
+			pKeyboard->destroy.notify = wlserver_handle_keyboard_destroy;
+			wl_signal_add( &device->events.destroy, &pKeyboard->destroy );
+			s_Keyboards.push_back( pKeyboard );
 			// Sync the state of the modifiers and the state of the LEDs
 			struct wlr_keyboard_modifiers mods = wlserver.keyboard_group->keyboard.modifiers;
 			if (mods.depressed != keyboard->modifiers.depressed ||
@@ -2039,6 +2064,82 @@ static gamescope::CAsyncWaiter g_LibEisWaiter( "gamescope-eis" );
 static std::unique_ptr<gamescope::GamescopeInputServer> g_InputServer;
 #endif
 
+static void wlserver_update_keymap();
+
+// Steam pushes the user's keyboard layout in here, as nothing in the session
+// exports it to us. See GAMESCOPE_KEYBOARD_LAYOUT in steamcompmgr.
+static gamescope::ConVar<std::string> cv_xkb_layout( "xkb_layout", "",
+	"XKB layout[:variant] used for physical keyboards, eg. \"es\" or \"fr:bepo\". Empty follows XKB_DEFAULT_LAYOUT and XKB_DEFAULT_VARIANT.",
+	[]( gamescope::ConVar<std::string> & ) { wlserver_update_keymap(); } );
+
+static void wlserver_set_keyboard_keymap( struct wlr_keyboard *pKeyboard, struct xkb_keymap *pKeymap )
+{
+	if ( wlr_keyboard_keymaps_match( pKeyboard->keymap, pKeymap ) )
+		return;
+
+	// A keymap that fails to apply is left alone, wlroots keeps the old one.
+	if ( !wlr_keyboard_set_keymap( pKeyboard, pKeymap ) )
+		wl_log.errorf( "Failed to set the keymap on keyboard %s", pKeyboard->base.name ? pKeyboard->base.name : "(unnamed)" );
+}
+
+static void wlserver_update_keymap()
+{
+	// The layout can be set from the environment before the keyboard group exists.
+	if ( !wlserver.keyboard_group )
+		return;
+
+	struct xkb_rule_names rules = { 0 };
+	rules.rules = getenv("XKB_DEFAULT_RULES");
+	rules.model = getenv("XKB_DEFAULT_MODEL");
+	rules.layout = getenv("XKB_DEFAULT_LAYOUT");
+	rules.variant = getenv("XKB_DEFAULT_VARIANT");
+	rules.options = getenv("XKB_DEFAULT_OPTIONS");
+	std::string strLayout = cv_xkb_layout.Get();
+	std::string strVariant;
+	if ( !strLayout.empty() )
+	{
+		size_t nVariant = strLayout.find( ':' );
+		if ( nVariant != std::string::npos )
+		{
+			strVariant = strLayout.substr( nVariant + 1 );
+			strLayout.resize( nVariant );
+		}
+
+		// The variant from the environment belongs to the layout it shipped with.
+		rules.layout = strLayout.c_str();
+		rules.variant = strVariant.c_str();
+	}
+
+	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	struct xkb_keymap *keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+	if ( keymap )
+	{
+		// A keyboard left on the old keymap keeps feeding its own modifier masks into
+		// the group, so AltGr would still arrive as the layout it joined with. Each one
+		// is checked on its own, so a keyboard we failed to update is retried next time.
+		wlserver_set_keyboard_keymap( &wlserver.keyboard_group->keyboard, keymap );
+		for ( struct wlserver_keyboard *pKeyboard : s_Keyboards )
+			wlserver_set_keyboard_keymap( pKeyboard->wlr, keymap );
+	}
+	else
+	{
+		// Unsetting the keymap would leave the group without an xkb_state to translate keys with.
+		wl_log.errorf( "Failed to compile keymap for layout \"%s\", keeping the current layout",
+			rules.layout ? rules.layout : "" );
+	}
+
+	xkb_keymap_unref( keymap );
+	xkb_context_unref( context );
+}
+
+void wlserver_set_keyboard_layout( const char *pszLayout )
+{
+	assert( wlserver_is_lock_held() );
+
+	cv_xkb_layout = std::string{ pszLayout };
+}
+
 bool wlserver_init( void ) {
 	assert( wlserver.display != nullptr );
 
@@ -2071,18 +2172,10 @@ bool wlserver_init( void ) {
 
 	// Create a keyboard group to keep all externally connected keyboards
 	// in sync (one single layout and a shared state)
-	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-	struct xkb_rule_names rules = { 0 };
-	rules.rules = getenv("XKB_DEFAULT_RULES");
-	rules.model = getenv("XKB_DEFAULT_MODEL");
-	rules.layout = getenv("XKB_DEFAULT_LAYOUT");
-	rules.variant = getenv("XKB_DEFAULT_VARIANT");
-	rules.options = getenv("XKB_DEFAULT_OPTIONS");
-	struct xkb_keymap *keymap = xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
 	wlserver.keyboard_group = wlr_keyboard_group_create();
 	struct wlr_keyboard *keyboard = &wlserver.keyboard_group->keyboard;
 	wlr_keyboard_set_repeat_info(keyboard, 25, 600);
-	wlr_keyboard_set_keymap(keyboard, keymap);
+	wlserver_update_keymap();
 	wlserver.keyboard_group_modifiers.notify = wlserver_handle_modifiers;
 	wl_signal_add(&keyboard->events.modifiers, &wlserver.keyboard_group_modifiers);
 	wlserver.keyboard_group_key.notify = wlserver_handle_key;

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -263,6 +263,7 @@ bool wlserver_is_lock_held(void);
 
 void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain = true );
 void wlserver_key( uint32_t key, bool press, uint32_t time );
+void wlserver_set_keyboard_layout( const char *pszLayout );
 
 void wlserver_mousefocus( struct wlr_surface *wlrsurface, int x = 0, int y = 0 );
 void wlserver_clear_dropdowns();

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -171,6 +171,7 @@ struct xwayland_ctx_t final : public gamescope::IWaitable
 		Atom gamescopeXWaylandModeControl;
 
 		Atom gamescopeFPSLimit;
+		Atom gamescopeKeyboardLayout;
 		Atom gamescopeLimiterFeedback;
 		Atom gamescopeDynamicRefresh[gamescope::GAMESCOPE_SCREEN_TYPE_COUNT];
 		Atom gamescopeLowLatency;


### PR DESCRIPTION
External keyboards always come up on the US ANSI layout. The layout only ever comes from the XKB_DEFAULT_* environment, which nothing in the session sets, so a Spanish user typing on a keyboard in the dock gets US symbols in game mode.

Take the layout from a GAMESCOPE_KEYBOARD_LAYOUT property on the root window, the channel Steam already uses for its other settings, and rebuild the keyboard group's keymap from it. Every keyboard in the group is rebuilt too, as a member left on the old keymap keeps feeding its own modifier masks back into the group, which would leave AltGr behaving as the layout that keyboard joined with. Each keyboard is compared against the new keymap on its own, so one we could not update is picked up the next time a layout comes in.