### PR TITLE
steamcompmgr: preserve override content across Xwayland blits

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -143,7 +143,7 @@ namespace gamescope
             &m_ulPoint,
             1,
             lTimeout,
-            DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL,
+            DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT,
             nullptr );
 
         if ( nRet < 0 )

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1,5 +1,6 @@
 #include <xf86drm.h>
 #include <sys/eventfd.h>
+#include <linux/dma-buf.h>
 
 #include "Timeline.h"
 #include "wlserver.hpp"
@@ -69,6 +70,42 @@ namespace gamescope
             m_pVkSemaphore = g_device.ImportTimelineSemaphore( this );
 
         return m_pVkSemaphore;
+    }
+
+    bool CTimeline::ImportDmabufFences( int32_t nDmabufFd, uint64_t ulPoint )
+    {
+        // A failing export will not start working, so ask once.
+        static bool s_bFailed = false;
+        if ( s_bFailed )
+            return false;
+
+        dma_buf_export_sync_file exportSyncFile =
+        {
+            .flags = DMA_BUF_SYNC_READ,
+            .fd = -1,
+        };
+        if ( drmIoctl( nDmabufFd, DMA_BUF_IOCTL_EXPORT_SYNC_FILE, &exportSyncFile ) != 0 )
+        {
+            s_bFailed = true;
+            s_TimelineLog.errorf_errno( "DMA_BUF_IOCTL_EXPORT_SYNC_FILE failed" );
+            return false;
+        }
+
+        // Sync files only import into binary syncobjs, so go through one.
+        uint32_t uBinaryHandle = 0;
+        int32_t nRet = drmSyncobjCreate( GetDrmRenderFD(), 0, &uBinaryHandle );
+        if ( nRet == 0 )
+            nRet = drmSyncobjImportSyncFile( GetDrmRenderFD(), uBinaryHandle, exportSyncFile.fd );
+        if ( nRet == 0 )
+            nRet = drmSyncobjTransfer( GetDrmRenderFD(), m_uSyncobjHandle, ulPoint, uBinaryHandle, 0, 0 );
+        if ( nRet != 0 )
+            s_TimelineLog.errorf_errno( "Importing a dma-buf sync file failed with: ret = %d", nRet );
+
+        if ( uBinaryHandle )
+            drmSyncobjDestroy( GetDrmRenderFD(), uBinaryHandle );
+        close( exportSyncFile.fd );
+
+        return nRet == 0;
     }
 
     // CTimelinePoint

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -46,6 +46,8 @@ namespace gamescope
         uint32_t GetSyncobjHandle() const { return m_uSyncobjHandle; }
 
         std::shared_ptr<VulkanTimelineSemaphore_t> ToVkSemaphore();
+
+        bool ImportDmabufFences( int32_t nDmabufFd, uint64_t ulPoint );
         
     private:
         int32_t m_nSyncobjFd = -1;

--- a/src/commit.h
+++ b/src/commit.h
@@ -65,6 +65,10 @@ struct commit_t final : public gamescope::RcObject, public gamescope::IWaitable,
 	bool is_steam = false;
 	uint32_t appID = 0;
 	std::optional<wlserver_vk_swapchain_feedback> feedback = std::nullopt;
+	// GPU readiness of vulkanTex, when the client or gamescope signals one.
+	std::shared_ptr<gamescope::CAcquireTimelinePoint> pAcquirePoint;
+	// vulkanTex is a whole frame of the override surface, merged Xwayland blits included.
+	bool bOverrideContent = false;
 
 	uint64_t win_seq = 0;
 	struct wlr_surface *surf = nullptr;

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1825,6 +1825,12 @@ void CVulkanCmdBuffer::copyImage(gamescope::Rc<CVulkanTexture> src, gamescope::R
 {
 	assert(src->width() == dst->width());
 	assert(src->height() == dst->height());
+	copyImageRegion(src, std::move(dst), 0, 0, src->width(), src->height());
+}
+
+void CVulkanCmdBuffer::copyImageRegion(gamescope::Rc<CVulkanTexture> src, gamescope::Rc<CVulkanTexture> dst, int32_t x, int32_t y, uint32_t width, uint32_t height)
+{
+	assert(src->format() == dst->format());
 	prepareSrcImage(src.get());
 	prepareDestImage(dst.get());
 	insertBarrier();
@@ -1834,13 +1840,15 @@ void CVulkanCmdBuffer::copyImage(gamescope::Rc<CVulkanTexture> src, gamescope::R
 			.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
 			.layerCount = 1
 		},
+		.srcOffset = { x, y, 0 },
 		.dstSubresource = {
 			.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
 			.layerCount = 1
 		},
+		.dstOffset = { x, y, 0 },
 		.extent = {
-			.width = src->width(),
-			.height = src->height(),
+			.width = width,
+			.height = height,
 			.depth = 1
 		},
 	};
@@ -2163,6 +2171,13 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 		};
 
 		res = getModifierProps( &imageInfo, pDMA->modifier, &externalImageProperties );
+		// Clients pick modifiers advertised for sampling alone, transfer is a bonus.
+		if ( res == VK_ERROR_FORMAT_NOT_SUPPORTED && flags.bTransferSrc )
+		{
+			flags.bTransferSrc = false;
+			imageInfo.usage &= ~VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+			res = getModifierProps( &imageInfo, pDMA->modifier, &externalImageProperties );
+		}
 		if ( res != VK_SUCCESS && res != VK_ERROR_FORMAT_NOT_SUPPORTED ) {
 			vk_errorf( res, "getModifierProps failed" );
 			return false;
@@ -2188,6 +2203,8 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 			imageInfo.tiling = tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
 		}
 	}
+
+	m_bTransferSrc = flags.bTransferSrc;
 
 	std::vector<uint64_t> modifiers = {};
 	// TODO(JoshA): Move this code to backend for making flippable image.
@@ -3651,6 +3668,7 @@ gamescope::OwningRc<CVulkanTexture> vulkan_create_texture_from_dmabuf( struct wl
 
 	CVulkanTexture::createFlags texCreateFlags;
 	texCreateFlags.bSampled = true;
+	texCreateFlags.bTransferSrc = true;
 
 	//fprintf(stderr, "pDMA->width: %d pDMA->height: %d pDMA->format: 0x%x pDMA->modifier: 0x%lx pDMA->n_planes: %d\n",
 	//	pDMA->width, pDMA->height, pDMA->format, pDMA->modifier, pDMA->n_planes);
@@ -4557,6 +4575,7 @@ gamescope::OwningRc<CVulkanTexture> vulkan_create_texture_from_wlr_buffer( struc
 	gamescope::OwningRc<CVulkanTexture> pTex = new CVulkanTexture();
 	CVulkanTexture::createFlags texCreateFlags;
 	texCreateFlags.bSampled = true;
+	texCreateFlags.bTransferSrc = true;
 	texCreateFlags.bTransferDst = true;
 	texCreateFlags.bFlippable = true;
 	if ( pTex->BInit( width, height, 1u, drmFormat, texCreateFlags, nullptr, 0, 0, nullptr, pBackendFb ) == false )

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1521,6 +1521,11 @@ void CVulkanCmdBuffer::AddSignal( std::shared_ptr<VulkanTimelineSemaphore_t> pTi
 	m_ExternalSignals.emplace_back( std::move( pTimelineSemaphore ), ulPoint );
 }
 
+void CVulkanCmdBuffer::AddReleasePoint( std::shared_ptr<gamescope::CReleaseTimelinePoint> pReleasePoint )
+{
+	m_releasePoints.emplace_back( std::move( pReleasePoint ) );
+}
+
 void CVulkanDevice::wait(uint64_t sequence, bool reset)
 {
 	if (m_submissionSeqNo == sequence)
@@ -1575,6 +1580,7 @@ void CVulkanCmdBuffer::reset()
 {
 	vk_check( m_device->vk.ResetCommandBuffer(m_cmdBuffer, 0) );
 	m_textureRefs.clear();
+	m_releasePoints.clear();
 	m_usedDescriptorSets.clear();
 	m_textureState.clear();
 

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -180,6 +180,7 @@ public:
 	inline gamescope::IBackendFb* GetBackendFb() { return m_pBackendFb.get(); }
 	inline uint8_t *mappedData() { return m_pMappedData; }
 	inline VkFormat format() const { return m_format; }
+	inline bool transferSrc() const { return m_bTransferSrc; }
 	inline const struct wlr_dmabuf_attributes& dmabuf() { return m_dmabuf; }
 	inline VkImage vkImage() { return m_vkImage; }
 	inline bool outputImage() { return m_bOutputImage; }
@@ -210,6 +211,7 @@ public:
 private:
 	bool m_bInitialized = false;
 	bool m_bExternal = false;
+	bool m_bTransferSrc = false;
 	bool m_bOutputImage = false;
 
 	uint32_t m_drmFormat = DRM_FORMAT_INVALID;
@@ -995,6 +997,7 @@ public:
 	void bindPipeline(VkPipeline pipeline);
 	void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1);
 	void copyImage(gamescope::Rc<CVulkanTexture> src, gamescope::Rc<CVulkanTexture> dst);
+	void copyImageRegion(gamescope::Rc<CVulkanTexture> src, gamescope::Rc<CVulkanTexture> dst, int32_t x, int32_t y, uint32_t width, uint32_t height);
 	void copyBufferToImage(VkBuffer buffer, VkDeviceSize offset, uint32_t stride, gamescope::Rc<CVulkanTexture> dst);
 
 

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -1012,6 +1012,8 @@ public:
 
 	void AddDependency( std::shared_ptr<VulkanTimelineSemaphore_t> pTimelineSemaphore, uint64_t ulPoint );
 	void AddSignal( std::shared_ptr<VulkanTimelineSemaphore_t> pTimelineSemaphore, uint64_t ulPoint );
+	// Retain release points until the submitted GPU work completes.
+	void AddReleasePoint( std::shared_ptr<gamescope::CReleaseTimelinePoint> pReleasePoint );
 
 	const std::vector<VulkanTimelinePoint_t> &GetExternalDependencies() const { return m_ExternalDependencies; }
 	const std::vector<VulkanTimelinePoint_t> &GetExternalSignals() const { return m_ExternalSignals; }
@@ -1028,6 +1030,7 @@ private:
 
 	// Per Use State
 	std::vector<gamescope::Rc<CVulkanTexture>> m_textureRefs;
+	std::vector<std::shared_ptr<gamescope::CReleaseTimelinePoint>> m_releasePoints;
 	std::vector<uint32_t> m_usedDescriptorSets;
 	std::unordered_map<CVulkanTexture *, TextureState> m_textureState;
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1002,14 +1002,6 @@ struct BaseLayerInfo_t
 	AlphaBlendingMode_t eAlphaBlendingMode = ALPHA_BLENDING_MODE_PREMULTIPLIED;
 };
 
-struct TempUpscaleImage_t
-{
-	gamescope::OwningRc<CVulkanTexture> pTexture;
-	// Timeline of upscale -> release, to be used as acquire for the commit.
-	std::shared_ptr<gamescope::CTimeline> pReleaseTimeline;
-	uint64_t ulLastPoint = 0ul;
-};
-
 struct global_focus_t : public focus_t
 {
 	steamcompmgr_win_t	  	 		*keyboardFocusWindow;
@@ -1020,7 +1012,7 @@ struct global_focus_t : public focus_t
 	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
 	// Cleanup for the previous pre-emptive upscale, kept a frame behind.
 	std::optional<uint64_t> oLastPreemptiveUpscaleSeqNo;
-	std::vector<TempUpscaleImage_t> UpscaleImages;
+	std::vector<PooledImage_t> UpscaleImages;
 	uint32_t uNextUpscaleImage = 0;
 
 	std::array< gamescope::Rc<commit_t>, HELD_COMMIT_COUNT > HeldCommits;
@@ -8040,7 +8032,7 @@ static void ClearUpscaleImages( global_focus_t *pFocus )
 	pFocus->uNextUpscaleImage = 0;
 }
 
-static TempUpscaleImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat )
+static PooledImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t uWidth, uint32_t uHeight, uint32_t uDrmFormat )
 {
 	if ( pFocus->UpscaleImages.size() )
 	{
@@ -8059,7 +8051,7 @@ static TempUpscaleImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t
 	for ( size_t i = 0; i < pFocus->UpscaleImages.size(); i++ )
 	{
 		size_t uIndex = ( pFocus->uNextUpscaleImage + i ) % pFocus->UpscaleImages.size();
-		TempUpscaleImage_t &image = pFocus->UpscaleImages[ uIndex ];
+		PooledImage_t &image = pFocus->UpscaleImages[ uIndex ];
 		if ( !image.pTexture->IsInUse() )
 		{
 			pFocus->uNextUpscaleImage = ( uIndex + 1 ) % pFocus->UpscaleImages.size();
@@ -8084,9 +8076,144 @@ static TempUpscaleImage_t *GetTempUpscaleImage( global_focus_t *pFocus, uint32_t
 	imageFlags.bStorage = true;
 	imageFlags.bFlippable = true;
 	pTexture->BInit( g_nOutputWidth, g_nOutputHeight, 1, uDrmFormat, imageFlags );
-	TempUpscaleImage_t &image = pFocus->UpscaleImages.emplace_back( std::move( pTexture ), std::move( pTimeline ) );
+	PooledImage_t &image = pFocus->UpscaleImages.emplace_back( std::move( pTexture ), std::move( pTimeline ) );
 
 	return &image;
+}
+
+static PooledImage_t *GetOverrideBlitImage( steamcompmgr_win_t *w, CVulkanTexture *pLike )
+{
+	auto &images = w->overrideBlitImages;
+	if ( !images.empty() &&
+		 ( images[0].pTexture->width() != pLike->width() ||
+		   images[0].pTexture->height() != pLike->height() ||
+		   images[0].pTexture->drmFormat() != pLike->drmFormat() ) )
+	{
+		images.clear();
+		w->uNextOverrideBlitImage = 0;
+	}
+
+	// Round robin so a slot rests as long as possible.
+	for ( size_t i = 0; i < images.size(); i++ )
+	{
+		size_t uIndex = ( w->uNextOverrideBlitImage + i ) % images.size();
+		if ( !images[ uIndex ].pTexture->IsInUse() )
+		{
+			w->uNextOverrideBlitImage = ( uIndex + 1 ) % images.size();
+			return &images[ uIndex ];
+		}
+	}
+
+	if ( images.size() >= 8 )
+	{
+		xwm_log.warnf( "No override blit images free!" );
+		return nullptr;
+	}
+
+	std::shared_ptr<gamescope::CTimeline> pTimeline = gamescope::CTimeline::Create();
+	if ( !pTimeline )
+		return nullptr;
+
+	gamescope::OwningRc<CVulkanTexture> pTexture = new CVulkanTexture();
+	CVulkanTexture::createFlags imageFlags;
+	imageFlags.bSampled = true;
+	imageFlags.bTransferSrc = true;
+	imageFlags.bTransferDst = true;
+	// Only the modifier path needs a format the planes take.
+	imageFlags.bFlippable = !GetBackend()->UsesModifiers() || GetBackend()->SupportsFormat( pLike->drmFormat() );
+	if ( !pTexture->BInit( pLike->width(), pLike->height(), 1, pLike->drmFormat(), imageFlags ) )
+		return nullptr;
+
+	return &images.emplace_back( std::move( pTexture ), std::move( pTimeline ) );
+}
+
+struct BufferWait_t
+{
+	std::shared_ptr<VulkanTimelineSemaphore_t> pSemaphore;
+	uint64_t ulPoint = 0;
+};
+
+// The producer's signal for pBuffer, put on the image's timeline when it is only implicit.
+static std::optional<BufferWait_t> GetBufferWait( PooledImage_t &image, const std::shared_ptr<gamescope::CAcquireTimelinePoint> &pAcquirePoint, struct wlr_buffer *pBuffer )
+{
+	if ( pAcquirePoint )
+		return BufferWait_t{ pAcquirePoint->GetTimeline()->ToVkSemaphore(), pAcquirePoint->GetPoint() };
+
+	// shm uploads are waited for at import.
+	struct wlr_dmabuf_attributes dmabuf = {0};
+	if ( !wlr_buffer_get_dmabuf( pBuffer, &dmabuf ) )
+		return BufferWait_t{};
+
+	const uint64_t ulPoint = ++image.ulLastPoint;
+	if ( !image.pReleaseTimeline->ImportDmabufFences( dmabuf.fd[0], ulPoint ) )
+		return std::nullopt;
+
+	return BufferWait_t{ image.pReleaseTimeline->ToVkSemaphore(), ulPoint };
+}
+
+// Include pending frames so a blit cannot hide a newer override present.
+static gamescope::Rc<commit_t> NewestOverrideFrame( steamcompmgr_win_t *w )
+{
+	for ( auto it = w->commit_queue.rbegin(); it != w->commit_queue.rend(); ++it )
+	{
+		if ( (*it)->bOverrideContent )
+			return *it;
+	}
+	return nullptr;
+}
+
+// A bypassing client's pixmap holds only its GDI blits, lay them over the frame.
+static bool MergeBlitsOverOverride( steamcompmgr_win_t *w, commit_t *pCommit, commit_t *pBase, const ResListEntry_t &entry )
+{
+	gamescope::Rc<CVulkanTexture> pBlits = pCommit->vulkanTex;
+	if ( entry.damage.empty() || pBlits->format() != pBase->vulkanTex->format() || !pBlits->transferSrc() || !pBase->vulkanTex->transferSrc() )
+		return false;
+
+	// The layer only bypasses a child within 2px of its toplevel.
+	if ( std::abs( int32_t( pBlits->width() ) - int32_t( pBase->vulkanTex->width() ) ) > 2 ||
+		 std::abs( int32_t( pBlits->height() ) - int32_t( pBase->vulkanTex->height() ) ) > 2 )
+		return false;
+
+	PooledImage_t *pImage = GetOverrideBlitImage( w, pBase->vulkanTex.get() );
+	if ( !pImage )
+		return false;
+
+	std::optional<BufferWait_t> oBaseWait = GetBufferWait( *pImage, pBase->pAcquirePoint, pBase->buf );
+	std::optional<BufferWait_t> oBlitWait = GetBufferWait( *pImage, entry.pAcquirePoint, entry.buf );
+	if ( !oBaseWait || !oBlitWait )
+		return false;
+
+	gamescope::Rc<CVulkanTexture> pTarget = pImage->pTexture;
+	std::unique_ptr<CVulkanCmdBuffer> pCmdBuffer = g_device.commandBuffer();
+	if ( oBaseWait->pSemaphore )
+		pCmdBuffer->AddDependency( oBaseWait->pSemaphore, oBaseWait->ulPoint );
+	if ( oBlitWait->pSemaphore )
+		pCmdBuffer->AddDependency( oBlitWait->pSemaphore, oBlitWait->ulPoint );
+
+	pCmdBuffer->copyImage( pBase->vulkanTex, pTarget );
+
+	const int32_t nWidth = std::min( pBlits->width(), pTarget->width() );
+	const int32_t nHeight = std::min( pBlits->height(), pTarget->height() );
+	for ( const pixman_box32_t &box : entry.damage )
+	{
+		const int32_t x1 = std::max( box.x1, 0 );
+		const int32_t y1 = std::max( box.y1, 0 );
+		const int32_t x2 = std::min( box.x2, nWidth );
+		const int32_t y2 = std::min( box.y2, nHeight );
+		if ( x2 > x1 && y2 > y1 )
+			pCmdBuffer->copyImageRegion( pBlits, pTarget, x1, y1, x2 - x1, y2 - y1 );
+	}
+
+	const uint64_t ulPoint = ++pImage->ulLastPoint;
+	pCmdBuffer->AddSignal( pImage->pReleaseTimeline->ToVkSemaphore(), ulPoint );
+	if ( entry.pReleasePoint )
+		pCmdBuffer->AddReleasePoint( entry.pReleasePoint );
+	g_device.submit( std::move( pCmdBuffer ) );
+
+	pCommit->vulkanTex = std::move( pTarget );
+	pCommit->bOverrideContent = true;
+	pCommit->pAcquirePoint = std::make_shared<gamescope::CAcquireTimelinePoint>( pImage->pReleaseTimeline, ulPoint );
+	return true;
 }
 
 gamescope::ConVar<bool> cv_surface_update_force_only_current_surface( "surface_update_force_only_current_surface", false, "Force updates to apply only to the current surface, ignoring commits for other surfaces." );
@@ -8132,6 +8259,12 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 	bool bOnlyCurrentSurface = w->bHasHadNonSRGBColorSpace || bPossiblyBogus || !bHasDamage || cv_surface_update_force_only_current_surface;
 
 	bool for_current_surface = !w->override_surface() || w->current_surface() == reslistentry.surf;
+
+	if ( !w->override_surface() )
+	{
+		w->overrideBlitImages.clear();
+		w->uNextOverrideBlitImage = 0;
+	}
 
 	if ( !for_current_surface )
 	{
@@ -8184,6 +8317,21 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 	{
 		// Import failed to import, early exit.
 		return;
+	}
+
+	newCommit->bOverrideContent = reslistentry.surf == w->override_surface();
+	newCommit->pAcquirePoint = reslistentry.pAcquirePoint;
+
+	bool bMerged = false;
+	if ( gamescope::Rc<commit_t> pBase = for_current_surface ? nullptr : NewestOverrideFrame( w ) )
+	{
+		bMerged = MergeBlitsOverOverride( w, newCommit.get(), pBase.get(), reslistentry );
+		// The bare pixmap would flash the frame black, so drop the blit instead.
+		if ( !bMerged )
+		{
+			w->receivedDoneCommit = true;
+			return;
+		}
 	}
 
 	int fence = -1;
@@ -8254,7 +8402,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		zoomScaleRatio = flOldZoomScale;
 		overscanScaleRatio = flOldOverscanScale;
 
-		TempUpscaleImage_t *pTempImage = GetTempUpscaleImage( pUpscaleFocus, g_nOutputWidth, g_nOutputHeight, g_output.uOutputFormat );
+		PooledImage_t *pTempImage = GetTempUpscaleImage( pUpscaleFocus, g_nOutputWidth, g_nOutputHeight, g_output.uOutputFormat );
 		if ( pTempImage )
 		{
 			const uint64_t ulNextReleasePoint = ++pTempImage->ulLastPoint;
@@ -8307,13 +8455,14 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 			ClearUpscaleImages( pUpscaleFocus );
 		}
 
-		if ( reslistentry.pAcquirePoint )
+		if ( newCommit->pAcquirePoint )
 		{
-			eventFd = reslistentry.pAcquirePoint->CreateEventFd();
+			eventFd = newCommit->pAcquirePoint->CreateEventFd();
 		}
 	}
 
-	if ( gamescope::IBackendFb *pBackendFb = newCommit->vulkanTex->GetBackendFb() )
+	// A merged frame is gamescope's own image, the client buffer was only read.
+	if ( gamescope::IBackendFb *pBackendFb = bMerged ? nullptr : newCommit->vulkanTex->GetBackendFb() )
 	{
 		if ( reslistentry.pReleasePoint )
 			pBackendFb->SetReleasePoint( reslistentry.pReleasePoint );
@@ -8325,6 +8474,13 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 	{
 		fence = eventFd.first;
 		bKnownReady = eventFd.second;
+	}
+	else if ( bMerged )
+	{
+		// The client fence does not cover the copy, so wait for its point here.
+		if ( !newCommit->pAcquirePoint->Wait() )
+			xwm_log.errorf( "Waiting for a merged blit failed, presenting it anyway." );
+		bKnownReady = true;
 	}
 	else
 	{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8124,8 +8124,8 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 	bool bPossiblyBogus = reslistentry.buf->width <= 2 || reslistentry.buf->height <= 2;
 
 	// If the buffer has no damage, always prefer our override surface.
-	bool bHasDamage = ( reslistentry.surf->buffer_damage.extents.x2 - reslistentry.surf->buffer_damage.extents.x1 ) > 2 &&
-					  ( reslistentry.surf->buffer_damage.extents.y2 - reslistentry.surf->buffer_damage.extents.y1 ) > 2;
+	bool bHasDamage = ( reslistentry.damageExtents.x2 - reslistentry.damageExtents.x1 ) > 2 &&
+					  ( reslistentry.damageExtents.y2 - reslistentry.damageExtents.y1 ) > 2;
 
 	// If we have an override surface, make sure this commit is for the current surface
 	// or if the commit is probably bogus.

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -7,10 +7,20 @@
 #include <wlr/util/box.h>
 
 #include "xwayland_ctx.hpp"
+#include "Timeline.h"
 #include "gamescope-control-protocol.h"
 
 struct commit_t;
 struct wlserver_vk_swapchain_feedback;
+class CVulkanTexture;
+
+struct PooledImage_t
+{
+	gamescope::OwningRc<CVulkanTexture> pTexture;
+	// Tracks imported producer fences and completion of writes to this image.
+	std::shared_ptr<gamescope::CTimeline> pReleaseTimeline;
+	uint64_t ulLastPoint = 0ul;
+};
 
 struct wlserver_x11_surface_info
 {
@@ -163,6 +173,10 @@ struct steamcompmgr_win_t {
 
 	std::vector< gamescope::Rc<commit_t> > commit_queue;
 	std::shared_ptr<std::vector< uint32_t >> icon;
+
+	// Xwayland blits merged onto the override surface's frames, see MergeBlitsOverOverride.
+	std::vector<PooledImage_t> overrideBlitImages;
+	size_t uNextOverrideBlitImage = 0;
 
 	steamcompmgr_win_type_t		type;
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -164,8 +164,16 @@ ResListEntry_t PrepareCommit( struct wlr_surface *surf, struct wlr_buffer *buf )
 		wl_surf->present_id,
 		wl_surf->desired_present_time,
 		std::move( pAcquirePoint ),
-		std::move( pReleasePoint )
+		std::move( pReleasePoint ),
 	};
+	newEntry.damageExtents = *pixman_region32_extents( &surf->buffer_damage );
+	// Only a window with an override surface merges its blits, spare the rest the copy.
+	if ( wl_surf->x11_surface && wl_surf->x11_surface->override_surface )
+	{
+		int nDamageRects = 0;
+		pixman_box32_t *pDamageRects = pixman_region32_rectangles( &surf->buffer_damage, &nDamageRects );
+		newEntry.damage.assign( pDamageRects, pDamageRects + nDamageRects );
+	}
 	wl_surf->present_id = std::nullopt;
 	wl_surf->desired_present_time = 0;
 	wl_surf->pending_presentation_feedbacks.clear();

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -50,6 +50,9 @@ struct ResListEntry_t {
 	uint64_t desired_present_time;
 	std::shared_ptr<gamescope::CAcquireTimelinePoint> pAcquirePoint;
 	std::shared_ptr<gamescope::CReleaseTimelinePoint> pReleasePoint;
+	// Buffer damage of this commit, in buffer coordinates.
+	pixman_box32_t damageExtents;
+	std::vector<pixman_box32_t> damage;
 };
 
 struct wlserver_content_override;


### PR DESCRIPTION
Games mixing Vulkan presentation with GDI drawing can show black or stale content outside the blitted rectangle because the Xwayland pixmap lacks the bypassed Vulkan frame. This affects UBOAT’s launcher and The Fruit of Grisaia.

Merge Xwayland’s damaged regions onto the latest override frame, preserving earlier blits until the next override present. This retains WSI bypass at the cost of one full-frame copy per blit. Preservation follows Xwayland’s reported damage, which can include untouched pixels when clipping or damage coalescing produces a bounding box.