### PR TITLE
Added --inhibit-idle as an option for nested wayland sessions

### DIFF
--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -11,7 +11,7 @@ wayland_protos = dependency('wayland-protocols',
 )
 wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
 
-protocols = [
+server_protocols = [
 	# Upstream protocols
 	wl_protocol_dir / 'stable/linux-dmabuf/linux-dmabuf-v1.xml',
 	wl_protocol_dir / 'stable/viewporter/viewporter.xml',
@@ -47,10 +47,18 @@ protocols = [
 	'wlr-layer-shell-unstable-v1.xml',
 ]
 
+# Wayland protocols that may be utilised if exposed by parent compositor 
+# These are NOT implemented by gamescope
+client_protocols = [
+    wl_protocol_dir / 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml',
+]
+
+all_protocols = server_protocols + client_protocols
+
 protocols_client_src = []
 protocols_server_src = []
 
-foreach xml : protocols
+foreach xml : all_protocols
 	name = fs.name(xml).replace('.xml', '')
 
 	code = custom_target(
@@ -60,13 +68,6 @@ foreach xml : protocols
 		command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
 	)
 
-	server_header = custom_target(
-		name + '-protocol.h',
-		input: xml,
-		output: '@BASENAME@-protocol.h',
-		command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
-	)
-
 	client_header = custom_target(
 		name + '-client-protocol.h',
 		input: xml,
@@ -74,6 +75,18 @@ foreach xml : protocols
 		command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
 	)
 
-	protocols_server_src += [code, server_header]
 	protocols_client_src += [code, client_header]
+endforeach
+
+foreach xml: server_protocols
+	name = fs.name(xml).replace('.xml', '')
+
+	server_header = custom_target(
+		name + '-protocol.h',
+		input: xml,
+		output: '@BASENAME@-protocol.h',
+		command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+	)
+
+	protocols_server_src += [code, server_header]
 endforeach

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -35,6 +35,7 @@
 #include <primary-selection-unstable-v1-client-protocol.h>
 #include <fractional-scale-v1-client-protocol.h>
 #include <xdg-toplevel-icon-v1-client-protocol.h>
+#include <idle-inhibit-unstable-v1-client-protocol.h>
 #include "wlr_end.hpp"
 
 #include "drm_include.h"
@@ -43,6 +44,7 @@
 
 extern int g_nPreferredOutputWidth;
 extern int g_nPreferredOutputHeight;
+extern bool g_bNestedWaylandInhibitIdle;
 extern bool g_bForceHDR10OutputDebug;
 extern bool g_bBorderlessOutputWindow;
 extern gamescope::ConVar<bool> cv_adaptive_sync;
@@ -294,6 +296,7 @@ namespace gamescope
         wp_color_management_surface_feedback_v1 *m_pWPColorManagedSurfaceFeedback = nullptr;
         wp_fractional_scale_v1 *m_pFractionalScale = nullptr;
         wl_subsurface *m_pSubsurface = nullptr;
+        zwp_idle_inhibitor_v1 *m_pIdleInhibitor = nullptr;
         libdecor_frame *m_pFrame = nullptr;
         libdecor_window_state m_eWindowState = LIBDECOR_WINDOW_STATE_NONE;
         std::vector<wl_output *> m_pOutputs;
@@ -715,6 +718,7 @@ namespace gamescope
         wp_image_description_v1 *GetWPImageDescription( GamescopeAppTextureColorspace eColorspace ) const { return m_pWPImageDescriptions[ (uint32_t)eColorspace ]; }
         wp_fractional_scale_manager_v1 *GetFractionalScaleManager() const { return m_pFractionalScaleManager; }
         xdg_toplevel_icon_manager_v1 *GetToplevelIconManager() const { return m_pToplevelIconManager; }
+        zwp_idle_inhibit_manager_v1 *GetIdleInhibitManager() const { return m_pIdleInhibitManager; }
         libdecor *GetLibDecor() const { return m_pLibDecor; }
 
         void UpdateFullscreenState();
@@ -805,6 +809,7 @@ namespace gamescope
         zwp_relative_pointer_manager_v1 *m_pRelativePointerManager = nullptr;
         wp_fractional_scale_manager_v1 *m_pFractionalScaleManager = nullptr;
         xdg_toplevel_icon_manager_v1 *m_pToplevelIconManager = nullptr;
+        zwp_idle_inhibit_manager_v1 *m_pIdleInhibitManager = nullptr;
 
         // TODO: Restructure and remove the need for this.
         std::atomic<CWaylandConnector *> m_pFocusConnector;
@@ -1373,6 +1378,8 @@ namespace gamescope
             wp_viewport_destroy( m_pViewport );
         if ( m_pSurface )
             wl_surface_destroy( m_pSurface );
+        if ( m_pIdleInhibitor )
+            zwp_idle_inhibitor_v1_destroy( m_pIdleInhibitor );
     }
 
     bool CWaylandPlane::Init( CWaylandPlane *pParent, CWaylandPlane *pSiblingBelow )
@@ -1428,6 +1435,11 @@ namespace gamescope
             wl_subsurface_set_sync( m_pSubsurface );
 			// Allow pParent to receive input while covered by subsurface planes
 			wl_surface_set_input_region( m_pSurface, m_pBackend->GetEmptyRegion() );
+        }
+
+        if( !pParent && m_pBackend->GetIdleInhibitManager() && g_bNestedWaylandInhibitIdle )
+        {
+            m_pIdleInhibitor = zwp_idle_inhibit_manager_v1_create_inhibitor( m_pBackend->GetIdleInhibitManager(), m_pSurface );
         }
 
         wl_surface_commit( m_pSurface );
@@ -2573,6 +2585,10 @@ namespace gamescope
         else if ( !strcmp( pInterface, zwp_primary_selection_device_manager_v1_interface.name ) )
         {
             m_pPrimarySelectionDeviceManager = (zwp_primary_selection_device_manager_v1 *)wl_registry_bind( pRegistry, uName, &zwp_primary_selection_device_manager_v1_interface, 1u );
+        }
+        else if ( !strcmp( pInterface, zwp_idle_inhibit_manager_v1_interface.name) )
+        {
+            m_pIdleInhibitManager = (zwp_idle_inhibit_manager_v1 *)wl_registry_bind( pRegistry, uName, &zwp_idle_inhibit_manager_v1_interface, 1u );
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "grab", no_argument, nullptr, 'g' },
 	{ "force-grab-cursor", no_argument, nullptr, 0 },
 	{ "display-index", required_argument, nullptr, 0 },
+    { "inhibit-idle", no_argument, nullptr, 0 },
 
 	// embedded mode options
 	{ "disable-layers", no_argument, nullptr, 0 },
@@ -227,7 +228,8 @@ const char usage[] =
 	"  -f, --fullscreen               make the window fullscreen\n"
 	"  -g, --grab                     grab the keyboard\n"
 	"  --force-grab-cursor            always use relative mouse mode instead of flipping dependent on cursor visibility.\n"
-	"  --display-index                forces gamescope to use a specific display in nested mode."
+	"  --display-index                forces gamescope to use a specific display in nested mode.\n"
+    "  --inhibit-idle                 if the parent compositor is Wayland, attempts to disable idle detection. You should use this when using a gamepad which is not recognised by libinput and therefore does not send activity signals to Wayland.\n"
 	"\n"
 	"Embedded mode options:\n"
 	"  -O, --prefer-output            list of connectors in order of preference (ex: DP-1,DP-2,DP-3,HDMI-A-1)\n"
@@ -298,6 +300,7 @@ int g_nNestedHeight = 0;
 int g_nNestedRefresh = 0;
 int g_nNestedUnfocusedRefresh = 0;
 int g_nNestedDisplayIndex = 0;
+bool g_bNestedWaylandInhibitIdle = false;
 
 uint32_t g_nOutputWidth = 0;
 uint32_t g_nOutputHeight = 0;
@@ -840,6 +843,8 @@ int main(int argc, char **argv)
 					g_bForceRelativeMouse = true;
 				} else if (strcmp(opt_name, "display-index") == 0) {
 					g_nNestedDisplayIndex = parse_integer( optarg, opt_name );
+                } else if (strcmp(opt_name, "inhibit-idle") == 0) {
+                    g_bNestedWaylandInhibitIdle = true;
 				} else if (strcmp(opt_name, "adaptive-sync") == 0) {
 					cv_adaptive_sync = true;
 				} else if (strcmp(opt_name, "expose-wayland") == 0) {


### PR DESCRIPTION
An existing issue with Wayland based compositors is that libinput does not (and is not planned to) handle input from gamepad-like devices. There are existing utilities to work around this limitation, however these necessarily do not report gamepad input to the compositor directly. Hence gamepad input will not trigger any idle-detection mechanism implemented by the compositor.

I have added an option "--inhibit-idle" to cause gamescope to indicate to the parent compositor that it should not enter an idle state. This functionality makes use of Wayland protocol [zwp_idle_inhibit_manager_v1](https://wayland.app/protocols/idle-inhibit-unstable-v1#zwp_idle_inhibit_manager_v1), and so the app will not block idle "If the surface is destroyed, unmapped, becomes occluded, loses visibility, or otherwise becomes not visually relevant for the user".

If gamescope is not nested beneath a Wayland based compositor, or that compositor does not implement zwp_idle_inhibit_manager, this option will be ignored.

I've tested that this option is correctly respected when running nested within a wlroots based compositor. I have not been able to test the cases of non-Wayland compositors or running unnested.