### PR TITLE
steamcompmgr: keep nested menus visible and correctly stacked

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4067,7 +4067,10 @@ is_focus_priority_greater( steamcompmgr_win_t *a, steamcompmgr_win_t *b )
 		!a->xwayland().transientFor != !b->xwayland().transientFor )
 		return !a->xwayland().transientFor;
 
-	if ( win_has_game_id( a ) && a->xwayland().map_sequence != b->xwayland().map_sequence )
+	// A newly mapped sibling menu must displace an older menu even if a focus
+	// pass raised the older one between the new window's creation and mapping.
+	if ( ( win_has_game_id( a ) || ( win_maybe_a_dropdown( a ) && win_maybe_a_dropdown( b ) ) ) &&
+		a->xwayland().map_sequence != b->xwayland().map_sequence )
 		return a->xwayland().map_sequence > b->xwayland().map_sequence;
 
 	// The damage sequences are only relevant for game windows.
@@ -4695,21 +4698,64 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	if ( inputFocus == ctx->focus.focusWindow && ctx->focus.overrideWindowMouse )
 		inputFocus = ctx->focus.overrideWindowMouse;
 
-	// X routes the pointer by stacking, so the mouse pick's base window goes under its override, above the rest.
-	bool bRaisedBase = false;
+	// X routes input by stacking. Raise the mouse pick together with its menus,
+	// preserving the parent menu above the base when a submenu takes the pick.
 	if ( mouseBaseWindow && mouseBaseWindow != inputFocus )
 	{
-		steamcompmgr_win_t *pTop = ctx->list;
-		bool bBaseStacked = pTop == mouseBaseWindow ||
-			( pTop == inputFocus && pTop->xwayland().next == mouseBaseWindow );
-		if ( !bBaseStacked )
+		size_t nWindowCount = 0;
+		steamcompmgr_win_t *pFirstMapped = nullptr;
+		for ( steamcompmgr_win_t *pWindow = ctx->list; pWindow; pWindow = pWindow->xwayland().next )
 		{
-			mouseBaseWindow->Raise();
-			bRaisedBase = true;
+			++nWindowCount;
+			if ( !pFirstMapped && pWindow->xwayland().a.map_state == IsViewable )
+				pFirstMapped = pWindow;
+		}
+
+		auto isMenu = [&]( steamcompmgr_win_t *candidate )
+		{
+			// Bound the transient walk so malformed cycles cannot hang the focus pass.
+			steamcompmgr_win_t *ancestor = candidate;
+			for ( size_t remaining = nWindowCount; remaining && ancestor &&
+				ancestor->xwayland().a.map_state == IsViewable && win_maybe_a_dropdown( ancestor ) &&
+				is_good_override_candidate( ancestor, mouseBaseWindow ); --remaining )
+			{
+				if ( ancestor->xwayland().transientFor == mouseBaseWindow->xwayland().id )
+					return true;
+				// No hint means app ownership. Explicit links elsewhere still win.
+				if ( !ancestor->xwayland().transientFor )
+					return true;
+				ancestor = find_win( ctx, ancestor->xwayland().transientFor, false );
+			}
+			return false;
+		};
+
+		bool bNeedsRestack = pFirstMapped != inputFocus;
+		bool bSeenBase = false;
+		for ( steamcompmgr_win_t *pWindow = ctx->list; !bNeedsRestack && pWindow; pWindow = pWindow->xwayland().next )
+		{
+			if ( pWindow->xwayland().a.map_state != IsViewable || pWindow == inputFocus )
+				continue;
+			if ( pWindow == mouseBaseWindow )
+				bSeenBase = true;
+			else if ( isMenu( pWindow ) == bSeenBase )
+				bNeedsRestack = true; // A non-menu window is above the base, or a menu is below it.
+		}
+
+		if ( bNeedsRestack && mouseBaseWindow->xwayland().a.map_state == IsViewable &&
+			inputFocus->xwayland().a.map_state == IsViewable )
+		{
+			std::vector<Window> order{ inputFocus->xwayland().id };
+			for ( steamcompmgr_win_t *pWindow = ctx->list; pWindow; pWindow = pWindow->xwayland().next )
+			{
+				if ( pWindow != inputFocus && pWindow != mouseBaseWindow && isMenu( pWindow ) )
+					order.push_back( pWindow->xwayland().id );
+			}
+			order.push_back( mouseBaseWindow->xwayland().id );
+			inputFocus->Raise();
+			XRestackWindows( ctx->dpy, order.data(), order.size() );
 		}
 	}
-
-	if ( bRaisedBase || ctx->list[0].xwayland().id != inputFocus->xwayland().id )
+	else if ( ctx->list[0].xwayland().id != inputFocus->xwayland().id )
 		inputFocus->Raise();
 
 	wlserver_lock();


### PR DESCRIPTION
Dolphin can lose submenus when a focus pass raises the old menu and base over a newly created, unmapped sibling. The mapped submenu then loses the override pick. Raising only the selected menu and base also buries the parent menu and misroutes clicks.

Check only mapped windows before restacking the mouse pick's menu group. Use transient links to keep other toplevels' menus separate, falling back to app ownership only when hints are absent. Prefer newer map sequences between tied dropdowns in every mode, including paths without a mouse connector where raising the old override can still bury an unmapped sibling.