### PR TITLE
buildSDRColorimetry: output-aware SDR source for PQ/HDR10 output

### DIFF
--- a/src/color_helpers.cpp
+++ b/src/color_helpers.cpp
@@ -835,7 +835,7 @@ bool BIsWideGamut( const displaycolorimetry_t & nativeDisplayOutput )
 }
 
 void buildSDRColorimetry( displaycolorimetry_t * pColorimetry, colormapping_t *pMapping,
-	float flSDRGamutWideness, const displaycolorimetry_t & nativeDisplayOutput  )
+	float flSDRGamutWideness, const displaycolorimetry_t & nativeDisplayOutput, EOTF outputEncodingEOTF )
 {
     if ( BIsWideGamut( nativeDisplayOutput) )
     {
@@ -858,45 +858,63 @@ void buildSDRColorimetry( displaycolorimetry_t * pColorimetry, colormapping_t *p
     }
     else
     {
-        // If not set, make it native.
+        // If not set, default to 0.0f.
         if (flSDRGamutWideness < 0 )
             flSDRGamutWideness = 0.0f;
 
-        // 0.0: Native
-        // 0.5: Generic wide gamut display w/smooth mapping
-        // 1.0: Generic wide gamut display w/harsh mapping
-
-        // This is a full blending to the unit cube, starting at 70% max sat
-        // Creates a smooth transition from in-gamut to out of gamut
-        colormapping_t smoothRemap;
-        smoothRemap.blendEnableMinSat = 0.7f;
-        smoothRemap.blendEnableMaxSat = 1.0f;
-        smoothRemap.blendAmountMin = 0.0f;
-        smoothRemap.blendAmountMax = 1.f;
-
-        // Assume linear saturation computation
-        // This is a partial (25%) blending to the unit cube
-        // Allows some (but not full) clipping
-        colormapping_t partialRemap;
-        partialRemap.blendEnableMinSat = 0.7f;
-        partialRemap.blendEnableMaxSat = 1.0f;
-        partialRemap.blendAmountMin = 0.0f;
-        partialRemap.blendAmountMax = 0.25;
-
-        displaycolorimetry_t wideGamutNativeWhite = displaycolorimetry_widegamutgeneric;
-        wideGamutNativeWhite.white = nativeDisplayOutput.white;
-
-        if ( flSDRGamutWideness < 0.5f )
+        if ( outputEncodingEOTF == EOTF_PQ )
         {
-            float t = cfit( flSDRGamutWideness, 0.f, 0.5f, 0.0f, 1.0f );
-            *pColorimetry = lerp( nativeDisplayOutput, wideGamutNativeWhite, t );
-            *pMapping = smoothRemap;
+            // PQ dest is an absolute D65 container, not the panel, so the
+            // saturation blend toward the dest cube does not apply; use a
+            // pure colorimetric map from a D65 source.
+            // 0.0: 709
+            // 0.5+: Generic wide gamut
+            colormapping_t noRemap;
+            noRemap.blendEnableMinSat = 0.7f;
+            noRemap.blendEnableMaxSat = 1.0f;
+            noRemap.blendAmountMin = 0.0f;
+            noRemap.blendAmountMax = 0.0f;
+            *pMapping = noRemap;
+            *pColorimetry = lerp( displaycolorimetry_709, displaycolorimetry_widegamutgeneric, cfit( flSDRGamutWideness, 0.f, 0.5f, 0.0f, 1.0f ) );
         }
         else
         {
-            float t = cfit( flSDRGamutWideness, 0.5f, 1.0f, 0.0f, 1.0f );
-            *pColorimetry = wideGamutNativeWhite;
-            *pMapping = lerp( smoothRemap, partialRemap, t );
+            // 0.0: Native
+            // 0.5: Generic wide gamut display w/smooth mapping
+            // 1.0: Generic wide gamut display w/harsh mapping
+
+            // This is a full blending to the unit cube, starting at 70% max sat
+            // Creates a smooth transition from in-gamut to out of gamut
+            colormapping_t smoothRemap;
+            smoothRemap.blendEnableMinSat = 0.7f;
+            smoothRemap.blendEnableMaxSat = 1.0f;
+            smoothRemap.blendAmountMin = 0.0f;
+            smoothRemap.blendAmountMax = 1.f;
+
+            // Assume linear saturation computation
+            // This is a partial (25%) blending to the unit cube
+            // Allows some (but not full) clipping
+            colormapping_t partialRemap;
+            partialRemap.blendEnableMinSat = 0.7f;
+            partialRemap.blendEnableMaxSat = 1.0f;
+            partialRemap.blendAmountMin = 0.0f;
+            partialRemap.blendAmountMax = 0.25;
+
+            displaycolorimetry_t wideGamutNativeWhite = displaycolorimetry_widegamutgeneric;
+            wideGamutNativeWhite.white = nativeDisplayOutput.white;
+
+            if ( flSDRGamutWideness < 0.5f )
+            {
+                float t = cfit( flSDRGamutWideness, 0.f, 0.5f, 0.0f, 1.0f );
+                *pColorimetry = lerp( nativeDisplayOutput, wideGamutNativeWhite, t );
+                *pMapping = smoothRemap;
+            }
+            else
+            {
+                float t = cfit( flSDRGamutWideness, 0.5f, 1.0f, 0.0f, 1.0f );
+                *pColorimetry = wideGamutNativeWhite;
+                *pMapping = lerp( smoothRemap, partialRemap, t );
+            }
         }
     }
 }

--- a/src/color_helpers.h
+++ b/src/color_helpers.h
@@ -383,10 +383,11 @@ void calcColorTransform( lut1d_t * pShaper, int nLutSize1d,
 	const lut3d_t * pLook, float flGain )
 
 // Build colorimetry and a gamut mapping for the given SDR configuration
-// Note: the output colorimetry will use the native display's white point
-// Only the color gamut will change
+// Note: the source colorimetry uses the native display's white point, except for
+// PQ output on non-wide displays, where it is built against the D65 container.
+// The outputEncodingEOTF parameter only affects non-wide displays.
 void buildSDRColorimetry( displaycolorimetry_t * pColorimetry, colormapping_t *pMapping,
-	float flSDRGamutWideness, const displaycolorimetry_t & nativeDisplayOutput );
+	float flSDRGamutWideness, const displaycolorimetry_t & nativeDisplayOutput, EOTF outputEncodingEOTF );
 
 // Build colorimetry and a gamut mapping for the given PQ configuration
 void buildPQColorimetry( displaycolorimetry_t * pColorimetry, colormapping_t *pMapping, const displaycolorimetry_t & nativeDisplayOutput );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -377,9 +377,10 @@ create_color_mgmt_luts(const gamescope_color_mgmt_t& newColorMgmt, gamescope_col
 				}
 
 				// The final display colorimetry is used to build the output mapping, as we want a gamut-aware handling
-				// for sdrGamutWideness indepdendent of the output encoding (for SDR data), and when mapping SDR -> PQ output
-				// we only want to utilize a portion of the gamut the actual display can reproduce
-				buildSDRColorimetry( &inputColorimetry, &colorMapping, newColorMgmt.sdrGamutWideness, displayColorimetry );
+				// for sdrGamutWideness independent of the output encoding (for SDR data). buildSDRColorimetry is
+				// output-aware: on a wide-gamut display SDR -> PQ uses a portion of the panel gamut; on a non-wide
+				// display it encodes SDR from an absolute 709/D65 source, since the sink owns the container->panel mapping.
+				buildSDRColorimetry( &inputColorimetry, &colorMapping, newColorMgmt.sdrGamutWideness, displayColorimetry, newColorMgmt.outputEncodingEOTF );
 			}
 			else if ( inputEOTF == EOTF_PQ )
 			{


### PR DESCRIPTION
For SDR content on an HDR10 output, `buildSDRColorimetry` treated the display as the destination. But on HDR10 the destination is a BT.2020 container, not the display.

Two problems follow:
1. The gamut mapping used for displays not classified as wide-gamut (`smoothRemap`/`partialRemap`) only makes sense when the destination is the display. Against a BT.2020 container it pushes saturated SDR toward full BT.2020 saturation, which the display clips, so SDR looks oversaturated and hue-shifted.
2. It used the panel's own colorimetry as the source. A container uses fixed absolute values (D65), not the panel's; the panel's values are only as trustworthy as its EDID, and junk or non-D65 EDID values get baked into the encoding.

This affects any display not classified as wide-gamut on HDR10. Related: #1887, #2331, #1827, #2138, #2242.

## Fix

Make `buildSDRColorimetry` aware of the output: when `outputEncodingEOTF == EOTF_PQ` on a display not classified as wide-gamut, use a D65 source and no gamut remap. The wide-gamut branch, the SDR-output (G22) path, screenshots, and luminance handling are unchanged.

The SDR-output path keeps the panel as its reference. At default wideness the source and destination are the same panel, so the EDID values cancel out and junk EDIDs only affect the relative mapping, never the absolute encoding.

## Testing

Tested on a Steam Machine driving an external HDR display (Sony A95K) whose EDID doesn't classify it as wide-gamut. SDR content in HDR Game Mode now renders as intended; before the fix it was oversaturated with hue shifts.

Note: on displays not classified as wide-gamut, `sdrGamutWideness` above 0.5 does nothing on this path (the source reaches `widegamutgeneric` at 0.5, and `noRemap` has nothing to change). Use `sdrGamutWideness` to turn saturation back up.
