### PR TITLE
build: bump meson required version to 0.60

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'gamescope',
   'c',
   'cpp',
-  meson_version: '>=0.58.0',
+  meson_version: '>=0.60.0',
   default_options: [
     'cpp_std=c++20',
     'warning_level=2',


### PR DESCRIPTION
Since be4ad80ac3dd36476bd0656384906dcb02e8fd5d, the install_tag argument is used in a call to configure_file(), which requires a newer version of meson.