### PR TITLE
gamescope-control: expose the keyboard layout request

### DIFF
--- a/protocol/gamescope-control.xml
+++ b/protocol/gamescope-control.xml
@@ -29,7 +29,7 @@
     it.
   </description>
 
-  <interface name="gamescope_control" version="6">
+  <interface name="gamescope_control" version="7">
     <request name="destroy" type="destructor"></request>
 
     <enum name="feature">
@@ -44,6 +44,7 @@
       <entry name="mura_correction" value="5"/>
       <entry name="look" value="6"/>
       <entry name="perf_query" value="7"/>
+      <entry name="keyboard_layout" value="8"/>
     </enum>
 
     <event name="feature_support">
@@ -142,6 +143,16 @@
       <arg name="frametime_ns_lo" type="uint" summary="Time delta between the two most recent frames"></arg>
       <arg name="frametime_ns_hi" type="uint" summary="frametime_ns high bits"></arg>
     </event>
+
+    <request name="set_keyboard_layout" since="7">
+      <description summary="Sets the XKB layout used for physical keyboards">
+        An empty layout goes back to the layout from the XKB_DEFAULT_*
+        environment, and a variant without a layout is ignored. A layout
+        that fails to compile is ignored and the current keymap is kept.
+      </description>
+      <arg name="layout" type="string" summary="XKB layout name, eg. fr"></arg>
+      <arg name="variant" type="string" summary="XKB layout variant, eg. bepo. Empty for the default variant"></arg>
+    </request>
 
   </interface>
 </protocol>

--- a/src/Apps/gamescopectl.cpp
+++ b/src/Apps/gamescopectl.cpp
@@ -231,6 +231,8 @@ namespace gamescope
                 return "Look";
             case GAMESCOPE_CONTROL_FEATURE_PERF_QUERY:
                 return "Performance Query";
+            case GAMESCOPE_CONTROL_FEATURE_KEYBOARD_LAYOUT:
+                return "Keyboard Layout";
             default:
                 return "Unknown";
         }

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1379,6 +1379,19 @@ void wlserver_app_presented( uint32_t app_id, uint64_t frametime_ns )
 	wlserver.app_perf_requests.erase( it );
 }
 
+static void gamescope_control_set_keyboard_layout( struct wl_client *client, struct wl_resource *resource, const char *layout, const char *variant )
+{
+	// A variant with no layout is meaningless, let the empty layout reset through.
+	std::string sLayout = layout;
+	if ( !sLayout.empty() && variant[0] )
+	{
+		sLayout += ":";
+		sLayout += variant;
+	}
+
+	wlserver_set_keyboard_layout( sLayout.c_str() );
+}
+
 static const struct gamescope_control_interface gamescope_control_impl = {
 	.destroy = gamescope_control_handle_destroy,
 	.set_app_target_refresh_cycle = gamescope_control_set_app_target_refresh_cycle,
@@ -1387,6 +1400,7 @@ static const struct gamescope_control_interface gamescope_control_impl = {
 	.set_look = gamescope_control_set_look,
 	.unset_look = gamescope_control_unset_look,
 	.request_app_performance_stats = gamescope_control_request_app_performance_stats,
+	.set_keyboard_layout = gamescope_control_set_keyboard_layout,
 };
 
 static uint32_t get_conn_display_info_flags()
@@ -1457,6 +1471,7 @@ static void gamescope_control_bind( struct wl_client *client, void *data, uint32
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_MURA_CORRECTION, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_LOOK, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_PERF_QUERY, 1, 0 );
+	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_KEYBOARD_LAYOUT, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_DONE, 0, 0 );
 
 	wlserver_send_gamescope_control( resource );
@@ -1466,7 +1481,7 @@ static void gamescope_control_bind( struct wl_client *client, void *data, uint32
 
 static void create_gamescope_control( void )
 {
-	uint32_t version = 6;
+	uint32_t version = 7;
 	wl_global_create( wlserver.display, &gamescope_control_interface, version, NULL, gamescope_control_bind );
 }
 
@@ -2074,7 +2089,8 @@ static std::unique_ptr<gamescope::GamescopeInputServer> g_InputServer;
 static void wlserver_update_keymap();
 
 // Steam pushes the user's keyboard layout in here, as nothing in the session
-// exports it to us. See GAMESCOPE_KEYBOARD_LAYOUT in steamcompmgr.
+// exports it to us. See gamescope_control.set_keyboard_layout and
+// GAMESCOPE_KEYBOARD_LAYOUT in steamcompmgr.
 static gamescope::ConVar<std::string> cv_xkb_layout( "xkb_layout", "",
 	"XKB layout[:variant] used for physical keyboards, eg. \"es\" or \"fr:bepo\". Empty follows XKB_DEFAULT_LAYOUT and XKB_DEFAULT_VARIANT.",
 	[]( gamescope::ConVar<std::string> & ) { wlserver_update_keymap(); } );


### PR DESCRIPTION
Steam sets the layout through a GAMESCOPE_KEYBOARD_LAYOUT root property, and the client has no way to tell whether the gamescope it is talking to reads it.

The request takes the layout and variant as two strings, so the colon form the xkb_layout ConVar stores stays out of the wire contract. The property path stays for clients already using it, both end up in the same ConVar.