### PR TITLE
WaylandBackend: don't abort the input thread on Wayland errors

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2863,7 +2863,8 @@ namespace gamescope
             if ( ( nRet = wl_display_dispatch_queue_pending( m_pBackend->GetDisplay(), m_pQueue ) ) < 0 )
             {
                 LogDisplayError( "Failed to dispatch input thread queue", m_pBackend->GetDisplay() );
-                abort();
+                raise( SIGTERM );
+                return;
             }
 
             if ( ( nRet = wl_display_prepare_read_queue( m_pBackend->GetDisplay(), m_pQueue ) ) < 0 )
@@ -2872,7 +2873,8 @@ namespace gamescope
                     continue;
 
                 LogDisplayError( "Failed to prepare read of input thread queue", m_pBackend->GetDisplay() );
-                abort();
+                raise( SIGTERM );
+                return;
             }
 
             if ( ( nRet = m_Waiter.PollEvents() ) <= 0 )
@@ -2881,7 +2883,8 @@ namespace gamescope
                 if ( nRet < 0 )
                 {
                     xdg_log.errorf_errno( "Input thread poll failed" );
-                    abort();
+                    raise( SIGTERM );
+                    return;
                 }
 
                 assert( nRet == 0 );
@@ -2891,7 +2894,8 @@ namespace gamescope
             if ( ( nRet = wl_display_read_events( m_pBackend->GetDisplay() ) ) < 0 )
             {
                 LogDisplayError( "Failed to read events on input thread", m_pBackend->GetDisplay() );
-                abort();
+                raise( SIGTERM );
+                return;
             }
         }
     }


### PR DESCRIPTION
The Wayland backend's input thread calls `abort()` on any libwayland failure in its event loop. When a compositor raises a protocol error, gamescope takes SIGABRT and dumps core, killing the hosted game without running the normal shutdown path.

This raises SIGTERM and returns instead, matching how the SDL and OpenVR backends end a session. Children are torn down by the existing reaper path.

**This is not a fix for #2391.** The protocol violation that triggers the error is still there and is a separate change. This only stops that failure from being a core dump.

Reproduced with the script in https://github.com/ValveSoftware/gamescope/issues/2391#issuecomment-5608322718

    xdg_surface#46: error 3: must ack the initial configure before attaching buffer
    [gamescope] [Error] xdg_backend: Failed to dispatch input thread queue: protocol error 3 on xdg_surface@46
    abort (core dumped)

After:

    xdg_surface#46: error 3: must ack the initial configure before attaching buffer
    [gamescope] [Error] xdg_backend: Failed to dispatch input thread queue: protocol error 3 on xdg_surface@46
    [gamescopereaper] [Info]  reaper: Parent of gamescopereaper was killed. Killing children.
    [gamescope] [Info]  launch: Primary child shut down!

The `wl_display_get_fd()` check before the loop keeps `abort()`, since a display created successfully but yielding no fd is a broken invariant rather than an environmental failure.

One thing I left alone: exit status is still 0, since `ShutdownGamescope()` just sets `g_bRun = false`. Making an error-triggered shutdown report non-zero would affect every SIGTERM path, so it seemed out of scope here. Happy to add it if you'd prefer.
