### PR TITLE
Implement Snapdragon™ Game Super Resolution 1 upscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ See `gamescope --help` for a full list of options.
 * `-o`: set a frame-rate limit for the game when unfocused. Specified in frames per second. Defaults to unlimited.
 * `-F fsr`: use AMD FidelityFX™ Super Resolution 1.0 for upscaling
 * `-F nis`: use NVIDIA Image Scaling v1.0.3 for upscaling
+* `-F sgsr`: use Snapdragon™ Game Super Resolution 1 with RCAS sharpening for upscaling
 * `-S integer`: use integer scaling.
 * `-S stretch`: use stretch scaling, the game will fill the window. (e.g. 4:3 to 16:9)
 * `-b`: create a border-less window.

--- a/protocol/gamescope-control.xml
+++ b/protocol/gamescope-control.xml
@@ -45,6 +45,7 @@
       <entry name="look" value="6"/>
       <entry name="perf_query" value="7"/>
       <entry name="keyboard_layout" value="8"/>
+      <entry name="sgsr_filter" value="9"/>
     </enum>
 
     <event name="feature_support">

--- a/src/Apps/gamescopectl.cpp
+++ b/src/Apps/gamescopectl.cpp
@@ -233,6 +233,8 @@ namespace gamescope
                 return "Performance Query";
             case GAMESCOPE_CONTROL_FEATURE_KEYBOARD_LAYOUT:
                 return "Keyboard Layout";
+            case GAMESCOPE_CONTROL_FEATURE_SGSR_FILTER:
+                return "SGSR Filter";
             default:
                 return "Unknown";
         }

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -3662,7 +3662,9 @@ namespace gamescope
 
 			bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
-			bool bNeedsCompositeFromFilter = (pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::NEAREST || pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
+			GamescopeUpscaleFilter eLayer0Filter = pFrameInfo->layers.get( 0 ).filter;
+			bool bNeedsCompositeFromFilter = ( eLayer0Filter == GamescopeUpscaleFilter::NEAREST ||
+			                                   eLayer0Filter == GamescopeUpscaleFilter::PIXEL ) && !bLayer0ScreenSize;
 
 			bool bNeedsFullComposite = false;
 			bNeedsFullComposite |= cv_composite_force;

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -3671,6 +3671,7 @@ namespace gamescope
 			bNeedsFullComposite |= bWasFirstFrame;
 			bNeedsFullComposite |= pFrameInfo->useFSRLayer0;
 			bNeedsFullComposite |= pFrameInfo->useNISLayer0;
+			bNeedsFullComposite |= pFrameInfo->useSGSRLayer0;
 			bNeedsFullComposite |= pFrameInfo->blurLayer0;
 			bNeedsFullComposite |= bNeedsCompositeFromFilter;
 			bNeedsFullComposite |= !cv_drm_cursor_plane && bDrewCursor;

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -1811,7 +1811,9 @@ namespace gamescope
         // TODO: Dedupe some of this composite check code between us and drm.cpp
         bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
-        bool bNeedsCompositeFromFilter = (pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::NEAREST || pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
+        GamescopeUpscaleFilter eLayer0Filter = pFrameInfo->layers.get( 0 ).filter;
+        bool bNeedsCompositeFromFilter = ( eLayer0Filter == GamescopeUpscaleFilter::NEAREST ||
+                                           eLayer0Filter == GamescopeUpscaleFilter::PIXEL ) && !bLayer0ScreenSize;
 
         bNeedsFullComposite |= cv_composite_force;
         bNeedsFullComposite |= pFrameInfo->useFSRLayer0;

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -1818,6 +1818,7 @@ namespace gamescope
         bNeedsFullComposite |= cv_composite_force;
         bNeedsFullComposite |= pFrameInfo->useFSRLayer0;
         bNeedsFullComposite |= pFrameInfo->useNISLayer0;
+        bNeedsFullComposite |= pFrameInfo->useSGSRLayer0;
         bNeedsFullComposite |= pFrameInfo->blurLayer0;
         bNeedsFullComposite |= bNeedsCompositeFromFilter;
         bNeedsFullComposite |= g_bColorSliderInUse;

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1067,7 +1067,9 @@ namespace gamescope
             // TODO: Dedupe some of this composite check code between us and drm.cpp
             bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
-            bool bNeedsCompositeFromFilter = (pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::NEAREST || pFrameInfo->eUpscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
+            GamescopeUpscaleFilter eLayer0Filter = pFrameInfo->layers.get( 0 ).filter;
+            bool bNeedsCompositeFromFilter = ( eLayer0Filter == GamescopeUpscaleFilter::NEAREST ||
+                                               eLayer0Filter == GamescopeUpscaleFilter::PIXEL ) && !bLayer0ScreenSize;
 
             bNeedsFullComposite |= cv_composite_force;
             bNeedsFullComposite |= pFrameInfo->useFSRLayer0;

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1074,6 +1074,7 @@ namespace gamescope
             bNeedsFullComposite |= cv_composite_force;
             bNeedsFullComposite |= pFrameInfo->useFSRLayer0;
             bNeedsFullComposite |= pFrameInfo->useNISLayer0;
+            bNeedsFullComposite |= pFrameInfo->useSGSRLayer0;
             bNeedsFullComposite |= pFrameInfo->blurLayer0;
             bNeedsFullComposite |= bNeedsCompositeFromFilter;
             bNeedsFullComposite |= g_bColorSliderInUse;

--- a/src/commit.cpp
+++ b/src/commit.cpp
@@ -124,6 +124,7 @@ void commit_t::SetFence( int nFence, bool bMangoNudge, uint32_t uMangoMsgType, C
 }
 
 void calc_scale_factor(GamescopeUpscaleScaler eScaler, float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight);
+void calc_scale_factor_scaler(GamescopeUpscaleScaler eScaler, float &out_scale_x, float &out_scale_y, float sourceWidth, float sourceHeight);
 
 bool commit_t::ShouldPreemptivelyUpscale( GamescopeUpscaleFilter eFilter, GamescopeUpscaleScaler eScaler )
 {
@@ -145,6 +146,16 @@ bool commit_t::ShouldPreemptivelyUpscale( GamescopeUpscaleFilter eFilter, Gamesc
     // I wish this function was more programatic with its inputs, but it does do exactly what we want right now...
     // It should also return a std::pair or a glm uvec
     calc_scale_factor( eScaler, flScaleX, flScaleY, vulkanTex->width(), vulkanTex->height() );
+
+    // The pre-emptive paint forces the global scale to one, so judge magnification without it and on both axes like the paint path.
+    if ( ResolveUpscaleFilter( eFilter, colorspace(), vulkanTex->isYcbcr() ) == GamescopeUpscaleFilter::SGSR )
+    {
+        float flUpscaleX = 1.0f;
+        float flUpscaleY = 1.0f;
+        calc_scale_factor_scaler( eScaler, flUpscaleX, flUpscaleY, vulkanTex->width(), vulkanTex->height() );
+        if ( flUpscaleX <= 1.0f || flUpscaleY <= 1.0f )
+            return false;
+    }
 
     return !close_enough( flScaleX, 1.0f ) || !close_enough( flScaleY, 1.0f );
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,9 +176,10 @@ const char usage[] =
 	"  -r, --nested-refresh           game refresh rate (frames per second)\n"
 	"  -m, --max-scale                maximum scale factor\n"
 	"  -S, --scaler                   upscaler type (auto, integer, fit, fill, stretch)\n"
-	"  -F, --filter                   upscaler filter (linear, nearest, fsr, nis, pixel)\n"
+	"  -F, --filter                   upscaler filter (linear, nearest, fsr, nis, pixel, sgsr)\n"
 	"                                     fsr => AMD FidelityFX™ Super Resolution 1.0\n"
 	"                                     nis => NVIDIA Image Scaling v1.0.3\n"
+	"                                     sgsr => Snapdragon™ Game Super Resolution 1 with RCAS\n"
 	"  --sharpness, --fsr-sharpness   upscaler sharpness from 0 (max) to 20 (min)\n"
 	"  --expose-wayland               support wayland clients using xdg-shell\n"
 	"  -s, --mouse-sensitivity        multiply mouse movement by given decimal number\n"
@@ -416,6 +417,8 @@ static enum GamescopeUpscaleFilter parse_upscaler_filter(const char *str)
 		return GamescopeUpscaleFilter::NIS;
 	} else if (strcmp(str, "pixel") == 0) {
 		return GamescopeUpscaleFilter::PIXEL;
+	} else if (strcmp(str, "sgsr") == 0) {
+		return GamescopeUpscaleFilter::SGSR;
 	} else {
 		fprintf( stderr, "gamescope: invalid value for --filter\n" );
 		exit(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -407,22 +407,13 @@ static enum GamescopeUpscaleScaler parse_upscaler_scaler(const char *str)
 
 static enum GamescopeUpscaleFilter parse_upscaler_filter(const char *str)
 {
-	if (strcmp(str, "linear") == 0) {
-		return GamescopeUpscaleFilter::LINEAR;
-	} else if (strcmp(str, "nearest") == 0) {
-		return GamescopeUpscaleFilter::NEAREST;
-	} else if (strcmp(str, "fsr") == 0) {
-		return GamescopeUpscaleFilter::FSR;
-	} else if (strcmp(str, "nis") == 0) {
-		return GamescopeUpscaleFilter::NIS;
-	} else if (strcmp(str, "pixel") == 0) {
-		return GamescopeUpscaleFilter::PIXEL;
-	} else if (strcmp(str, "sgsr") == 0) {
-		return GamescopeUpscaleFilter::SGSR;
-	} else {
+	std::optional<GamescopeUpscaleFilter> oFilter = ParseUpscaleFilter( str );
+	if ( !oFilter )
+	{
 		fprintf( stderr, "gamescope: invalid value for --filter\n" );
 		exit(1);
 	}
+	return *oFilter;
 }
 
 static enum gamescope::GamescopeBackend parse_backend_name(const char *str)

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -43,6 +43,11 @@ enum class GamescopeUpscaleFilter : uint32_t
     FROM_VIEW = 0xF, // internal
 };
 
+static constexpr bool UpscaleFilterUsesSharpness( GamescopeUpscaleFilter eFilter )
+{
+    return eFilter == GamescopeUpscaleFilter::FSR || eFilter == GamescopeUpscaleFilter::NIS;
+}
+
 static constexpr bool DoesHardwareSupportUpscaleFilter( GamescopeUpscaleFilter eFilter )
 {
     // Could do nearest someday... AMDGPU DC supports custom tap placement to an extent.
@@ -63,6 +68,7 @@ struct UpscaleSettings_t
 {
     GamescopeUpscaleFilter eFilter{};
     GamescopeUpscaleScaler eScaler{};
+    int nSharpness{};
 };
 
 // XXX(misyl): This is bad! We shouldnt change the upscaler like this at all!!!
@@ -70,12 +76,13 @@ struct UpscaleSettings_t
 static constexpr UpscaleSettings_t GetUpscaleSettings(
     bool bFocusIsSteam,
     GamescopeUpscaleFilter eWantedFilter,
-    GamescopeUpscaleScaler eWantedScaler )
+    GamescopeUpscaleScaler eWantedScaler,
+    int nWantedSharpness )
 {
     if ( bFocusIsSteam )
-        return UpscaleSettings_t{ GamescopeUpscaleFilter::LINEAR, GamescopeUpscaleScaler::FIT };
+        return UpscaleSettings_t{ GamescopeUpscaleFilter::LINEAR, GamescopeUpscaleScaler::FIT, nWantedSharpness };
 
-    return UpscaleSettings_t{ eWantedFilter, eWantedScaler };
+    return UpscaleSettings_t{ eWantedFilter, eWantedScaler, nWantedSharpness };
 }
 
 extern GamescopeUpscaleFilter g_wantedUpscaleFilter;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -3,6 +3,9 @@
 #include <getopt.h>
 
 #include <atomic>
+#include <optional>
+#include <string_view>
+#include <utility>
 
 #include "gamescope_shared.h"
 
@@ -102,6 +105,26 @@ static constexpr UpscaleSettings_t GetUpscaleSettings(
         return UpscaleSettings_t{ GamescopeUpscaleFilter::LINEAR, GamescopeUpscaleScaler::FIT, nWantedSharpness };
 
     return UpscaleSettings_t{ eWantedFilter, eWantedScaler, nWantedSharpness };
+}
+
+// One name table for the --filter option and the scaling_filter command, so the two cannot drift.
+inline std::optional<GamescopeUpscaleFilter> ParseUpscaleFilter( std::string_view svName )
+{
+    static constexpr std::pair<std::string_view, GamescopeUpscaleFilter> k_Filters[] =
+    {
+        { "linear",  GamescopeUpscaleFilter::LINEAR },
+        { "nearest", GamescopeUpscaleFilter::NEAREST },
+        { "fsr",     GamescopeUpscaleFilter::FSR },
+        { "nis",     GamescopeUpscaleFilter::NIS },
+        { "pixel",   GamescopeUpscaleFilter::PIXEL },
+        { "sgsr",    GamescopeUpscaleFilter::SGSR },
+    };
+    for ( const auto &[svFilterName, eFilter] : k_Filters )
+    {
+        if ( svFilterName == svName )
+            return eFilter;
+    }
+    return std::nullopt;
 }
 
 extern GamescopeUpscaleFilter g_wantedUpscaleFilter;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -4,6 +4,8 @@
 
 #include <atomic>
 
+#include "gamescope_shared.h"
+
 extern const char *gamescope_optstring;
 extern const struct option *gamescope_options;
 
@@ -39,13 +41,30 @@ enum class GamescopeUpscaleFilter : uint32_t
     FSR,
     NIS,
     PIXEL,
+    SGSR,
 
     FROM_VIEW = 0xF, // internal
 };
 
 static constexpr bool UpscaleFilterUsesSharpness( GamescopeUpscaleFilter eFilter )
 {
-    return eFilter == GamescopeUpscaleFilter::FSR || eFilter == GamescopeUpscaleFilter::NIS;
+    return eFilter == GamescopeUpscaleFilter::FSR ||
+           eFilter == GamescopeUpscaleFilter::NIS ||
+           eFilter == GamescopeUpscaleFilter::SGSR;
+}
+
+// cs_sgsr reads the plain sampler slot, not the YCbCr one, and thresholds in 8-bit SDR units.
+static constexpr bool SgsrSupportsInput( GamescopeAppTextureColorspace eColorspace, bool bYcbcr )
+{
+    return !bYcbcr && ( eColorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR || eColorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_SRGB );
+}
+
+// Sharp ran FSR before SGSR existed, so HDR keeps that rather than losing the sharpening. Neither pre-pass reads the YCbCr slot.
+static constexpr GamescopeUpscaleFilter ResolveUpscaleFilter( GamescopeUpscaleFilter eFilter, GamescopeAppTextureColorspace eColorspace, bool bYcbcr )
+{
+    if ( eFilter != GamescopeUpscaleFilter::SGSR || SgsrSupportsInput( eColorspace, bYcbcr ) )
+        return eFilter;
+    return bYcbcr ? GamescopeUpscaleFilter::LINEAR : GamescopeUpscaleFilter::FSR;
 }
 
 static constexpr bool DoesHardwareSupportUpscaleFilter( GamescopeUpscaleFilter eFilter )

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -41,6 +41,8 @@ struct mangoapp_msg_v1 {
     bool bAppWantsHDR : 1;
     bool bSteamFocused : 1;
     char engineName[40];
+    uint8_t upscaler; // GamescopeUpscaleFilter that produced the frame, LINEAR when none did
+    uint8_t wantedUpscaler; // GamescopeUpscaleFilter the user selected
 
     // WARNING: Always ADD fields, never remove or repurpose fields
 } __attribute__((packed));
@@ -194,8 +196,9 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
     MangoappSnapshot_t snapshot;
     if ( uMsgType == k_uMangoappLegacyMsgType )
     {
-        snapshot.bFSRActive = g_bFSRActive;
-        snapshot.uFSRSharpness = (uint8_t) g_upscaleFilterSharpness;
+        snapshot.eActiveUpscaler = g_eActiveUpscaler;
+        snapshot.eWantedUpscaler = g_eWantedUpscaler;
+        snapshot.uFSRSharpness = (uint8_t) g_nActiveUpscaleSharpness;
         snapshot.nPid = focusWindow_pid;
         snapshot.uOutputWidth = g_nOutputWidth;
         snapshot.uOutputHeight = g_nOutputHeight;
@@ -219,7 +222,9 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
     msg.visible_frametime_ns = visible_frametime;
     msg.app_frametime_ns = app_frametime_ns;
     msg.latency_ns = latency_ns;
-    msg.fsrUpscale = snapshot.bFSRActive;
+    msg.fsrUpscale = snapshot.eActiveUpscaler == GamescopeUpscaleFilter::FSR;
+    msg.upscaler = uint8_t( snapshot.eActiveUpscaler );
+    msg.wantedUpscaler = uint8_t( snapshot.eWantedUpscaler );
     msg.fsrSharpness = snapshot.uFSRSharpness;
     msg.pid = snapshot.nPid;
     msg.outputWidth = snapshot.uOutputWidth;

--- a/src/meson.build
+++ b/src/meson.build
@@ -63,6 +63,7 @@ shader_src = [
   'shaders/cs_composite_blur.comp',
   'shaders/cs_composite_blur_cond.comp',
   'shaders/cs_composite_rcas.comp',
+  'shaders/cs_composite_rcas_1px.comp',
   'shaders/cs_easu.comp',
   'shaders/cs_easu_fp16.comp',
   'shaders/cs_gaussian_blur_horizontal.comp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -69,6 +69,7 @@ shader_src = [
   'shaders/cs_nis.comp',
   'shaders/cs_nis_fp16.comp',
   'shaders/cs_rgb_to_nv12.comp',
+  'shaders/cs_sgsr.comp',
 ]
 
 spirv_shaders = glsl_generator.process(shader_src)

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -4173,7 +4173,7 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 		cmdBuffer->setSamplerUnnormalized(0, false);
 		cmdBuffer->setSamplerNearest(0, false);
 		cmdBuffer->bindTarget(compositeImage);
-		cmdBuffer->uploadConstants<RcasPushData_t>(frameInfo, g_upscaleFilterSharpness / 10.0f, uOutputRotation);
+		cmdBuffer->uploadConstants<RcasPushData_t>(frameInfo, frameInfo->nUpscaleSharpness / 10.0f, uOutputRotation);
 
 		cmdBuffer->dispatch(div_roundup(currentOutputWidth, pixelsPerGroup), div_roundup(currentOutputHeight, pixelsPerGroup));
 	}
@@ -4187,7 +4187,7 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 		update_tmp_images(tempX, tempY);
 
-		float nisSharpness = (20 - g_upscaleFilterSharpness) / 20.0f;
+		float nisSharpness = (20 - frameInfo->nUpscaleSharpness) / 20.0f;
 
 		cmdBuffer->bindPipeline(g_device.pipeline(SHADER_TYPE_NIS));
 		cmdBuffer->bindTarget(g_output.tmpOutput);

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -47,6 +47,7 @@
 #include "cs_nis.h"
 #include "cs_nis_fp16.h"
 #include "cs_rgb_to_nv12.h"
+#include "cs_sgsr.h"
 
 #define A_CPU
 #include "shaders/ffx_a.h"
@@ -965,6 +966,7 @@ bool CVulkanDevice::createShaders()
 		SHADER(NIS, cs_nis);
 	}
 	SHADER(RGB_TO_NV12, cs_rgb_to_nv12);
+	SHADER(SGSR, cs_sgsr);
 #undef SHADER
 
 	for (uint32_t i = 0; i < shaderInfos.size(); i++)
@@ -1195,6 +1197,7 @@ void CVulkanDevice::compileAllPipelines(std::stop_token st)
 	SHADER(EASU, 1, 1, 1);
 	SHADER(NIS, 1, 1, 1);
 	SHADER(RGB_TO_NV12, 1, 1, 1);
+	SHADER(SGSR, 1, 1, 1);
 #undef SHADER
 
 	for (auto& info : pipelineInfos) {
@@ -3811,10 +3814,12 @@ struct BlitPushData_t
 			scale[i] = layer->scale;
 			offset[i] = layer->offsetPixelCenter();
 			opacity[i] = layer->opacity;
-            if (layer->isScreenSize() || (layer->filter == GamescopeUpscaleFilter::LINEAR && layer->viewConvertsToLinearAutomatically()))
+            // SGSR only exists as a pre-pass, a layer still carrying it samples as linear.
+            GamescopeUpscaleFilter eFilter = layer->filter == GamescopeUpscaleFilter::SGSR ? GamescopeUpscaleFilter::LINEAR : layer->filter;
+            if (layer->isScreenSize() || (eFilter == GamescopeUpscaleFilter::LINEAR && layer->viewConvertsToLinearAutomatically()))
                 u_shaderFilter |= ((uint32_t)GamescopeUpscaleFilter::FROM_VIEW) << (i * 4);
             else
-                u_shaderFilter |= ((uint32_t)layer->filter) << (i * 4);
+                u_shaderFilter |= ((uint32_t)eFilter) << (i * 4);
 
 			u_alphaMode |= ((uint32_t)layer->eAlphaBlendingMode) << ( i * 4 );
 
@@ -3917,6 +3922,17 @@ struct EasuPushData_t
 	}
 };
 
+struct SgsrPushData_t
+{
+	uint32_t u_width;
+	uint32_t u_height;
+
+	SgsrPushData_t(uint32_t tempX, uint32_t tempY)
+		: u_width(tempX), u_height(tempY)
+	{
+	}
+};
+
 struct RcasPushData_t
 {
 	uvec2_t u_layer0Offset;
@@ -3955,10 +3971,11 @@ struct RcasPushData_t
 		{
 			const FrameInfo_t::Layer_t *layer = &frameInfo->layers.get( i );
 
-            if (i == 0 || layer->isScreenSize() || (layer->filter == GamescopeUpscaleFilter::LINEAR && layer->viewConvertsToLinearAutomatically()))
+            GamescopeUpscaleFilter eFilter = layer->filter == GamescopeUpscaleFilter::SGSR ? GamescopeUpscaleFilter::LINEAR : layer->filter;
+            if (i == 0 || layer->isScreenSize() || (eFilter == GamescopeUpscaleFilter::LINEAR && layer->viewConvertsToLinearAutomatically()))
                 u_shaderFilter |= ((uint32_t)GamescopeUpscaleFilter::FROM_VIEW) << (i * 4);
             else
-                u_shaderFilter |= ((uint32_t)layer->filter) << (i * 4);
+                u_shaderFilter |= ((uint32_t)eFilter) << (i * 4);
 
 			u_alphaMode |= ((uint32_t)layer->eAlphaBlendingMode) << ( i * 4 );
 
@@ -4144,7 +4161,7 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 	for (uint32_t i = 0; i < EOTF_Count; i++)
 		cmdBuffer->bindColorMgmtLuts(i, frameInfo->shaperLut[i], frameInfo->lut3D[i]);
 
-	if ( frameInfo->useFSRLayer0 )
+	if ( frameInfo->useFSRLayer0 || frameInfo->useSGSRLayer0 )
 	{
 		uint32_t inputX = frameInfo->layers.get( 0 ).tex->width();
 		uint32_t inputY = frameInfo->layers.get( 0 ).tex->height();
@@ -4154,13 +4171,16 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 		update_tmp_images(tempX, tempY);
 
-		cmdBuffer->bindPipeline(g_device.pipeline(SHADER_TYPE_EASU));
+		cmdBuffer->bindPipeline(g_device.pipeline(frameInfo->useSGSRLayer0 ? SHADER_TYPE_SGSR : SHADER_TYPE_EASU));
 		cmdBuffer->bindTarget(g_output.tmpOutput);
 		cmdBuffer->bindTexture(0, frameInfo->layers.get( 0 ).tex);
 		cmdBuffer->setTextureSrgb(0, true);
 		cmdBuffer->setSamplerUnnormalized(0, false);
 		cmdBuffer->setSamplerNearest(0, false);
-		cmdBuffer->uploadConstants<EasuPushData_t>(inputX, inputY, tempX, tempY);
+		if ( frameInfo->useSGSRLayer0 )
+			cmdBuffer->uploadConstants<SgsrPushData_t>(tempX, tempY);
+		else
+			cmdBuffer->uploadConstants<EasuPushData_t>(inputX, inputY, tempX, tempY);
 
 		int pixelsPerGroup = 16;
 

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -41,6 +41,7 @@
 #include "cs_composite_blur.h"
 #include "cs_composite_blur_cond.h"
 #include "cs_composite_rcas.h"
+#include "cs_composite_rcas_1px.h"
 #include "cs_easu.h"
 #include "cs_easu_fp16.h"
 #include "cs_gaussian_blur_horizontal.h"
@@ -527,6 +528,12 @@ bool CVulkanDevice::createDevice()
 		m_bSupportsFp16 = vulkan12Features.shaderFloat16 && features2.features.shaderInt16;
 	}
 
+	{
+		VkPhysicalDeviceProperties deviceProperties;
+		vk.GetPhysicalDeviceProperties( physDev(), &deviceProperties );
+		m_uVendorID = deviceProperties.vendorID;
+	}
+
 	float queuePriorities = 1.0f;
 
 	VkDeviceQueueGlobalPriorityCreateInfoEXT queueCreateInfoEXT = {
@@ -954,7 +961,15 @@ bool CVulkanDevice::createShaders()
 	SHADER(BLUR, cs_composite_blur);
 	SHADER(BLUR_COND, cs_composite_blur_cond);
 	SHADER(BLUR_FIRST_PASS, cs_gaussian_blur_horizontal);
-	SHADER(RCAS, cs_composite_rcas);
+	// The one pixel layout is only measured on Adreno, every other vendor keeps the quad swizzle.
+	if (m_uVendorID == 0x5143) /* Qualcomm */
+	{
+		SHADER(RCAS, cs_composite_rcas_1px);
+	}
+	else
+	{
+		SHADER(RCAS, cs_composite_rcas);
+	}
 	if (m_bSupportsFp16)
 	{
 		SHADER(EASU, cs_easu_fp16);

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -285,6 +285,7 @@ struct FrameInfo_t
 	// Upscale settings for this frame.
 	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
+	int nUpscaleSharpness = 0;
 	bool bFadingOut;
 	BlurMode blurLayer0;
 	int blurRadius;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -282,6 +282,7 @@ struct FrameInfo_t
 {
 	bool useFSRLayer0;
 	bool useNISLayer0;
+	bool useSGSRLayer0;
 	// Upscale settings for this frame.
 	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
@@ -613,6 +614,7 @@ enum ShaderType {
 	SHADER_TYPE_RCAS,
 	SHADER_TYPE_NIS,
 	SHADER_TYPE_RGB_TO_NV12,
+	SHADER_TYPE_SGSR,
 
 	SHADER_TYPE_COUNT
 };

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -919,6 +919,7 @@ protected:
 	dev_t m_drmPrimaryDevId = 0;
 
 	bool m_bSupportsFp16 = false;
+	uint32_t m_uVendorID = 0;
 	bool m_bHasDrmPrimaryDevId = false;
 	bool m_bSupportsModifiers = false;
 	bool m_bInitialized = false;

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -139,7 +139,7 @@ vec4 sampleBilinear(sampler2D tex, vec2 coord, uint colorspace, bool unnormalize
     vec2 pixCoord = coord * scale - 0.5f;
     vec2 originPixCoord = floor(pixCoord);
 
-    vec2 gatherUV = (originPixCoord * scale + 1.0f) / scale;
+    vec2 gatherUV = (originPixCoord + 1.0f) / scale;
 
     vec4 red   = textureGather(tex, gatherUV, 0);
     vec4 green = textureGather(tex, gatherUV, 1);

--- a/src/shaders/cs_composite_rcas_1px.comp
+++ b/src/shaders/cs_composite_rcas_1px.comp
@@ -1,0 +1,103 @@
+#version 460
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+#include "descriptor_set.h"
+
+layout(
+  local_size_x = 16,
+  local_size_y = 16,
+  local_size_z = 1) in;
+
+layout(binding = 0, scalar)
+uniform layers_t {
+    uvec2 u_layer0Offset;
+    vec2 u_scale[VKR_MAX_LAYERS - 1];
+    vec2 u_offset[VKR_MAX_LAYERS - 1];
+    float u_opacity[VKR_MAX_LAYERS];
+    mat3x4 u_ctm[VKR_MAX_LAYERS];
+    uint u_borderMask;
+    uint u_frameId;
+    uint u_c1;
+
+	uint u_shaderFilter;
+    uint u_alphaMode;
+
+    // hdr
+    float u_linearToNits;
+    float u_nitsToLinear;
+    float u_itmSdrNits;
+    float u_itmTargetNits;
+
+    uint u_rotation;
+};
+
+#include "composite.h"
+
+#define A_GPU 1
+#define A_GLSL 1
+#include "ffx_a.h"
+#define FSR_RCAS_F 1
+vec4 FsrRcasLoadF(ivec2 p) { return texelFetch(s_samplers[0], ivec2(p), 0); }
+// our input is already srgb
+void FsrRcasInputF(inout float r, inout float g, inout float b) {}
+#include "ffx_fsr1.h"
+
+vec4 sampleLayer(uint layerIdx, vec2 uv) {
+    if ((c_ycbcrMask & (1 << layerIdx)) != 0)
+        return sampleLayerEx(s_ycbcr_samplers[layerIdx], layerIdx - 1, layerIdx, uv, false);
+    return sampleLayerEx(s_samplers[layerIdx], layerIdx - 1, layerIdx, uv, true);
+}
+
+
+void rcasComposite(uvec2 pos)
+{
+    vec3 outputValue = vec3(0.0f);
+
+    if (checkDebugFlag(compositedebug_PlaneBorders))
+        outputValue = vec3(1.0f, 0.0f, 0.0f);
+
+    if (c_layerCount > 0) {
+        // this is actually signed, underflow will be filtered out by the branch below
+        uvec2 rcasPos = pos + u_layer0Offset;
+        uvec2 layer0Extent = uvec2(textureSize(s_samplers[0], 0));
+
+        if (all(lessThan(rcasPos, layer0Extent))) {
+            FsrRcasF(outputValue.r, outputValue.g, outputValue.b, rcasPos, u_c1.xxxx);
+
+            uint colorspace = get_layer_colorspace(0);
+            if (colorspace == colorspace_linear)
+            {
+                // We don't use an sRGB view for FSR due to the spaces RCAS works in.
+                colorspace = colorspace_sRGB;
+            }
+
+            outputValue.rgb = colorspace_plane_degamma_tf(outputValue.rgb, colorspace);
+            outputValue.rgb = (vec4(outputValue.rgb, 1.0f) * u_ctm[0]).rgb;
+            outputValue.rgb = apply_layer_color_mgmt(outputValue.rgb, 0, colorspace);
+            outputValue *= u_opacity[0];
+        }
+    }
+
+
+    if (c_layerCount > 1) {
+        vec2 uv = vec2(pos);
+
+        for (int i = 1; i < c_layerCount; i++) {
+            vec4 layerColor = sampleLayer(i, uv);
+            outputValue = BlendLayer( i, outputValue, layerColor, u_opacity[i] );
+        }
+    }
+
+    outputValue = encodeOutputColor(outputValue);
+    imageStore(dst, rotateOutputCoord(pos, u_rotation), vec4(outputValue, 0));
+
+    if (checkDebugFlag(compositedebug_Markers))
+        compositing_debug(pos, u_rotation);
+}
+
+void main()
+{
+    rcasComposite(gl_GlobalInvocationID.xy);
+}

--- a/src/shaders/cs_sgsr.comp
+++ b/src/shaders/cs_sgsr.comp
@@ -1,0 +1,34 @@
+#version 460
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+#include "descriptor_set.h"
+
+layout(
+  local_size_x = 16,
+  local_size_y = 16,
+  local_size_z = 1) in;
+
+layout(binding = 0, scalar)
+uniform layers_t {
+    uint u_width;
+    uint u_height;
+};
+
+#include "sgsr1.h"
+
+void sgsrPass(uvec2 pos, vec2 invSize)
+{
+    if (pos.x >= u_width || pos.y >= u_height)
+        return;
+    vec4 color = sampleSgsr1(s_samplers[0], (vec2(pos) + 0.5) * invSize);
+    imageStore(dst, ivec2(pos), vec4(color.rgb, 1));
+}
+
+void main()
+{
+    // One pixel per thread, four as EASU does keeps too many gathers live here.
+    vec2 invSize = 1.0 / vec2(u_width, u_height);
+    sgsrPass(gl_GlobalInvocationID.xy, invSize);
+}

--- a/src/shaders/sgsr1.h
+++ b/src/shaders/sgsr1.h
@@ -1,0 +1,139 @@
+/*
+Copyright (c) 2023, 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+// Adapted from Qualcomm SGSR1, d926f074bcb9d714e179f1ce0fcb9ee2eeb5074e.
+// sgsr/v1/include/glsl/sgsr1_shader_mobile.frag, with the departures noted below.
+
+mediump float sgsrFastLanczos2(mediump float x)
+{
+	// The polynomial turns positive again past 4, the narrower kernel can reach it.
+	x = min(x, 4.0);
+	mediump float wA = x-4.0;
+	mediump float wB = x*wA-wA;
+	wA *= wA;
+	return wB*wA;
+}
+// Above the reference 0.55 to narrow the kernel, so far taps cannot outvote a lone dark texel.
+const float sgsrKernelWidth = 0.8;
+
+// Outlier rejection fades in with tap distance, so the texel covering the pixel always votes.
+mediump float sgsrWeight(mediump float dx, mediump float dy, mediump float g, mediump float std)
+{
+	mediump float d2 = (dx*dx)+(dy*dy);
+	mediump float outlier = clamp(abs(g)*std, 0.0, 1.0) * min(d2 * 0.5, 1.0);
+	return sgsrFastLanczos2(d2 * sgsrKernelWidth + outlier);
+}
+// Clamped to its own nearest 2x2, so shared weights cannot pull a channel out of range.
+mediump float sgsrChannel(mediump float w[12], mediump vec4 ud, mediump vec4 l, mediump vec4 r, mediump float invSum)
+{
+	mediump float acc = dot(vec4(w[0], w[1], w[2], w[3]), ud) + dot(vec4(w[4], w[5], w[6], w[7]), l) + dot(vec4(w[8], w[9], w[10], w[11]), r);
+	mediump float lo = min(min(l.y, l.z), min(r.x, r.w));
+	mediump float hi = max(max(l.y, l.z), max(r.x, r.w));
+	return clamp(acc * invSum, lo, hi);
+}
+mediump float sgsrMean(mediump vec4 l, mediump vec4 r)
+{
+	return (l.y+l.z+r.x+r.w)*0.25;
+}
+
+vec4 sampleSgsr1(sampler2D tex, vec2 uv)
+{
+	const float edgeThreshold = 8.0 / 255.0;
+	mediump vec4 color = textureLod(tex, uv, 0.0);
+
+	vec2 size = vec2(textureSize(tex, 0));
+	vec4 viewport = vec4(1.0 / size, size);
+	{
+		highp vec2 imgCoord = ((uv*viewport.zw)+vec2(-0.5,0.5));
+		highp vec2 imgCoordPixel = floor(imgCoord);
+		highp vec2 coord = (imgCoordPixel*viewport.xy);
+		mediump vec2 pl = (imgCoord+(-imgCoordPixel));
+		mediump vec4 leftG = textureGather(tex,coord, 1);
+
+		mediump float edgeVote = abs(leftG.z - leftG.y) + abs(color.g - leftG.y)  + abs(color.g - leftG.z) ;
+		if(edgeVote > edgeThreshold)
+		{
+			// Red and blue wait on green's weights so twelve gathers are never live at once.
+			highp vec2 leftCoord = coord;
+			coord.x += viewport.x;
+			highp vec2 rightCoord = coord + vec2(viewport.x, 0.0);
+			highp vec2 upCoord = coord + vec2(0.0, -viewport.y);
+			highp vec2 downCoord = coord + vec2(0.0, viewport.y);
+			mediump vec4 rightG = textureGather(tex,rightCoord, 1);
+			mediump vec4 upDownG;
+			upDownG.xy = textureGather(tex,upCoord, 1).wz;
+			upDownG.zw = textureGather(tex,downCoord, 1).yx;
+
+			mediump float meanG = sgsrMean(leftG, rightG);
+			leftG -= vec4(meanG); rightG -= vec4(meanG); upDownG -= vec4(meanG);
+
+			mediump float sum = (((((abs(leftG.x)+abs(leftG.y))+abs(leftG.z))+abs(leftG.w))+(((abs(rightG.x)+abs(rightG.y))+abs(rightG.z))+abs(rightG.w)))+(((abs(upDownG.x)+abs(upDownG.y))+abs(upDownG.z))+abs(upDownG.w)));
+			mediump float std = 2.181818/sum;
+
+			mediump float w[12];
+			w[0]  = sgsrWeight(pl.x,     pl.y+1.0, upDownG.x, std);
+			w[1]  = sgsrWeight(pl.x-1.0, pl.y+1.0, upDownG.y, std);
+			w[2]  = sgsrWeight(pl.x-1.0, pl.y-2.0, upDownG.z, std);
+			w[3]  = sgsrWeight(pl.x,     pl.y-2.0, upDownG.w, std);
+			w[4]  = sgsrWeight(pl.x+1.0, pl.y-1.0, leftG.x, std);
+			w[5]  = sgsrWeight(pl.x,     pl.y-1.0, leftG.y, std);
+			w[6]  = sgsrWeight(pl.x,     pl.y,     leftG.z, std);
+			w[7]  = sgsrWeight(pl.x+1.0, pl.y,     leftG.w, std);
+			w[8]  = sgsrWeight(pl.x-1.0, pl.y-1.0, rightG.x, std);
+			w[9]  = sgsrWeight(pl.x-2.0, pl.y-1.0, rightG.y, std);
+			w[10] = sgsrWeight(pl.x-2.0, pl.y,     rightG.z, std);
+			w[11] = sgsrWeight(pl.x-1.0, pl.y,     rightG.w, std);
+			mediump float invSum = 1.0 / (((w[0]+w[1])+(w[2]+w[3]))+((w[4]+w[5])+(w[6]+w[7]))+((w[8]+w[9])+(w[10]+w[11])));
+
+			// Green is centered on its mean, so its clamp window is centered too.
+			color.g = meanG + sgsrChannel(w, upDownG, leftG, rightG, invSum);
+			{
+				mediump vec4 l = textureGather(tex,leftCoord, 0);
+				mediump vec4 r = textureGather(tex,rightCoord, 0);
+				mediump vec4 ud;
+				ud.xy = textureGather(tex,upCoord, 0).wz;
+				ud.zw = textureGather(tex,downCoord, 0).yx;
+				color.r = sgsrChannel(w, ud, l, r, invSum);
+			}
+			{
+				mediump vec4 l = textureGather(tex,leftCoord, 2);
+				mediump vec4 r = textureGather(tex,rightCoord, 2);
+				mediump vec4 ud;
+				ud.xy = textureGather(tex,upCoord, 2).wz;
+				ud.zw = textureGather(tex,downCoord, 2).yx;
+				color.b = sgsrChannel(w, ud, l, r, invSum);
+			}
+		}
+	}
+
+	return color;
+}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1018,6 +1018,7 @@ struct global_focus_t : public focus_t
 
 	GamescopeUpscaleFilter eUpscaleFilter = GamescopeUpscaleFilter::LINEAR;
 	GamescopeUpscaleScaler eUpscaleScaler = GamescopeUpscaleScaler::AUTO;
+	int nUpscaleSharpness = 0;
 	// Cleanup for the previous pre-emptive upscale, kept a frame behind.
 	std::optional<uint64_t> oLastPreemptiveUpscaleSeqNo;
 	std::vector<TempUpscaleImage_t> UpscaleImages;
@@ -2801,9 +2802,11 @@ static void paint_pipewire()
 	const UpscaleSettings_t upscaleSettings = GetUpscaleSettings(
 		GetCurrentFocus() && window_is_steam( GetCurrentFocus()->focusWindow ),
 		g_wantedUpscaleFilter,
-		g_wantedUpscaleScaler );
+		g_wantedUpscaleScaler,
+		g_upscaleFilterSharpness );
 	frameInfo.eUpscaleFilter = upscaleSettings.eFilter;
 	frameInfo.eUpscaleScaler = upscaleSettings.eScaler;
+	frameInfo.nUpscaleSharpness = upscaleSettings.nSharpness;
 
 	// Apply screenshot-style color management.
 	for ( uint32_t nInputEOTF = 0; nInputEOTF < EOTF_Count; nInputEOTF++ )
@@ -3070,6 +3073,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	frameInfo.bFadingOut = fadingOut;
 	frameInfo.eUpscaleFilter = pFocus->eUpscaleFilter;
 	frameInfo.eUpscaleScaler = pFocus->eUpscaleScaler;
+	frameInfo.nUpscaleSharpness = pFocus->nUpscaleSharpness;
 
 	// If the window we'd paint as the base layer is the streaming client,
 	// find the video underlay and put it up first in the scenegraph
@@ -3502,6 +3506,7 @@ paint_all( global_focus_t *pFocus, bool async )
 				FrameInfo_t screenshotFrameInfo{};
 				screenshotFrameInfo.eUpscaleFilter = frameInfo.eUpscaleFilter;
 				screenshotFrameInfo.eUpscaleScaler = frameInfo.eUpscaleScaler;
+				screenshotFrameInfo.nUpscaleSharpness = frameInfo.nUpscaleSharpness;
 				screenshotFrameInfo.applyOutputColorMgmt = true;
 				screenshotFrameInfo.outputEncodingEOTF = bHDRScreenshot ? EOTF_PQ : EOTF_Gamma22;
 				for ( uint32_t nInputEOTF = 0; nInputEOTF < EOTF_Count; nInputEOTF++ )
@@ -7086,7 +7091,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 	if ( ev->atom == ctx->atoms.gamescopeFSRSharpness || ev->atom == ctx->atoms.gamescopeSharpness )
 	{
 		g_upscaleFilterSharpness = (int)clamp( get_prop( ctx, ctx->root, ev->atom, 2 ), 0u, 20u );
-		if ( g_wantedUpscaleFilter == GamescopeUpscaleFilter::FSR || g_wantedUpscaleFilter == GamescopeUpscaleFilter::NIS )
+		if ( UpscaleFilterUsesSharpness( g_wantedUpscaleFilter ) )
 			hasRepaint = true;
 	}
 	if ( ev->atom == ctx->atoms.gamescopeXWaylandModeControl )
@@ -8308,6 +8313,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		globalScaleRatio = 1.0f;
 		upscaledFrameInfo.eUpscaleFilter = pUpscaleFocus->eUpscaleFilter;
 		upscaledFrameInfo.eUpscaleScaler = pUpscaleFocus->eUpscaleScaler;
+		upscaledFrameInfo.nUpscaleSharpness = pUpscaleFocus->nUpscaleSharpness;
 		paint_window_commit( newCommit, w, w, &upscaledFrameInfo, nullptr );
 		upscaledFrameInfo.useFSRLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::FSR;
 		upscaledFrameInfo.useNISLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::NIS;
@@ -10375,9 +10381,11 @@ steamcompmgr_main(int argc, char **argv)
 			const UpscaleSettings_t upscaleSettings = GetUpscaleSettings(
 				window_is_steam( pPaintFocus->focusWindow ),
 				g_wantedUpscaleFilter,
-				g_wantedUpscaleScaler );
+				g_wantedUpscaleScaler,
+				g_upscaleFilterSharpness );
 			pPaintFocus->eUpscaleFilter = upscaleSettings.eFilter;
 			pPaintFocus->eUpscaleScaler = upscaleSettings.eScaler;
+			pPaintFocus->nUpscaleSharpness = upscaleSettings.nSharpness;
 
 			if ( vblank )
 			{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1027,7 +1027,7 @@ struct global_focus_t : public focus_t
 	std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > CachedPlanes = {};
 	unsigned int uFadeOutStartTime = 0;
 	bool bPendingFade = false;
-	bool bFSRActive = false;
+	GamescopeUpscaleFilter eActiveUpscaler = GamescopeUpscaleFilter::LINEAR;
 	uint64_t ulBasePlaneCommitID = 0;
 	uint32_t uBasePlaneAppID = 0;
 	bool bBasePlaneIsFifo = false;
@@ -1242,7 +1242,10 @@ gamescope::ConCommand cc_debug_set_fps_limit( "debug_set_fps_limit", "Set refres
 
 static int g_nRuntimeInfoFd = -1;
 
-bool g_bFSRActive = false;
+// The shader upscaler that produced the base layer, LINEAR when none did.
+GamescopeUpscaleFilter g_eActiveUpscaler = GamescopeUpscaleFilter::LINEAR;
+GamescopeUpscaleFilter g_eWantedUpscaler = GamescopeUpscaleFilter::LINEAR;
+int g_nActiveUpscaleSharpness = 0;
 
 BlurMode g_BlurMode = BLUR_MODE_OFF;
 BlurMode g_BlurModeOld = BLUR_MODE_OFF;
@@ -3323,10 +3326,29 @@ paint_all( global_focus_t *pFocus, bool async )
 		frameInfo.useSGSRLayer0 = false;
 	}
 
-	pFocus->bFSRActive = frameInfo.useFSRLayer0;
-	if ( const auto& heldCommit = pFocus->HeldCommits[HELD_COMMIT_BASE]; heldCommit && heldCommit->upscaledTexture ) {
-		pFocus->bFSRActive = ( heldCommit->upscaledTexture->eFilter == GamescopeUpscaleFilter::FSR );
+	pFocus->eActiveUpscaler = GamescopeUpscaleFilter::LINEAR;
+	if ( frameInfo.useFSRLayer0 )
+		pFocus->eActiveUpscaler = GamescopeUpscaleFilter::FSR;
+	else if ( frameInfo.useNISLayer0 )
+		pFocus->eActiveUpscaler = GamescopeUpscaleFilter::NIS;
+	else if ( frameInfo.useSGSRLayer0 )
+		pFocus->eActiveUpscaler = GamescopeUpscaleFilter::SGSR;
+	// A full blur draws layer 0 from the blurred image, so its filter never runs.
+	else if ( frameInfo.layers.count() && !frameInfo.layers.get( 0 ).isScreenSize() && frameInfo.blurLayer0 != BLUR_MODE_ALWAYS )
+	{
+		switch ( frameInfo.layers.get( 0 ).filter )
+		{
+			case GamescopeUpscaleFilter::NEAREST:
+			case GamescopeUpscaleFilter::PIXEL:
+				pFocus->eActiveUpscaler = frameInfo.layers.get( 0 ).filter;
+				break;
+			default:
+				break;
+		}
 	}
+	if ( const auto& heldCommit = pFocus->HeldCommits[HELD_COMMIT_BASE];
+		 heldCommit && heldCommit->upscaledTexture && frameInfo.layers.count() && frameInfo.layers.get( 0 ).tex == heldCommit->upscaledTexture->pTexture )
+		pFocus->eActiveUpscaler = ResolveUpscaleFilter( heldCommit->upscaledTexture->eFilter, heldCommit->colorspace(), heldCommit->vulkanTex->isYcbcr() );
 
 	g_bFirstFrame = false;
 
@@ -9535,7 +9557,9 @@ static void publish_mangoapp_snapshot()
 	if ( !pFocus )
 		return;
 
-	g_bFSRActive = pFocus->bFSRActive;
+	g_eActiveUpscaler = pFocus->eActiveUpscaler;
+	g_eWantedUpscaler = g_wantedUpscaleFilter;
+	g_nActiveUpscaleSharpness = pFocus->nUpscaleSharpness;
 	focusWindow_pid = pFocus->nFocusWindowPid;
 	focusWindow_engine = pFocus->pFocusWindowEngine;
 	g_uCurrentBasePlaneCommitID = pFocus->ulBasePlaneCommitID;
@@ -9560,8 +9584,9 @@ static void publish_mangoapp_connector_snapshots()
 		snapshots[ uMsgType ] = MangoappSnapshot_t
 		{
 			.nPid = pFocus->nFocusWindowPid,
-			.bFSRActive = pFocus->bFSRActive,
-			.uFSRSharpness = (uint8_t) g_upscaleFilterSharpness,
+			.eActiveUpscaler = pFocus->eActiveUpscaler,
+			.eWantedUpscaler = g_wantedUpscaleFilter,
+			.uFSRSharpness = (uint8_t) pFocus->nUpscaleSharpness,
 			.pEngineName = pFocus->pFocusWindowEngine,
 			.bSteamFocused = window_is_steam( pFocus->inputFocusWindow ),
 			.bAppWantsHDR = g_bAppWantsHDRCached,
@@ -9910,13 +9935,13 @@ steamcompmgr_main(int argc, char **argv)
 			flush_root = true;
 		}
 
-		if ( g_bFSRActive != g_bWasFSRActive )
+		if ( const bool bFSRActive = g_eActiveUpscaler == GamescopeUpscaleFilter::FSR; bFSRActive != g_bWasFSRActive )
 		{
-			uint32_t active = g_bFSRActive ? 1 : 0;
+			uint32_t active = bFSRActive ? 1 : 0;
 			XChangeProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeFSRFeedback, XA_CARDINAL, 32, PropModeReplace,
 					(unsigned char *)&active, 1 );
 
-			g_bWasFSRActive = g_bFSRActive;
+			g_bWasFSRActive = bFSRActive;
 			flush_root = true;
 		}
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -301,7 +301,6 @@ gamescope::ConVar<bool> cv_adaptive_sync_uncapped( "adaptive_sync_uncapped", tru
 
 gamescope::ConVar<bool> cv_upscale_preemptive( "upscale_preemptive", true, "Allow pre-emptive upscaling" );
 gamescope::ConVar<bool> cv_upscale_preemptive_debug_force_sync( "upscale_preemptive_debug_force_sync", false, "Force synchronize pre-emptive upscaling" );
-gamescope::ConVar<bool> cv_hack_remap_sharp_to_fsr( "hack_remap_sharp_to_fsr", true, "HACK: treat unknown scaling filter 5 as FSR" );
 
 uint64_t g_SteamCompMgrLimitedAppRefreshCycle = 16'666'666;
 uint64_t g_SteamCompMgrAppRefreshCycle = 16'666'666;
@@ -3141,8 +3140,10 @@ paint_all( global_focus_t *pFocus, bool async )
 					paint_window(pFocus, w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders, 1.0f, fit);
 
 					bool needsScaling = frameInfo.layers.get( 0 ).scale.x < 0.999f && frameInfo.layers.get( 0 ).scale.y < 0.999f;
-					frameInfo.useFSRLayer0 = frameInfo.eUpscaleFilter == GamescopeUpscaleFilter::FSR && needsScaling;
-					frameInfo.useNISLayer0 = frameInfo.eUpscaleFilter == GamescopeUpscaleFilter::NIS && needsScaling;
+					GamescopeUpscaleFilter eLayer0Filter = ResolveUpscaleFilter( frameInfo.eUpscaleFilter, frameInfo.layers.get( 0 ).colorspace, frameInfo.layers.get( 0 ).isYcbcr() );
+					frameInfo.useFSRLayer0 = eLayer0Filter == GamescopeUpscaleFilter::FSR && needsScaling;
+					frameInfo.useNISLayer0 = eLayer0Filter == GamescopeUpscaleFilter::NIS && needsScaling;
+					frameInfo.useSGSRLayer0 = eLayer0Filter == GamescopeUpscaleFilter::SGSR && needsScaling;
 				}
 				if ( pFocus == GetCurrentMouseFocus() )
 					update_touch_scaling( &frameInfo );
@@ -3319,6 +3320,7 @@ paint_all( global_focus_t *pFocus, bool async )
 
 		frameInfo.useFSRLayer0 = false;
 		frameInfo.useNISLayer0 = false;
+		frameInfo.useSGSRLayer0 = false;
 	}
 
 	pFocus->bFSRActive = frameInfo.useFSRLayer0;
@@ -7209,16 +7211,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 	{
 		uint32_t uScalingFilter = get_prop( ctx, ctx->root, ctx->atoms.gamescopeNewScalingFilter, 0 );
 
-		// HACK: Steam Frame's Sharp option sends 5, which no filter enum
-		// defines. Remap it so the option does something while the wire
-		// mismatch is sorted out with Steam.
-		if ( cv_hack_remap_sharp_to_fsr && uScalingFilter == 5 )
-		{
-			xwm_log.infof( "HACK: remapping scaling filter 5 to FSR" );
-			uScalingFilter = uint32_t( GamescopeUpscaleFilter::FSR );
-		}
-
-		if ( uScalingFilter > uint32_t( GamescopeUpscaleFilter::PIXEL ) )
+		if ( uScalingFilter > uint32_t( GamescopeUpscaleFilter::SGSR ) )
 			xwm_log.errorf( "Unknown scaling filter %u, keeping %u", uScalingFilter, uint32_t( g_wantedUpscaleFilter ) );
 		else if ( g_wantedUpscaleFilter != GamescopeUpscaleFilter( uScalingFilter ) )
 		{
@@ -8315,8 +8308,10 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		upscaledFrameInfo.eUpscaleScaler = pUpscaleFocus->eUpscaleScaler;
 		upscaledFrameInfo.nUpscaleSharpness = pUpscaleFocus->nUpscaleSharpness;
 		paint_window_commit( newCommit, w, w, &upscaledFrameInfo, nullptr );
-		upscaledFrameInfo.useFSRLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::FSR;
-		upscaledFrameInfo.useNISLayer0 = upscaledFrameInfo.eUpscaleFilter == GamescopeUpscaleFilter::NIS;
+		GamescopeUpscaleFilter eLayer0Filter = ResolveUpscaleFilter( upscaledFrameInfo.eUpscaleFilter, upscaledFrameInfo.layers.get( 0 ).colorspace, upscaledFrameInfo.layers.get( 0 ).isYcbcr() );
+		upscaledFrameInfo.useFSRLayer0 = eLayer0Filter == GamescopeUpscaleFilter::FSR;
+		upscaledFrameInfo.useNISLayer0 = eLayer0Filter == GamescopeUpscaleFilter::NIS;
+		upscaledFrameInfo.useSGSRLayer0 = eLayer0Filter == GamescopeUpscaleFilter::SGSR;
 		globalScaleRatio = flOldGlobalScale;
 		zoomScaleRatio = flOldZoomScale;
 		overscanScaleRatio = flOldOverscanScale;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1137,6 +1137,62 @@ static gamescope::ConCommand cc_focus_info( "focus_info", "Dump debug info about
 	g_bPendingFocusInfo = true;
 });
 
+// The upscale globals belong to the steamcompmgr thread, the main loop applies these.
+static std::atomic<int32_t> g_nPendingUpscaleFilter = { -1 };
+static std::atomic<int32_t> g_nPendingUpscaleSharpness = { -1 };
+
+static gamescope::ConCommand cc_scaling_filter( "scaling_filter", "Set the scaling filter (linear, nearest, fsr, nis, pixel, sgsr)",
+[]( std::span<std::string_view> args )
+{
+	if ( args.size() < 2 )
+	{
+		console_log.errorf( "Usage: scaling_filter <filter>" );
+		return;
+	}
+
+	std::optional<GamescopeUpscaleFilter> oFilter = ParseUpscaleFilter( args[1] );
+	if ( !oFilter )
+	{
+		console_log.errorf( "Unknown scaling filter '%.*s'", (int)args[1].size(), args[1].data() );
+		return;
+	}
+
+	g_nPendingUpscaleFilter = int32_t( *oFilter );
+});
+
+static gamescope::ConCommand cc_scaling_sharpness( "scaling_sharpness", "Set the scaling sharpness (0 to 20)",
+[]( std::span<std::string_view> args )
+{
+	if ( args.size() < 2 )
+	{
+		console_log.errorf( "Usage: scaling_sharpness <0 to 20>" );
+		return;
+	}
+
+	std::optional<int32_t> onSharpness = gamescope::Parse<int32_t>( args[1] );
+	if ( !onSharpness )
+	{
+		console_log.errorf( "Failed to parse sharpness." );
+		return;
+	}
+
+	g_nPendingUpscaleSharpness = clamp( *onSharpness, 0, 20 );
+});
+
+static void ApplyPendingUpscaleSettings()
+{
+	int32_t nSharpness = g_nPendingUpscaleSharpness.exchange( -1 );
+	if ( nSharpness >= 0 )
+		g_upscaleFilterSharpness = nSharpness;
+
+	int32_t nFilter = g_nPendingUpscaleFilter.exchange( -1 );
+	if ( nFilter >= 0 )
+		g_wantedUpscaleFilter = GamescopeUpscaleFilter( nFilter );
+
+	if ( nSharpness >= 0 || nFilter >= 0 )
+		hasRepaint = true;
+}
+
 unsigned long	damageSequence = 0;
 
 uint64_t		cursorHideTime = 10'000ul * 1'000'000ul;
@@ -10376,6 +10432,8 @@ steamcompmgr_main(int argc, char **argv)
 
 		if ( g_bPendingFocusInfo.exchange( false ) )
 			DumpFocusInfo();
+
+		ApplyPendingUpscaleSettings();
 
 		g_bSteamIsActiveWindow = GetCurrentFocus() && window_is_steam( GetCurrentFocus()->focusWindow );
 

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -132,7 +132,9 @@ extern float focusedWindowScaleY;
 extern float focusedWindowOffsetX;
 extern float focusedWindowOffsetY;
 
-extern bool g_bFSRActive;
+extern GamescopeUpscaleFilter g_eActiveUpscaler;
+extern GamescopeUpscaleFilter g_eWantedUpscaler;
+extern int g_nActiveUpscaleSharpness;
 
 extern uint32_t inputCounter;
 extern uint64_t g_lastWinSeq;
@@ -145,7 +147,8 @@ void force_repaint( void );
 struct MangoappSnapshot_t
 {
 	pid_t nPid = 0;
-	bool bFSRActive = false;
+	GamescopeUpscaleFilter eActiveUpscaler = GamescopeUpscaleFilter::LINEAR;
+	GamescopeUpscaleFilter eWantedUpscaler = GamescopeUpscaleFilter::LINEAR;
 	uint8_t uFSRSharpness = 0;
 	std::shared_ptr<std::string> pEngineName;
 	bool bSteamFocused = false;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1472,6 +1472,7 @@ static void gamescope_control_bind( struct wl_client *client, void *data, uint32
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_LOOK, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_PERF_QUERY, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_KEYBOARD_LAYOUT, 1, 0 );
+	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_SGSR_FILTER, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_DONE, 0, 0 );
 
 	wlserver_send_gamescope_control( resource );

--- a/tests/test_upscale.cpp
+++ b/tests/test_upscale.cpp
@@ -2,7 +2,27 @@
 
 #include "main.hpp"
 
+TEST_CASE("SGSR keeps the wire value Steam writes", "[upscale]") {
+	REQUIRE( uint32_t( GamescopeUpscaleFilter::SGSR ) == 5 );
+}
+
+TEST_CASE("SGSR only takes SDR RGB input", "[upscale]") {
+	REQUIRE( SgsrSupportsInput( GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR, false ) );
+	REQUIRE( SgsrSupportsInput( GAMESCOPE_APP_TEXTURE_COLORSPACE_SRGB, false ) );
+	REQUIRE_FALSE( SgsrSupportsInput( GAMESCOPE_APP_TEXTURE_COLORSPACE_SRGB, true ) );
+	for ( auto colorspace : { GAMESCOPE_APP_TEXTURE_COLORSPACE_SCRGB, GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ, GAMESCOPE_APP_TEXTURE_COLORSPACE_PASSTHRU } )
+		REQUIRE_FALSE( SgsrSupportsInput( colorspace, false ) );
+}
+
+TEST_CASE("SGSR falls back on input it cannot read", "[upscale]") {
+	REQUIRE( ResolveUpscaleFilter( GamescopeUpscaleFilter::SGSR, GAMESCOPE_APP_TEXTURE_COLORSPACE_SRGB, false ) == GamescopeUpscaleFilter::SGSR );
+	REQUIRE( ResolveUpscaleFilter( GamescopeUpscaleFilter::SGSR, GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ, false ) == GamescopeUpscaleFilter::FSR );
+	REQUIRE( ResolveUpscaleFilter( GamescopeUpscaleFilter::SGSR, GAMESCOPE_APP_TEXTURE_COLORSPACE_SRGB, true ) == GamescopeUpscaleFilter::LINEAR );
+	REQUIRE( ResolveUpscaleFilter( GamescopeUpscaleFilter::NIS, GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ, false ) == GamescopeUpscaleFilter::NIS );
+}
+
 TEST_CASE("UpscaleFilterUsesSharpness", "[upscale]") {
+	REQUIRE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::SGSR ) );
 	REQUIRE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::FSR ) );
 	REQUIRE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::NIS ) );
 	REQUIRE_FALSE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::LINEAR ) );

--- a/tests/test_upscale.cpp
+++ b/tests/test_upscale.cpp
@@ -2,26 +2,35 @@
 
 #include "main.hpp"
 
+TEST_CASE("UpscaleFilterUsesSharpness", "[upscale]") {
+	REQUIRE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::FSR ) );
+	REQUIRE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::NIS ) );
+	REQUIRE_FALSE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::LINEAR ) );
+	REQUIRE_FALSE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::PIXEL ) );
+}
+
 TEST_CASE("GetUpscaleSettings", "[upscale]") {
 	SECTION("a Steam focus window forces linear and fit") {
 		const UpscaleSettings_t settings = GetUpscaleSettings(
-			true, GamescopeUpscaleFilter::FSR, GamescopeUpscaleScaler::INTEGER );
+			true, GamescopeUpscaleFilter::FSR, GamescopeUpscaleScaler::INTEGER, 7 );
 
 		REQUIRE( settings.eFilter == GamescopeUpscaleFilter::LINEAR );
 		REQUIRE( settings.eScaler == GamescopeUpscaleScaler::FIT );
+		REQUIRE( settings.nSharpness == 7 );
 	}
 
 	SECTION("a non-Steam focus window keeps the wanted settings") {
 		const UpscaleSettings_t settings = GetUpscaleSettings(
-			false, GamescopeUpscaleFilter::FSR, GamescopeUpscaleScaler::INTEGER );
+			false, GamescopeUpscaleFilter::FSR, GamescopeUpscaleScaler::INTEGER, 7 );
 
 		REQUIRE( settings.eFilter == GamescopeUpscaleFilter::FSR );
 		REQUIRE( settings.eScaler == GamescopeUpscaleScaler::INTEGER );
+		REQUIRE( settings.nSharpness == 7 );
 	}
 
 	SECTION("passes through a different wanted filter and scaler pair") {
 		const UpscaleSettings_t settings = GetUpscaleSettings(
-			false, GamescopeUpscaleFilter::NEAREST, GamescopeUpscaleScaler::AUTO );
+			false, GamescopeUpscaleFilter::NEAREST, GamescopeUpscaleScaler::AUTO, 0 );
 
 		REQUIRE( settings.eFilter == GamescopeUpscaleFilter::NEAREST );
 		REQUIRE( settings.eScaler == GamescopeUpscaleScaler::AUTO );

--- a/tests/test_upscale.cpp
+++ b/tests/test_upscale.cpp
@@ -21,6 +21,16 @@ TEST_CASE("SGSR falls back on input it cannot read", "[upscale]") {
 	REQUIRE( ResolveUpscaleFilter( GamescopeUpscaleFilter::NIS, GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ, false ) == GamescopeUpscaleFilter::NIS );
 }
 
+TEST_CASE("ParseUpscaleFilter names every filter", "[upscale]") {
+	REQUIRE( ParseUpscaleFilter( "linear" ) == GamescopeUpscaleFilter::LINEAR );
+	REQUIRE( ParseUpscaleFilter( "nearest" ) == GamescopeUpscaleFilter::NEAREST );
+	REQUIRE( ParseUpscaleFilter( "fsr" ) == GamescopeUpscaleFilter::FSR );
+	REQUIRE( ParseUpscaleFilter( "nis" ) == GamescopeUpscaleFilter::NIS );
+	REQUIRE( ParseUpscaleFilter( "pixel" ) == GamescopeUpscaleFilter::PIXEL );
+	REQUIRE( ParseUpscaleFilter( "sgsr" ) == GamescopeUpscaleFilter::SGSR );
+	REQUIRE_FALSE( ParseUpscaleFilter( "sharp" ).has_value() );
+}
+
 TEST_CASE("UpscaleFilterUsesSharpness", "[upscale]") {
 	REQUIRE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::SGSR ) );
 	REQUIRE( UpscaleFilterUsesSharpness( GamescopeUpscaleFilter::FSR ) );


### PR DESCRIPTION
 Implement Snapdragon™ Game Super Resolution 1 upscaling followed by an RCAS sharpening pass. SGSR1 alone appears very soft when compared to FSR1, but SGSR1 is a lot lighter than EASU, so it runs as the pre-pass in FSR's place and the existing RCAS stage and sharpness slider apply unchanged. 

Steam Frame's Sharp option already writes filter value 5, which master remaps to FSR with a HACK, so this takes that value for SGSR and drops the remap.

|                | FSR    | SGSR + RCAS   |
|----------------|--------|--------|
| NieR Replicant | 925 us | 680 us |
| Dave the Diver | 900 us | 530 us |

I've also wired up mangoapp reporting the selected and active scaling filter rather than just "FSR OFF" and "FSR ON", as well as gamescopectl commands to change scaling filter and sharpening without needing to interact directly with the xatoms. I modified RCAS to run one pixel per-thread on Adreno, as there was a ~5% gain in RCAS pass performance with this. SGSR only reads SDR RGB, so HDR input keeps FSR for Sharp.