### PR TITLE
WaylandBackend: allow equal HDR luminance values

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1859,7 +1859,7 @@ namespace gamescope
     {
         auto *pHDRInfo = &m_pConnector->m_HDRInfo;
         if (m_pBackend->SupportsColorManagement()) {
-            pHDRInfo->bExposeHDRSupport   = ( cv_hdr_enabled && m_pConnector->m_uMaxTargetLuminance > m_pConnector->m_uReferenceLuminance );
+            pHDRInfo->bExposeHDRSupport   = ( cv_hdr_enabled && m_pConnector->m_uMaxTargetLuminance >= m_pConnector->m_uReferenceLuminance );
             pHDRInfo->eOutputEncodingEOTF = pHDRInfo->bExposeHDRSupport ? EOTF_PQ : EOTF_Gamma22;
         }
 


### PR DESCRIPTION
## Description

Wayland HDR support is not exposed when the connector's maximum target luminance is exactly equal to its reference luminance.

The current check in `Wayland_WPImageDescriptionInfo_Done()` uses:

```cpp
m_pConnector->m_uMaxTargetLuminance > m_pConnector->m_uReferenceLuminance
```
For displays reporting equal values (for example, 400 nits maximum target luminance and 400 nits reference luminance), this evaluates to false and bExposeHDRSupport remains disabled, even though the display can otherwise expose HDR.

This changes the comparison from > to >=, allowing equal luminance values to pass the HDR capability check.

## Testing

I tested this with an AMD Radeon RX 6700 XT using RADV on Fedora/KDE Wayland.

With the original > comparison, Gamescope did not expose HDR support.

After changing the comparison to >=, Gamescope reported:

```
bExposeHDRSupport: true
server hdr output enabled: true
hdr formats exposed to client: true
```
The relevant luminance values are effectively:
```
max target luminance: 400 nits
reference luminance:  400 nits
```
Therefore:
```
400 > 400   -> false
400 >= 400  -> true
```
This allows HDR support to be exposed in the equality case without changing the reported luminance values themselves.

Change
```cpp
- pHDRInfo->bExposeHDRSupport = ( cv_hdr_enabled && m_pConnector->m_uMaxTargetLuminance > m_pConnector->m_uReferenceLuminance );
+ pHDRInfo->bExposeHDRSupport = ( cv_hdr_enabled && m_pConnector->m_uMaxTargetLuminance >= m_pConnector->m_uReferenceLuminance );
```
No other behavior or luminance values are changed.